### PR TITLE
Refactor visual pipeline: split image prompts and images into separate bots

### DIFF
--- a/skills/video-pipeline/clients/anthropic_client.py
+++ b/skills/video-pipeline/clients/anthropic_client.py
@@ -553,11 +553,17 @@ Return JSON with segments array. Each segment groups sentences by visual concept
         previous_prompt: str = "",
     ) -> str:
         """Generate an image prompt for a semantic segment."""
-        system_prompt = """You are an expert image prompt creator for a faceless YouTube channel.
+        CHANNEL_STYLE = """Atmospheric lo-fi 2D digital illustration style. Hand-drawn aesthetic with soft painterly textures.
+Dark moody backgrounds with glowing accent elements. Muted color palette with strategic bright highlights.
+16:9 aspect ratio composition. Cinematic documentary feel."""
 
-STRICT STYLE GUIDELINES:
-The style is "Cinematic Lofi Digital".
-Your output MUST start with "Atmospheric lo-fi 2D digital illustration, 16:9."
+        system_prompt = f"""You are a visual director segmenting narration into image concepts.
+Each concept will become ONE image shown while that portion of the narration plays.
+
+REQUIRED VISUAL STYLE FOR ALL IMAGES:
+{CHANNEL_STYLE}
+
+Every image_prompt you generate MUST start with "Atmospheric lo-fi 2D digital illustration, 16:9." and incorporate the hand-drawn, painterly aesthetic described above.
 
 VISUAL ANCHOR PROTOCOL:
 Frame using one of these "Anchor Settings":
@@ -593,7 +599,9 @@ NARRATION TEXT:
 "{segment_text}"
 {continuity_note}
 
-Generate a single prompt that visually represents this segment's core concept."""
+Generate a single prompt that visually represents this segment's core concept.
+
+REMINDER: Start with 'Atmospheric lo-fi 2D digital illustration, 16:9.' then describe the scene with hand-drawn aesthetic, soft painterly textures, moody lighting, and specific color palette. 100+ words."""
 
         response = await self.generate(
             prompt=prompt,


### PR DESCRIPTION
## Summary
This PR refactors the video pipeline to separate image prompt generation from image generation into two distinct, sequential steps. This provides better granularity, clearer status tracking, and improved workflow control.

## Key Changes

### Pipeline Architecture
- Split `STATUS_READY_VISUALS` into two separate statuses:
  - `STATUS_READY_IMAGE_PROMPTS` - triggers image prompt generation
  - `STATUS_READY_IMAGES` - triggers image generation from prompts
- Updated workflow from 7 to 10 status stages for better process visibility
- Renumbered all subsequent pipeline stages accordingly

### New Bot Methods
- Added `run_image_prompt_bot()` - generates semantic segment image prompts
- Added `run_image_bot()` - generates images from existing prompts
- Kept `run_visuals_pipeline()` as a combined/legacy method for backward compatibility

### Prompt Engineering Improvements
- Extracted channel style guidelines into a reusable `CHANNEL_STYLE` constant
- Enhanced system prompt with clearer instructions for visual directors
- Added explicit reminder about prompt format and minimum word count (100+ words)
- Improved continuity protocol documentation in the prompt template

### Status Flow Updates
- Voice Bot now updates to `STATUS_READY_IMAGE_PROMPTS` (was `STATUS_READY_VISUALS`)
- Image Prompt Bot updates to `STATUS_READY_IMAGES`
- Image Bot updates to `STATUS_READY_VIDEO_SCRIPTS`
- Updated `check_existing_work()` logic to suggest appropriate intermediate statuses

## Benefits
- **Better separation of concerns**: Each bot has a single, focused responsibility
- **Improved error recovery**: Can retry image generation without regenerating prompts
- **Clearer status tracking**: Airtable status now accurately reflects pipeline stage
- **More maintainable**: Easier to modify or replace individual components
- **Backward compatible**: Legacy `run_visuals_pipeline()` still available for combined execution

https://claude.ai/code/session_01KeajzmCcKiAdVWRSTUcB45