### PR TITLE
Add visual identity image prompt engine for NanoBanana pipeline

### DIFF
--- a/skills/video-pipeline/image_prompt_engine/__init__.py
+++ b/skills/video-pipeline/image_prompt_engine/__init__.py
@@ -1,0 +1,58 @@
+"""
+Image Prompt Engine — Visual Identity System for NanoBanana pipeline.
+
+Replaces generic AI image prompts with a structured visual identity system
+producing cinematic, intelligence-briefing-aesthetic imagery across three
+styles: Dossier, Schema, and Echo.
+
+Usage
+-----
+::
+
+    from image_prompt_engine import generate_prompts, resolve_accent_color
+
+    scenes = [
+        {"scene_description": "A figure in a dark suit walking through a corridor"},
+        {"scene_description": "Aerial city at night with glowing network lines"},
+        ...
+    ]
+
+    prompts = generate_prompts(
+        scenes,
+        topic_category="geopolitical",
+        seed=42,
+    )
+
+    for p in prompts:
+        print(p["style"], p["composition"], p["prompt"][:80])
+"""
+
+from .prompt_builder import build_prompt, generate_prompts, resolve_accent_color
+from .sequencer import assign_styles
+from .style_config import (
+    ACCENT_COLOR_MAP,
+    ACT_STYLE_WEIGHTS,
+    COMPOSITION_CYCLE,
+    COMPOSITION_DIRECTIVES,
+    DEFAULT_CONFIG,
+    KEN_BURNS_PAN_ALTERNATES,
+    KEN_BURNS_RULES,
+    STYLE_SUFFIXES,
+)
+
+__all__ = [
+    # High-level API
+    "generate_prompts",
+    "build_prompt",
+    "resolve_accent_color",
+    "assign_styles",
+    # Configuration
+    "STYLE_SUFFIXES",
+    "COMPOSITION_DIRECTIVES",
+    "COMPOSITION_CYCLE",
+    "ACCENT_COLOR_MAP",
+    "ACT_STYLE_WEIGHTS",
+    "KEN_BURNS_RULES",
+    "KEN_BURNS_PAN_ALTERNATES",
+    "DEFAULT_CONFIG",
+]

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -1,0 +1,140 @@
+"""
+Prompt builder for the visual identity system.
+
+Takes scene descriptions and sequencing metadata, produces fully constructed
+image generation prompts ready for NanoBanana.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .style_config import (
+    ACCENT_COLOR_MAP,
+    COMPOSITION_DIRECTIVES,
+    DEFAULT_CONFIG,
+    STYLE_SUFFIXES,
+)
+from .sequencer import assign_styles
+
+
+def resolve_accent_color(
+    accent_color: Optional[str] = None,
+    topic_category: Optional[str] = None,
+) -> str:
+    """Determine the accent color for a video.
+
+    Uses the explicit *accent_color* if provided, otherwise looks up
+    *topic_category* in :data:`ACCENT_COLOR_MAP`, falling back to the
+    default accent color.
+    """
+    if accent_color:
+        return accent_color
+    if topic_category:
+        return ACCENT_COLOR_MAP.get(
+            topic_category,
+            DEFAULT_CONFIG["default_accent_color"],
+        )
+    return DEFAULT_CONFIG["default_accent_color"]
+
+
+def build_prompt(
+    scene_description: str,
+    style: str,
+    composition: str,
+    accent_color: str,
+) -> str:
+    """Assemble a complete image generation prompt.
+
+    Structure: ``[SCENE_DESCRIPTION], [COMPOSITION_DIRECTIVE], [STYLE_SUFFIX]``
+
+    Parameters
+    ----------
+    scene_description : str
+        What the image depicts (from the script / visual seeds).
+    style : str
+        One of ``"dossier"``, ``"schema"``, ``"echo"``.
+    composition : str
+        A key from :data:`COMPOSITION_DIRECTIVES`.
+    accent_color : str
+        The accent color string (e.g. ``"cold teal"``).
+
+    Returns
+    -------
+    str
+        The complete prompt string, ready for the image generation model.
+    """
+    comp_text = COMPOSITION_DIRECTIVES.get(composition, "")
+    suffix = STYLE_SUFFIXES[style].replace("[ACCENT_COLOR]", accent_color)
+
+    parts = [scene_description.rstrip(", ")]
+    if comp_text:
+        parts.append(comp_text)
+    parts_str = ", ".join(parts)
+
+    # The suffix already starts with ", " so we just concatenate.
+    return parts_str + suffix
+
+
+def generate_prompts(
+    scenes: list[dict],
+    *,
+    accent_color: Optional[str] = None,
+    topic_category: Optional[str] = None,
+    act_timestamps: Optional[dict] = None,
+    seed: Optional[int] = None,
+) -> list[dict]:
+    """Generate fully constructed prompts for an entire video.
+
+    Parameters
+    ----------
+    scenes : list[dict]
+        Each dict must contain at minimum:
+        - ``"scene_description"`` (str): what the image depicts.
+        Optionally:
+        - ``"act"`` (str): act override; if omitted, derived from position.
+    accent_color : str, optional
+        Explicit accent color for the video.
+    topic_category : str, optional
+        Topic category used to auto-select accent color if *accent_color*
+        is not provided.
+    act_timestamps : dict, optional
+        Custom act timestamp breakpoints. Falls back to defaults.
+    seed : int, optional
+        RNG seed for reproducible style sequencing.
+
+    Returns
+    -------
+    list[dict]
+        One entry per scene with keys: ``prompt``, ``style``, ``composition``,
+        ``accent_color``, ``act``, ``index``, ``ken_burns``.
+    """
+    color = resolve_accent_color(accent_color, topic_category)
+    total_images = len(scenes)
+
+    # Generate the style/composition sequence.
+    assignments = assign_styles(
+        total_images,
+        act_timestamps=act_timestamps,
+        seed=seed,
+    )
+
+    results: list[dict] = []
+    for scene, assignment in zip(scenes, assignments):
+        desc = scene.get("scene_description", "")
+        style = assignment["style"]
+        composition = assignment["composition"]
+
+        prompt = build_prompt(desc, style, composition, color)
+
+        results.append({
+            "prompt": prompt,
+            "style": style,
+            "composition": composition,
+            "accent_color": color,
+            "act": assignment["act"],
+            "index": assignment["index"],
+            "ken_burns": assignment["ken_burns"],
+        })
+
+    return results

--- a/skills/video-pipeline/image_prompt_engine/sequencer.py
+++ b/skills/video-pipeline/image_prompt_engine/sequencer.py
@@ -1,0 +1,298 @@
+"""
+Sequencing engine for the visual identity system.
+
+Assigns a visual style (dossier / schema / echo) and composition directive
+to each image position in the video, respecting the narrative-arc pacing
+rules defined in the PRD.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+from .style_config import (
+    ACT_STYLE_WEIGHTS,
+    COMPOSITION_CYCLE,
+    DEFAULT_CONFIG,
+    KEN_BURNS_PAN_ALTERNATES,
+    KEN_BURNS_RULES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def assign_styles(
+    total_images: int,
+    act_timestamps: Optional[dict] = None,
+    *,
+    seed: Optional[int] = None,
+) -> list[dict]:
+    """Assign style, composition, and Ken Burns direction for every image.
+
+    Parameters
+    ----------
+    total_images : int
+        Number of images in the video.
+    act_timestamps : dict, optional
+        Mapping of ``"act{N}_end"`` to seconds. Falls back to
+        ``DEFAULT_CONFIG["act_timestamps"]``.
+    seed : int, optional
+        If provided, seeds the RNG for reproducible results.
+
+    Returns
+    -------
+    list[dict]
+        One entry per image with keys: ``index``, ``timestamp``, ``act``,
+        ``style``, ``composition``, ``ken_burns``.
+    """
+    if act_timestamps is None:
+        act_timestamps = DEFAULT_CONFIG["act_timestamps"]
+
+    rng = random.Random(seed)
+    total_seconds = act_timestamps["act6_end"]
+    image_duration = total_seconds / total_images
+
+    assignments: list[dict] = []
+
+    for i in range(total_images):
+        timestamp = i * image_duration
+        act = _get_act(timestamp, act_timestamps)
+
+        style = _select_style(act, i, total_images, assignments, rng)
+        composition = _select_composition(style, assignments)
+        ken_burns = _select_ken_burns(composition, assignments)
+
+        assignments.append({
+            "index": i,
+            "timestamp": round(timestamp, 2),
+            "act": act,
+            "style": style,
+            "composition": composition,
+            "ken_burns": ken_burns,
+        })
+
+    return assignments
+
+
+# ---------------------------------------------------------------------------
+# Act resolution
+# ---------------------------------------------------------------------------
+
+def _get_act(timestamp: float, act_timestamps: dict) -> str:
+    """Return the act name (``"act1"`` .. ``"act6"``) for a timestamp."""
+    if timestamp < act_timestamps["act1_end"]:
+        return "act1"
+    if timestamp < act_timestamps["act2_end"]:
+        return "act2"
+    if timestamp < act_timestamps["act3_end"]:
+        return "act3"
+    if timestamp < act_timestamps["act4_end"]:
+        return "act4"
+    if timestamp < act_timestamps["act5_end"]:
+        return "act5"
+    return "act6"
+
+
+# ---------------------------------------------------------------------------
+# Style selection with sequencing rules
+# ---------------------------------------------------------------------------
+
+def _count_trailing_style(history: list[dict], style: str) -> int:
+    """Count how many consecutive images at the tail of *history* have *style*."""
+    count = 0
+    for entry in reversed(history):
+        if entry["style"] == style:
+            count += 1
+        else:
+            break
+    return count
+
+
+def _select_style(
+    act: str,
+    index: int,
+    total_images: int,
+    history: list[dict],
+    rng: random.Random,
+) -> str:
+    """Select the visual style for position *index*, enforcing all global rules."""
+
+    # Rule 6: First and last images must be Dossier.
+    if index == 0 or index == total_images - 1:
+        return "dossier"
+
+    echo_run = _count_trailing_style(history, "echo") if history else 0
+
+    # Rule 3: If in an echo cluster below minimum, FORCE continuation.
+    if echo_run > 0 and echo_run < DEFAULT_CONFIG["echo_cluster_min"]:
+        return "echo"
+
+    # Rule 3+4: If in an echo cluster at/above max, FORCE exit to Dossier.
+    if echo_run >= DEFAULT_CONFIG["echo_cluster_max"]:
+        return "dossier"
+
+    # If in an echo cluster between min and max, decide: continue or exit.
+    # Rule 4: exiting always goes to Dossier.
+    if echo_run > 0:
+        act_echo_weight = ACT_STYLE_WEIGHTS[act].get("echo", 0)
+        if act in ("act1", "act2", "act6"):
+            act_echo_weight = 0
+        if act_echo_weight > 0 and rng.random() < act_echo_weight:
+            return "echo"
+        return "dossier"  # Rule 4: exit echo cluster → always Dossier
+
+    # --- Not in an echo cluster. Normal weighted selection. ---
+    weights = dict(ACT_STYLE_WEIGHTS[act])
+
+    # Rule 2: No Echo in acts 1, 2, or 6.
+    if act in ("act1", "act2", "act6"):
+        weights["echo"] = 0.0
+
+    # Rule 3 (isolated-single prevention): Don't start an echo run if we
+    # can't sustain at least the minimum cluster size.
+    if weights.get("echo", 0) > 0:
+        min_cluster = DEFAULT_CONFIG["echo_cluster_min"]
+        if index + min_cluster >= total_images:
+            weights["echo"] = 0.0
+        else:
+            remaining_in_act = _remaining_images_in_act(
+                index, total_images, act, history,
+            )
+            if remaining_in_act < min_cluster:
+                weights["echo"] = 0.0
+
+    # Compensate for forced cluster continuation: starting an echo cluster
+    # commits at least echo_cluster_min images, which inflates the effective
+    # echo rate.  Reduce the start probability proportionally.
+    if weights.get("echo", 0) > 0:
+        avg_cluster = (
+            DEFAULT_CONFIG["echo_cluster_min"] + DEFAULT_CONFIG["echo_cluster_max"]
+        ) / 2
+        weights["echo"] = weights["echo"] / avg_cluster
+
+    # Rule 1: No more than max_consecutive same style.
+    # For Dossier, reduce effective max near the end of the video to account
+    # for the forced-Dossier last image (prevents N consecutive + forced last
+    # from exceeding the limit).
+    max_consecutive = DEFAULT_CONFIG["max_consecutive_same_style"]
+    remaining_to_end = total_images - 1 - index
+
+    for style_name in ("dossier", "schema", "echo"):
+        if weights.get(style_name, 0) == 0:
+            continue
+        effective_max = max_consecutive
+        if style_name == "dossier" and 0 < remaining_to_end <= max_consecutive:
+            effective_max = max_consecutive - 1
+        run = _count_trailing_style(history, style_name)
+        if run >= effective_max:
+            weights[style_name] = 0.0
+
+    # Rule 5: Schema rarely clusters.
+    if history and history[-1]["style"] == "schema":
+        schema_run = _count_trailing_style(history, "schema")
+        # Determine the strictest limit across the entire schema run.
+        # A run that started outside Act 5 keeps the stricter limit even
+        # if the current image falls into Act 5 (prevents cross-act escape).
+        schema_max = (
+            DEFAULT_CONFIG["schema_cluster_max_act5"]
+            if act == "act5"
+            else DEFAULT_CONFIG["schema_cluster_max_default"]
+        )
+        cluster_start_idx = len(history) - schema_run
+        if 0 <= cluster_start_idx < len(history):
+            start_act = history[cluster_start_idx]["act"]
+            if start_act != "act5":
+                schema_max = min(
+                    schema_max, DEFAULT_CONFIG["schema_cluster_max_default"],
+                )
+        if schema_run >= schema_max:
+            weights["schema"] = 0.0
+        elif act != "act5":
+            weights["schema"] = weights.get("schema", 0) * 0.2
+
+    # Normalize and pick.
+    total_w = sum(weights.values())
+    if total_w == 0:
+        return "dossier"
+
+    r = rng.random() * total_w
+    cumulative = 0.0
+    for style, w in weights.items():
+        cumulative += w
+        if r <= cumulative:
+            return style
+    return "dossier"  # fallback
+
+
+def _remaining_images_in_act(
+    current_index: int,
+    total_images: int,
+    current_act: str,
+    history: list[dict],
+) -> int:
+    """Estimate how many images remain in the current act after *current_index*."""
+    # Count how many images were already in this act.
+    act_start_index = current_index  # will walk backwards
+    for entry in reversed(history):
+        if entry["act"] == current_act:
+            act_start_index = entry["index"]
+        else:
+            break
+    # Rough estimate: proportional to act time share.
+    act_timestamps = DEFAULT_CONFIG["act_timestamps"]
+    total_seconds = act_timestamps["act6_end"]
+    act_durations = _act_durations(act_timestamps)
+    act_fraction = act_durations.get(current_act, 0) / total_seconds
+    estimated_act_images = max(1, round(total_images * act_fraction))
+    images_used = current_index - act_start_index
+    return max(0, estimated_act_images - images_used)
+
+
+def _act_durations(act_timestamps: dict) -> dict:
+    ends = [
+        ("act1", 0, act_timestamps["act1_end"]),
+        ("act2", act_timestamps["act1_end"], act_timestamps["act2_end"]),
+        ("act3", act_timestamps["act2_end"], act_timestamps["act3_end"]),
+        ("act4", act_timestamps["act3_end"], act_timestamps["act4_end"]),
+        ("act5", act_timestamps["act4_end"], act_timestamps["act5_end"]),
+        ("act6", act_timestamps["act5_end"], act_timestamps["act6_end"]),
+    ]
+    return {name: end - start for name, start, end in ends}
+
+
+# ---------------------------------------------------------------------------
+# Composition selection
+# ---------------------------------------------------------------------------
+
+def _select_composition(style: str, history: list[dict]) -> str:
+    """Pick the next composition directive, cycling within same-style runs."""
+    # Find the index of the last composition used for this style.
+    same_style = [h for h in history if h["style"] == style]
+    if not same_style:
+        return COMPOSITION_CYCLE[0]
+
+    last_comp = same_style[-1]["composition"]
+    try:
+        idx = COMPOSITION_CYCLE.index(last_comp)
+    except ValueError:
+        idx = -1
+    return COMPOSITION_CYCLE[(idx + 1) % len(COMPOSITION_CYCLE)]
+
+
+# ---------------------------------------------------------------------------
+# Ken Burns direction
+# ---------------------------------------------------------------------------
+
+def _select_ken_burns(composition: str, history: list[dict]) -> str:
+    """Choose a Ken Burns zoom/pan direction, alternating pans to avoid monotony."""
+    base = KEN_BURNS_RULES.get(composition, "slow_zoom_in")
+
+    # For pan-based directions, alternate with previous same-composition entries.
+    if base in KEN_BURNS_PAN_ALTERNATES:
+        same_comp = [h for h in history if h["composition"] == composition]
+        if same_comp and same_comp[-1]["ken_burns"] == base:
+            return KEN_BURNS_PAN_ALTERNATES[base]
+    return base

--- a/skills/video-pipeline/image_prompt_engine/style_config.py
+++ b/skills/video-pipeline/image_prompt_engine/style_config.py
@@ -1,0 +1,147 @@
+"""
+Visual identity style configuration for the NanoBanana pipeline.
+
+Defines the three visual styles (Dossier, Schema, Echo), accent colors,
+composition directives, Ken Burns zoom rules, and default configuration.
+"""
+
+# ---------------------------------------------------------------------------
+# Style Prompt Suffixes
+# ---------------------------------------------------------------------------
+# Each style has a prompt suffix appended to every image prompt of that type.
+# The placeholder [ACCENT_COLOR] is replaced at build time with the video's
+# chosen accent color string (e.g. "cold teal").
+
+STYLE_SUFFIXES = {
+    "dossier": (
+        ", cinematic photorealistic, single dramatic light source, Rembrandt lighting, "
+        "deep shadows, desaturated color palette with [ACCENT_COLOR] accent, shallow "
+        "depth of field, subtle film grain, dark moody atmosphere, documentary "
+        "photography style, shot on Arri Alexa, 16:9"
+    ),
+    "schema": (
+        ", cinematic photorealistic background with translucent glowing data overlay, "
+        "thin luminous [ACCENT_COLOR] connection lines and node points, Bloomberg "
+        "terminal meets surveillance system aesthetic, dark atmosphere, minimal and "
+        "elegant, deep blacks with light-emitting data elements, subtle film grain, "
+        "16:9"
+    ),
+    "echo": (
+        ", photorealistic with subtle oil painting texture, dramatic chiaroscuro "
+        "candlelight lighting, warm amber tones, period-accurate costume and "
+        "architecture detail, deep shadows, slightly soft focus with painterly grain, "
+        "historical documentary style, heavy film grain, atmospheric and evocative, "
+        "16:9"
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Composition Directives
+# ---------------------------------------------------------------------------
+# Controls framing / camera angle for each image. Cycled through for
+# consecutive same-style images to ensure visual variety.
+
+COMPOSITION_DIRECTIVES = {
+    "wide": "wide establishing shot, full environment visible, figure small in frame",
+    "medium": "medium shot, figure from waist up in context of environment",
+    "closeup": "close-up detail shot, shallow depth of field, object or hands filling frame",
+    "environmental": "environmental detail, no human figure, architecture or objects telling the story",
+    "portrait": "medium close-up, figure from chest up, face partially in shadow",
+    "overhead": "high angle overhead view, looking down on scene, surveillance perspective",
+    "low_angle": "low angle looking up, figure or structure appearing powerful and imposing",
+}
+
+# Ordered rotation list for cycling compositions within consecutive same-style runs.
+COMPOSITION_CYCLE = ["wide", "medium", "closeup", "environmental", "portrait", "overhead", "low_angle"]
+
+# ---------------------------------------------------------------------------
+# Accent Color Map
+# ---------------------------------------------------------------------------
+
+ACCENT_COLOR_MAP = {
+    "geopolitical": "cold teal",
+    "ai_tech": "cold teal",
+    "corporate_power": "cold teal",
+    "surveillance": "cold teal",
+    "economic": "warm amber",
+    "financial": "warm amber",
+    "historical_power": "warm amber",
+    "old_money": "warm amber",
+    "conflict": "muted crimson",
+    "warfare": "muted crimson",
+    "political_violence": "muted crimson",
+    "default": "cold teal",
+}
+
+# ---------------------------------------------------------------------------
+# Act Style Weights
+# ---------------------------------------------------------------------------
+# Probability weights for style selection per act, before sequencing rule
+# adjustments.
+
+ACT_STYLE_WEIGHTS = {
+    "act1": {"dossier": 0.90, "schema": 0.10, "echo": 0.00},
+    "act2": {"dossier": 0.70, "schema": 0.30, "echo": 0.00},
+    "act3": {"dossier": 0.45, "schema": 0.20, "echo": 0.35},
+    "act4": {"dossier": 0.35, "schema": 0.20, "echo": 0.45},
+    "act5": {"dossier": 0.50, "schema": 0.35, "echo": 0.15},
+    "act6": {"dossier": 0.65, "schema": 0.35, "echo": 0.00},
+}
+
+# ---------------------------------------------------------------------------
+# Ken Burns Zoom Direction Rules
+# ---------------------------------------------------------------------------
+
+KEN_BURNS_RULES = {
+    "wide": "slow_zoom_in",
+    "medium": "slow_pan_right",
+    "closeup": "slow_zoom_out",
+    "environmental": "slow_pan_left",
+    "portrait": "slow_zoom_in",
+    "overhead": "slow_zoom_in",
+    "low_angle": "slow_tilt_up",
+}
+
+# Alternate pan directions to avoid monotony for compositions that pan.
+KEN_BURNS_PAN_ALTERNATES = {
+    "slow_pan_right": "slow_pan_left",
+    "slow_pan_left": "slow_pan_right",
+}
+
+# ---------------------------------------------------------------------------
+# Default Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_CONFIG = {
+    # Image timing
+    "image_duration_seconds": 11,
+    "video_duration_seconds": 1500,  # 25 minutes
+    "total_images": 136,             # ~1500/11, rounded
+
+    # Act breakpoints (in seconds from video start)
+    "act_timestamps": {
+        "act1_end": 90,
+        "act2_end": 360,
+        "act3_end": 720,
+        "act4_end": 1020,
+        "act5_end": 1320,
+        "act6_end": 1500,
+    },
+
+    # Style distribution targets (actual will vary due to sequencing rules)
+    "target_distribution": {
+        "dossier": 0.60,
+        "schema": 0.22,
+        "echo": 0.18,
+    },
+
+    # Default accent color
+    "default_accent_color": "cold teal",
+
+    # Sequencing constraints
+    "max_consecutive_same_style": 4,
+    "echo_cluster_min": 2,
+    "echo_cluster_max": 3,
+    "schema_cluster_max_default": 1,  # Max consecutive Schema outside Act 5
+    "schema_cluster_max_act5": 2,     # Max consecutive Schema in Act 5
+}

--- a/skills/video-pipeline/image_prompt_engine/tests/test_prompts.py
+++ b/skills/video-pipeline/image_prompt_engine/tests/test_prompts.py
@@ -1,0 +1,305 @@
+"""
+Tests for prompt construction and formatting.
+
+Verifies that the prompt builder produces correctly structured prompts
+with all required style markers, accent colors, and aspect ratios.
+"""
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from image_prompt_engine.prompt_builder import (
+    build_prompt,
+    generate_prompts,
+    resolve_accent_color,
+)
+from image_prompt_engine.style_config import (
+    ACCENT_COLOR_MAP,
+    COMPOSITION_DIRECTIVES,
+    DEFAULT_CONFIG,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sample_scenes(n: int = 136) -> list[dict]:
+    """Generate n minimal scene dicts."""
+    descriptions = [
+        "A lone figure in a dark tailored suit standing at the end of a rain-slicked corridor",
+        "Close-up of hands placing a black king chess piece onto an illuminated world map",
+        "Dark aerial view of a sprawling city at night with glowing connection lines",
+        "A shadowy figure silhouetted against a massive curved wall of data screens",
+        "A Renaissance-era ruler sitting alone at a desk covered in maps and sealed letters",
+        "Interior of the East India Company trading hall with merchants around a table",
+        "An empty boardroom with one chair illuminated by overhead light",
+        "A hand signing a classified document under harsh desk lamp lighting",
+        "Globe with luminous connection lines between entities on a dark background",
+        "Medieval war room with generals gathered around a sand table",
+    ]
+    return [{"scene_description": descriptions[i % len(descriptions)]} for i in range(n)]
+
+
+def _generate_full_video(seed: int = 42) -> list[dict]:
+    """Generate prompts for a full video."""
+    return generate_prompts(_sample_scenes(), topic_category="geopolitical", seed=seed)
+
+
+# ---------------------------------------------------------------------------
+# Prompt format tests
+# ---------------------------------------------------------------------------
+
+class TestPromptFormat:
+    def test_all_prompts_end_with_16_9(self):
+        """Every prompt ends with '16:9'."""
+        results = _generate_full_video()
+        for r in results:
+            assert r["prompt"].rstrip().endswith("16:9"), (
+                f"Prompt at index {r['index']} does not end with '16:9': "
+                f"...{r['prompt'][-30:]}"
+            )
+
+    def test_dossier_prompts_contain_arri_alexa(self):
+        """All Dossier prompts include 'shot on Arri Alexa'."""
+        results = _generate_full_video()
+        for r in results:
+            if r["style"] == "dossier":
+                assert "shot on Arri Alexa" in r["prompt"], (
+                    f"Dossier prompt at index {r['index']} missing 'shot on Arri Alexa'"
+                )
+
+    def test_echo_prompts_contain_candlelight(self):
+        """All Echo prompts include candlelight/chiaroscuro reference."""
+        results = _generate_full_video()
+        for r in results:
+            if r["style"] == "echo":
+                prompt_lower = r["prompt"].lower()
+                assert "candlelight" in prompt_lower or "chiaroscuro" in prompt_lower, (
+                    f"Echo prompt at index {r['index']} missing candlelight/chiaroscuro"
+                )
+
+    def test_schema_prompts_contain_bloomberg(self):
+        """All Schema prompts include Bloomberg/surveillance reference."""
+        results = _generate_full_video()
+        for r in results:
+            if r["style"] == "schema":
+                prompt_lower = r["prompt"].lower()
+                assert "bloomberg" in prompt_lower or "surveillance" in prompt_lower, (
+                    f"Schema prompt at index {r['index']} missing Bloomberg/surveillance"
+                )
+
+    def test_accent_color_substituted(self):
+        """No prompt contains the literal placeholder '[ACCENT_COLOR]'."""
+        results = _generate_full_video()
+        for r in results:
+            assert "[ACCENT_COLOR]" not in r["prompt"], (
+                f"Unsubstituted [ACCENT_COLOR] in prompt at index {r['index']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Accent color tests
+# ---------------------------------------------------------------------------
+
+class TestAccentColor:
+    def test_accent_color_consistency(self):
+        """All prompts in a video use the same accent color."""
+        results = _generate_full_video()
+        colors = {r["accent_color"] for r in results}
+        assert len(colors) == 1, f"Multiple accent colors found: {colors}"
+
+    def test_geopolitical_gets_cold_teal(self):
+        color = resolve_accent_color(topic_category="geopolitical")
+        assert color == "cold teal"
+
+    def test_financial_gets_warm_amber(self):
+        color = resolve_accent_color(topic_category="financial")
+        assert color == "warm amber"
+
+    def test_conflict_gets_muted_crimson(self):
+        color = resolve_accent_color(topic_category="conflict")
+        assert color == "muted crimson"
+
+    def test_unknown_category_gets_default(self):
+        color = resolve_accent_color(topic_category="unknown_category")
+        assert color == DEFAULT_CONFIG["default_accent_color"]
+
+    def test_explicit_color_overrides_category(self):
+        color = resolve_accent_color(accent_color="hot pink", topic_category="geopolitical")
+        assert color == "hot pink"
+
+    def test_no_inputs_returns_default(self):
+        color = resolve_accent_color()
+        assert color == DEFAULT_CONFIG["default_accent_color"]
+
+    def test_accent_color_appears_in_dossier_prompt(self):
+        """Dossier prompts contain the chosen accent color string."""
+        results = generate_prompts(
+            _sample_scenes(10),
+            accent_color="warm amber",
+            seed=42,
+        )
+        dossier = [r for r in results if r["style"] == "dossier"]
+        assert len(dossier) > 0
+        for r in dossier:
+            assert "warm amber" in r["prompt"]
+
+    def test_accent_color_appears_in_schema_prompt(self):
+        """Schema prompts contain the chosen accent color string."""
+        results = generate_prompts(
+            _sample_scenes(136),
+            accent_color="muted crimson",
+            seed=42,
+        )
+        schema = [r for r in results if r["style"] == "schema"]
+        assert len(schema) > 0
+        for r in schema:
+            assert "muted crimson" in r["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# Prompt structure tests
+# ---------------------------------------------------------------------------
+
+class TestPromptStructure:
+    def test_prompt_contains_scene_description(self):
+        """Each prompt starts with the scene description."""
+        scenes = [{"scene_description": "A unique test scene with a golden eagle"}]
+        results = generate_prompts(scenes, accent_color="cold teal", seed=42)
+        assert "A unique test scene with a golden eagle" in results[0]["prompt"]
+
+    def test_prompt_contains_composition_directive(self):
+        """Each prompt includes the composition directive text."""
+        results = _generate_full_video()
+        for r in results:
+            comp_text = COMPOSITION_DIRECTIVES[r["composition"]]
+            assert comp_text in r["prompt"], (
+                f"Composition '{r['composition']}' text not found in prompt at index {r['index']}"
+            )
+
+    def test_output_has_required_keys(self):
+        """Each result dict has all required output keys."""
+        required = {"prompt", "style", "composition", "accent_color", "act", "index", "ken_burns"}
+        results = _generate_full_video()
+        for r in results:
+            missing = required - set(r.keys())
+            assert not missing, f"Missing keys {missing} at index {r.get('index', '?')}"
+
+    def test_style_values_are_valid(self):
+        """Style field is always one of the three valid styles."""
+        valid = {"dossier", "schema", "echo"}
+        results = _generate_full_video()
+        for r in results:
+            assert r["style"] in valid, f"Invalid style '{r['style']}' at index {r['index']}"
+
+    def test_composition_values_are_valid(self):
+        """Composition field is always a recognized composition key."""
+        valid = set(COMPOSITION_DIRECTIVES.keys())
+        results = _generate_full_video()
+        for r in results:
+            assert r["composition"] in valid, (
+                f"Invalid composition '{r['composition']}' at index {r['index']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# build_prompt unit tests
+# ---------------------------------------------------------------------------
+
+class TestBuildPrompt:
+    def test_dossier_basic(self):
+        prompt = build_prompt(
+            "A figure in shadows",
+            "dossier",
+            "wide",
+            "cold teal",
+        )
+        assert prompt.startswith("A figure in shadows")
+        assert "wide establishing shot" in prompt
+        assert "cold teal" in prompt
+        assert "shot on Arri Alexa" in prompt
+        assert prompt.endswith("16:9")
+
+    def test_schema_basic(self):
+        prompt = build_prompt(
+            "City at night with data overlay",
+            "schema",
+            "overhead",
+            "warm amber",
+        )
+        assert "City at night with data overlay" in prompt
+        assert "overhead" in prompt.lower() or "surveillance perspective" in prompt
+        assert "warm amber" in prompt
+        assert "Bloomberg" in prompt
+        assert prompt.endswith("16:9")
+
+    def test_echo_basic(self):
+        prompt = build_prompt(
+            "Renaissance ruler at a desk",
+            "echo",
+            "medium",
+            "cold teal",
+        )
+        assert "Renaissance ruler at a desk" in prompt
+        assert "figure from waist up" in prompt
+        assert "candlelight" in prompt
+        assert "oil painting texture" in prompt
+        assert prompt.endswith("16:9")
+
+    def test_strips_trailing_comma_from_description(self):
+        """Scene descriptions with trailing commas don't create double commas."""
+        prompt = build_prompt("A test scene, ,", "dossier", "wide", "cold teal")
+        assert ", , ," not in prompt
+
+    def test_echo_always_has_warm_amber_tones(self):
+        """Echo suffix includes 'warm amber tones' regardless of chosen accent."""
+        prompt = build_prompt("Historical scene", "echo", "wide", "cold teal")
+        assert "warm amber tones" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline integration
+# ---------------------------------------------------------------------------
+
+class TestIntegration:
+    def test_full_video_generation_count(self):
+        """generate_prompts returns one result per scene."""
+        scenes = _sample_scenes(140)
+        results = generate_prompts(scenes, topic_category="surveillance", seed=7)
+        assert len(results) == 140
+
+    def test_custom_act_timestamps(self):
+        """Custom act timestamps are respected."""
+        custom = {
+            "act1_end": 60,
+            "act2_end": 300,
+            "act3_end": 600,
+            "act4_end": 900,
+            "act5_end": 1100,
+            "act6_end": 1200,
+        }
+        scenes = _sample_scenes(100)
+        results = generate_prompts(
+            scenes,
+            topic_category="financial",
+            act_timestamps=custom,
+            seed=42,
+        )
+        assert len(results) == 100
+        assert results[0]["style"] == "dossier"
+        assert results[-1]["style"] == "dossier"
+
+    @pytest.mark.parametrize("category,expected_color", [
+        ("geopolitical", "cold teal"),
+        ("financial", "warm amber"),
+        ("conflict", "muted crimson"),
+    ])
+    def test_topic_category_sets_accent_color(self, category, expected_color):
+        scenes = _sample_scenes(20)
+        results = generate_prompts(scenes, topic_category=category, seed=42)
+        assert all(r["accent_color"] == expected_color for r in results)

--- a/skills/video-pipeline/image_prompt_engine/tests/test_sequencing.py
+++ b/skills/video-pipeline/image_prompt_engine/tests/test_sequencing.py
@@ -1,0 +1,287 @@
+"""
+Tests for the sequencing engine.
+
+Verifies that all global sequencing rules from the PRD are enforced across
+a full video's worth of style assignments.
+"""
+
+import sys
+import os
+
+import pytest
+
+# Ensure the package is importable when running tests from this directory.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from image_prompt_engine.sequencer import assign_styles
+from image_prompt_engine.style_config import DEFAULT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_assignments(seed: int = 42, total: int = 136) -> list[dict]:
+    """Generate a deterministic full-video assignment sequence."""
+    return assign_styles(total, seed=seed)
+
+
+def _get_act(entry: dict) -> str:
+    return entry["act"]
+
+
+def _consecutive_runs(assignments: list[dict]) -> list[tuple[str, int]]:
+    """Return a list of (style, run_length) for consecutive same-style runs."""
+    if not assignments:
+        return []
+    runs = []
+    current_style = assignments[0]["style"]
+    count = 1
+    for entry in assignments[1:]:
+        if entry["style"] == current_style:
+            count += 1
+        else:
+            runs.append((current_style, count))
+            current_style = entry["style"]
+            count = 1
+    runs.append((current_style, count))
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: No more than 4 consecutive same style
+# ---------------------------------------------------------------------------
+
+class TestMaxConsecutive:
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_no_more_than_4_consecutive(self, seed):
+        """No style appears more than 4 times in a row."""
+        assignments = _make_assignments(seed=seed)
+        max_allowed = DEFAULT_CONFIG["max_consecutive_same_style"]
+        for style, run_len in _consecutive_runs(assignments):
+            assert run_len <= max_allowed, (
+                f"Style '{style}' has {run_len} consecutive images "
+                f"(max {max_allowed}), seed={seed}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: No Echo in restricted acts
+# ---------------------------------------------------------------------------
+
+class TestEchoRestriction:
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_no_echo_in_restricted_acts(self, seed):
+        """Echo never appears in Acts 1, 2, or 6."""
+        assignments = _make_assignments(seed=seed)
+        restricted = {"act1", "act2", "act6"}
+        for entry in assignments:
+            if entry["act"] in restricted:
+                assert entry["style"] != "echo", (
+                    f"Echo found in {entry['act']} at index {entry['index']}, seed={seed}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: Echo clusters minimum 2
+# ---------------------------------------------------------------------------
+
+class TestEchoClusters:
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_echo_clusters_minimum_2(self, seed):
+        """Echo images never appear as isolated singles."""
+        assignments = _make_assignments(seed=seed)
+        runs = _consecutive_runs(assignments)
+        for style, run_len in runs:
+            if style == "echo":
+                assert run_len >= DEFAULT_CONFIG["echo_cluster_min"], (
+                    f"Isolated echo (cluster size {run_len}), seed={seed}"
+                )
+
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_echo_clusters_maximum_3(self, seed):
+        """Echo clusters are at most 3 images long."""
+        assignments = _make_assignments(seed=seed)
+        runs = _consecutive_runs(assignments)
+        for style, run_len in runs:
+            if style == "echo":
+                assert run_len <= DEFAULT_CONFIG["echo_cluster_max"], (
+                    f"Echo cluster too long ({run_len}), seed={seed}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: Echo cluster followed by Dossier
+# ---------------------------------------------------------------------------
+
+class TestEchoFollowedByDossier:
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_echo_followed_by_dossier(self, seed):
+        """Every Echo cluster is followed by a Dossier image."""
+        assignments = _make_assignments(seed=seed)
+        runs = _consecutive_runs(assignments)
+        for i, (style, _run_len) in enumerate(runs):
+            if style == "echo" and i + 1 < len(runs):
+                next_style = runs[i + 1][0]
+                assert next_style == "dossier", (
+                    f"Echo cluster followed by '{next_style}' instead of 'dossier', seed={seed}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: Schema rarely clusters
+# ---------------------------------------------------------------------------
+
+class TestSchemaCluster:
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_schema_rarely_clusters(self, seed):
+        """Schema appears max 1 consecutive outside Act 5, max 2 in Act 5."""
+        assignments = _make_assignments(seed=seed)
+        for i, entry in enumerate(assignments):
+            if entry["style"] != "schema":
+                continue
+            # Count consecutive schema starting from this position.
+            run = 1
+            j = i + 1
+            while j < len(assignments) and assignments[j]["style"] == "schema":
+                run += 1
+                j += 1
+            # Determine the act for this run (use the first image's act).
+            act = entry["act"]
+            max_allowed = (
+                DEFAULT_CONFIG["schema_cluster_max_act5"]
+                if act == "act5"
+                else DEFAULT_CONFIG["schema_cluster_max_default"]
+            )
+            assert run <= max_allowed, (
+                f"Schema cluster of {run} in {act} at index {i} "
+                f"(max {max_allowed}), seed={seed}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: First and last images are Dossier
+# ---------------------------------------------------------------------------
+
+class TestFirstAndLast:
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_first_and_last_are_dossier(self, seed):
+        """First and last images are always Dossier style."""
+        assignments = _make_assignments(seed=seed)
+        assert assignments[0]["style"] == "dossier", (
+            f"First image is '{assignments[0]['style']}', expected 'dossier', seed={seed}"
+        )
+        assert assignments[-1]["style"] == "dossier", (
+            f"Last image is '{assignments[-1]['style']}', expected 'dossier', seed={seed}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Distribution within tolerance
+# ---------------------------------------------------------------------------
+
+class TestDistribution:
+    @pytest.mark.parametrize("seed", [1, 42, 99, 256, 1000])
+    def test_distribution_within_tolerance(self, seed):
+        """Overall distribution is within 10% of targets (60/22/18)."""
+        assignments = _make_assignments(seed=seed)
+        total = len(assignments)
+        counts = {"dossier": 0, "schema": 0, "echo": 0}
+        for entry in assignments:
+            counts[entry["style"]] += 1
+
+        targets = DEFAULT_CONFIG["target_distribution"]
+        tolerance = 0.10  # 10 percentage points
+
+        for style, target in targets.items():
+            actual = counts[style] / total
+            assert abs(actual - target) <= tolerance, (
+                f"Style '{style}': actual {actual:.2%} vs target {target:.0%} "
+                f"(tolerance {tolerance:.0%}), seed={seed}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Composition variety
+# ---------------------------------------------------------------------------
+
+class TestCompositionVariety:
+    def test_compositions_cycle_within_dossier(self):
+        """Consecutive Dossier images should not all use the same composition."""
+        assignments = _make_assignments(seed=42)
+        runs = _consecutive_runs(assignments)
+        idx = 0
+        for style, run_len in runs:
+            if style == "dossier" and run_len >= 3:
+                comps = [assignments[idx + k]["composition"] for k in range(run_len)]
+                assert len(set(comps)) > 1, (
+                    f"Dossier run of {run_len} all use composition '{comps[0]}'"
+                )
+            idx += run_len
+
+
+# ---------------------------------------------------------------------------
+# Ken Burns directions
+# ---------------------------------------------------------------------------
+
+class TestKenBurns:
+    def test_all_assignments_have_ken_burns(self):
+        """Every assignment includes a ken_burns direction."""
+        assignments = _make_assignments(seed=42)
+        for entry in assignments:
+            assert "ken_burns" in entry
+            assert entry["ken_burns"] is not None
+
+    def test_pan_directions_alternate(self):
+        """Pan-based Ken Burns directions alternate for same composition."""
+        assignments = _make_assignments(seed=42)
+        # Find medium-composition entries (default pan direction).
+        mediums = [a for a in assignments if a["composition"] == "medium"]
+        if len(mediums) >= 2:
+            # Should alternate between pan_right and pan_left.
+            directions = [m["ken_burns"] for m in mediums]
+            # At least some alternation should occur.
+            assert len(set(directions)) > 1, "Medium compositions never alternate pan direction"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_very_small_video(self):
+        """A video with only 5 images doesn't crash."""
+        assignments = assign_styles(5, seed=42)
+        assert len(assignments) == 5
+        assert assignments[0]["style"] == "dossier"
+        assert assignments[-1]["style"] == "dossier"
+
+    def test_single_image(self):
+        """A video with 1 image returns Dossier."""
+        assignments = assign_styles(1, seed=42)
+        assert len(assignments) == 1
+        assert assignments[0]["style"] == "dossier"
+
+    def test_large_video(self):
+        """A 300-image video runs without error and obeys rules."""
+        assignments = assign_styles(300, seed=42)
+        assert len(assignments) == 300
+        assert assignments[0]["style"] == "dossier"
+        assert assignments[-1]["style"] == "dossier"
+        # Check no more than 4 consecutive.
+        for _style, run_len in _consecutive_runs(assignments):
+            assert run_len <= DEFAULT_CONFIG["max_consecutive_same_style"]
+
+    def test_reproducible_with_seed(self):
+        """Same seed produces identical output."""
+        a = assign_styles(136, seed=12345)
+        b = assign_styles(136, seed=12345)
+        assert a == b
+
+    def test_different_seeds_differ(self):
+        """Different seeds produce different sequences (with high probability)."""
+        a = assign_styles(136, seed=1)
+        b = assign_styles(136, seed=2)
+        styles_a = [x["style"] for x in a]
+        styles_b = [x["style"] for x in b]
+        assert styles_a != styles_b


### PR DESCRIPTION
Implement a structured prompt engineering layer that replaces generic AI
image prompts with three cinematic visual styles (Dossier, Schema, Echo),
a narrative-arc sequencing engine with 8 enforced pacing rules, and
automatic accent color selection based on topic category.

All 77 unit tests pass covering sequencing rules, prompt format
validation, accent color consistency, and edge cases.

https://claude.ai/code/session_01UH9FCU26hU473P8Gj94y4r