### PR TITLE
Upgrade to Seed Dream 4.5 Edit with Core Image reference

### DIFF
--- a/animation/config.py
+++ b/animation/config.py
@@ -23,7 +23,7 @@ SCENE_PLANNER_MODEL = "claude-sonnet-4-5-20250929"
 QC_MODEL = "claude-haiku-4-5-20241022"
 
 # ==================== IMAGE GENERATION ====================
-SCENE_IMAGE_MODEL = "bytedance/seedream-v4-text-to-image"
+SCENE_IMAGE_MODEL = "seedream/4.5-edit"  # Seed Dream 4.5 Edit — reference-based generation
 THUMBNAIL_IMAGE_MODEL = "nano-banana-pro"
 
 # ==================== VIDEO GENERATION ====================

--- a/animation/image_generator.py
+++ b/animation/image_generator.py
@@ -1,4 +1,8 @@
-"""Image generation for animation frames via Kie.ai (Seed Dream 4.0 / Nano Banana Pro)."""
+"""Image generation for animation frames via Kie.ai (Seed Dream 4.5 Edit).
+
+All frame generation uses the project's Core Image as a reference to maintain
+visual consistency across the entire video.
+"""
 
 import asyncio
 import json
@@ -14,7 +18,11 @@ from animation.config import (
 
 
 class AnimationImageGenerator:
-    """Generates start and end frame images for animation scenes."""
+    """Generates start and end frame images for animation scenes.
+
+    Uses Seed Dream 4.5 Edit with the project's Core Image as a reference
+    so every generated frame stays visually consistent with the project identity.
+    """
 
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or KIE_API_KEY
@@ -24,13 +32,15 @@ class AnimationImageGenerator:
     async def generate_frame(
         self,
         prompt: str,
-        aspect_ratio: str = "landscape_16_9",
+        reference_image_url: str,
+        aspect_ratio: str = "16:9",
     ) -> Optional[str]:
-        """Generate a single frame image via Seed Dream 4.0.
+        """Generate a single frame image via Seed Dream 4.5 Edit.
 
         Args:
             prompt: Full image generation prompt
-            aspect_ratio: Image size parameter for Seed Dream
+            reference_image_url: URL of the Core Image from the project
+            aspect_ratio: Aspect ratio for Seed Dream 4.5 Edit
 
         Returns:
             URL of generated image, or None if failed
@@ -44,9 +54,9 @@ class AnimationImageGenerator:
             "model": SCENE_IMAGE_MODEL,
             "input": {
                 "prompt": prompt,
-                "image_size": aspect_ratio,
-                "image_resolution": "2K",
-                "max_images": 1,
+                "image_urls": [reference_image_url],
+                "aspect_ratio": aspect_ratio,
+                "quality": "basic",
             },
         }
 
@@ -87,26 +97,30 @@ class AnimationImageGenerator:
         self,
         start_prompt: str,
         end_prompt: str,
+        reference_image_url: str,
     ) -> tuple[Optional[str], Optional[str]]:
         """Generate start and end frame images for a scene.
+
+        Both frames use the Core Image as reference for visual consistency.
 
         Args:
             start_prompt: Prompt for the start frame
             end_prompt: Prompt for the end frame
+            reference_image_url: URL of the Core Image from the project
 
         Returns:
             Tuple of (start_image_url, end_image_url). Either may be None on failure.
         """
-        print(f"      \U0001f3a8 Generating start frame...")
-        start_url = await self.generate_frame(start_prompt)
+        print(f"      \U0001f3a8 Generating start frame (Seed Dream 4.5 Edit w/ Core Image ref)...")
+        start_url = await self.generate_frame(start_prompt, reference_image_url)
 
         if not start_url:
             print(f"      \u274c Start frame generation failed")
             return None, None
 
         print(f"      \u2705 Start frame ready")
-        print(f"      \U0001f3a8 Generating end frame...")
-        end_url = await self.generate_frame(end_prompt)
+        print(f"      \U0001f3a8 Generating end frame (Seed Dream 4.5 Edit w/ Core Image ref)...")
+        end_url = await self.generate_frame(end_prompt, reference_image_url)
 
         if not end_url:
             print(f"      \u274c End frame generation failed")

--- a/skills/video-pipeline/animation/__init__.py
+++ b/skills/video-pipeline/animation/__init__.py
@@ -2,7 +2,7 @@
 
 Handles the full animation workflow:
 - Scene planning with glow arc tracking
-- Image generation with Seed Dream 4.0
+- Image generation with Seed Dream 4.5 Edit (Core Image reference)
 - Video generation with Veo 3.1
 - QC checking with Haiku
 - Cost tracking and budget enforcement

--- a/skills/video-pipeline/run_prompts_and_images.py
+++ b/skills/video-pipeline/run_prompts_and_images.py
@@ -32,7 +32,18 @@ async def main():
 
     project_name = project.get("Project Name")
     creative_direction = project.get("Creative Direction", "")
+
+    # Extract Core Image URL from the project record
+    core_image_attachments = project.get("Core Image", [])
+    core_image_url = ""
+    if core_image_attachments and isinstance(core_image_attachments, list):
+        core_image_url = core_image_attachments[0].get("url", "")
+
     print(f"📁 Project: {project_name}")
+    if core_image_url:
+        print(f"🖼️  Core Image: {core_image_url[:80]}...")
+    else:
+        print(f"⚠️  No Core Image found on project — image generation will fail")
 
     # Get scenes
     scenes = await airtable.get_scenes_for_project(project_name)
@@ -85,8 +96,11 @@ async def main():
         print(f"    Type: {scene.get('scene_type')}")
         print(f"    Glow: {scene.get('glow_state')} ({scene.get('glow_behavior')})")
 
-        # Generate image
-        result = await image_client.generate_scene_image(prompt)
+        # Generate image using Seed Dream 4.5 Edit with Core Image reference
+        if not core_image_url:
+            print(f"    ❌ No Core Image — skipping")
+            continue
+        result = await image_client.generate_scene_image(prompt, core_image_url)
 
         if result and result.get("url"):
             image_url = result["url"]


### PR DESCRIPTION
## Summary
Unified all scene image generation to use Seed Dream 4.5 Edit with the project's Core Image as a reference, replacing the previous dual-model approach (Seed Dream 4.0 text-to-image + 4.0 Edit). This ensures visual consistency across all generated frames by anchoring them to a single reference image.

## Key Changes

- **Model Consolidation**: Replaced separate `SCENE_MODEL` (bytedance/seedream-v4-text-to-image) and `SCENE_MODEL_EDIT` (bytedance/seedream-v4-edit) with unified `SCENE_MODEL = "seedream/4.5-edit"`

- **Reference-Based Generation**: All scene image generation now requires a `reference_image_url` parameter pointing to the project's Core Image, ensuring visual consistency across the entire video

- **API Parameter Updates**: Updated Seed Dream API calls to use new 4.5 Edit parameters:
  - Changed from `image_size` to `aspect_ratio` (e.g., "16:9")
  - Changed from `image_resolution` to `quality` ("basic")
  - Added `image_urls` array for reference image input
  - Removed `max_images` parameter

- **Simplified Method Signatures**: 
  - `generate_scene_image()` now requires `reference_image_url` parameter
  - `generate_scene_image_with_reference()` now delegates to `generate_scene_image()` (eliminated code duplication)
  - `generate_frame()` and `generate_frame_pair()` updated to accept and use Core Image reference

- **Core Image Lookup**: Added `_get_core_image_url()` helper function to retrieve Core Image URL from Airtable project records, with validation and error handling

- **Pipeline Integration**: Updated all pipeline entry points to:
  - Extract Core Image URL from project records on load
  - Pass Core Image URL to all image generation calls
  - Display Core Image URL in logs for debugging
  - Skip generation with clear error messages if Core Image is missing

- **Cost Tracking**: Updated image generation cost from $0.025 to $0.0325 per image (6.5 credits for Seed Dream 4.5 Edit)

## Implementation Details

- Core Image is now a required dependency for all scene image generation across video and animation pipelines
- Reference image is consistently used for both start and end frame generation
- Removed dependency on start_image as reference; now uses project-level Core Image instead
- All user-facing messages updated to reflect Seed Dream 4.5 Edit and Core Image reference usage

https://claude.ai/code/session_019VgENWUUfZK7f7aZFYynvZ