### PR TITLE
feat: add discovery scanner system with title intelligence

### DIFF
--- a/skills/pipeline-bot/pipeline_control.py
+++ b/skills/pipeline-bot/pipeline_control.py
@@ -13,16 +13,21 @@ Commands:
   !cron 1h  - Set cron to every hour
   !cron off - Disable cron
   !update   - Pull latest code from GitHub
+  !discover / scan - Scan headlines and present 2-3 video ideas
+  !research / run research - Run deep research on approved idea
+  !research "topic" - Run deep research on specific topic
   !help     - Show available commands
 """
 
 import os
 from dotenv import load_dotenv
 load_dotenv(os.path.expanduser("~/projects/economy-fastforward/.env"))
+import asyncio
 import re
 import subprocess
 import signal
 import sys
+import threading
 import time
 import json
 import logging
@@ -37,7 +42,12 @@ APP_TOKEN = os.environ.get("SLACK_APP_TOKEN")
 PIPELINE_DIR = os.path.expanduser("~/projects/economy-fastforward/skills/video-pipeline")
 REPO_DIR = os.path.expanduser("~/projects/economy-fastforward")
 PIPELINE_LOG = "/tmp/pipeline.log"
+DISCOVERY_LOG = "/tmp/discovery.log"
 ALLOWED_CHANNEL = os.environ.get("SLACK_CHANNEL", "")  # Empty = respond anywhere
+
+# Track discovery messages for emoji reaction approval
+# Maps message_ts -> list of ideas from that discovery scan
+_discovery_messages = {}
 
 # ── Logging ─────────────────────────────────────────────────────────────────
 logging.basicConfig(
@@ -301,20 +311,311 @@ def _update_cron(cron_expr: str = None):
     proc.communicate(input=new_crontab)
 
 
+def send_message_with_ts(channel: str, text: str) -> str:
+    """Send a message and return its timestamp (for reaction tracking)."""
+    try:
+        response = web_client.chat_postMessage(channel=channel, text=text)
+        return response["ts"]
+    except Exception as e:
+        log.error(f"Failed to send Slack message: {e}")
+        return ""
+
+
+def add_reactions(channel: str, ts: str, emojis: list[str]):
+    """Add emoji reactions to a message."""
+    for emoji in emojis:
+        try:
+            web_client.reactions_add(channel=channel, name=emoji, timestamp=ts)
+        except Exception as e:
+            log.error(f"Failed to add reaction {emoji}: {e}")
+
+
+# ── Discovery Scanner & Research Commands ──────────────────────────────────
+
+def _run_async(coro):
+    """Run an async function from sync context."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def cmd_discover(channel: str, args: list = None):
+    """Scan headlines and present 2-3 video ideas."""
+    focus = " ".join(args) if args else None
+    focus_msg = f" (focus: {focus})" if focus else ""
+    send_message(channel, f"🔍 Scanning headlines{focus_msg}... This may take a moment.")
+
+    try:
+        # Import and run discovery scanner
+        sys.path.insert(0, PIPELINE_DIR)
+        from clients.anthropic_client import AnthropicClient
+        from discovery_scanner import run_discovery, format_ideas_for_slack
+
+        anthropic = AnthropicClient()
+        result = _run_async(run_discovery(
+            anthropic_client=anthropic,
+            focus=focus,
+        ))
+
+        # Format and send to Slack
+        slack_msg = format_ideas_for_slack(result)
+        ts = send_message_with_ts(channel, slack_msg)
+
+        if ts:
+            # Track this message for emoji reaction approval
+            _discovery_messages[ts] = result.get("ideas", [])
+
+            # Add reaction emojis for approval
+            idea_count = len(result.get("ideas", []))
+            emojis = ["one", "two", "three"][:idea_count]
+            add_reactions(channel, ts, emojis)
+
+            log.info(
+                f"Discovery posted: {idea_count} ideas, "
+                f"message_ts={ts}"
+            )
+
+    except Exception as e:
+        log.error(f"Discovery error: {e}", exc_info=True)
+        send_message(channel, f"❌ Discovery scan failed: {e}")
+    finally:
+        # Clean up sys.path
+        if PIPELINE_DIR in sys.path:
+            sys.path.remove(PIPELINE_DIR)
+
+
+def cmd_research(channel: str, args: list = None):
+    """Run deep research on a topic or approved idea.
+
+    Usage:
+        research             — Research next approved idea from Airtable
+        research "topic"     — Research a specific topic
+        run research         — Same as research
+    """
+    # Check if topic was provided (quoted or unquoted)
+    topic = None
+    if args:
+        raw = " ".join(args)
+        # Strip surrounding quotes if present
+        if (raw.startswith('"') and raw.endswith('"')) or \
+           (raw.startswith("'") and raw.endswith("'")):
+            raw = raw[1:-1]
+        topic = raw.strip()
+
+    if topic:
+        send_message(channel, f"🔬 Starting deep research on: _{topic}_")
+    else:
+        send_message(channel, "🔬 Looking for approved idea to research...")
+
+    try:
+        sys.path.insert(0, PIPELINE_DIR)
+        from clients.anthropic_client import AnthropicClient
+        from clients.airtable_client import AirtableClient
+        from research_agent import run_research
+
+        anthropic = AnthropicClient()
+        airtable = AirtableClient()
+
+        if not topic:
+            # Find next approved idea
+            approved = airtable.get_ideas_by_status("Approved", limit=1)
+            if not approved:
+                send_message(
+                    channel,
+                    "💤 No approved ideas in queue. "
+                    "Use `discover` to find ideas, or `research \"topic\"` "
+                    "for a specific topic."
+                )
+                return
+
+            idea = approved[0]
+            topic = idea.get("Video Title", "")
+            record_id = idea.get("id", "")
+            send_message(
+                channel,
+                f"🔬 Researching approved idea: _{topic}_"
+            )
+
+            # Run research with Airtable write-back
+            payload = _run_async(run_research(
+                anthropic_client=anthropic,
+                topic=topic,
+                context=idea.get("Hook Script", ""),
+                airtable_client=airtable,
+            ))
+
+            # Update status to Ready For Scripting
+            if record_id:
+                try:
+                    airtable.update_idea_status(record_id, "Ready For Scripting")
+                except Exception as e:
+                    log.warning(f"Could not update status: {e}")
+
+            send_message(
+                channel,
+                f"✅ Research complete for: _{topic}_\n"
+                f"Headline: {payload.get('headline', 'N/A')}\n"
+                f"Status: Ready For Scripting"
+            )
+        else:
+            # Direct topic research — save to Airtable
+            payload = _run_async(run_research(
+                anthropic_client=anthropic,
+                topic=topic,
+                airtable_client=airtable,
+            ))
+
+            send_message(
+                channel,
+                f"✅ Research complete for: _{topic}_\n"
+                f"Headline: {payload.get('headline', 'N/A')}\n"
+                f"Saved to Idea Concepts table."
+            )
+
+    except Exception as e:
+        log.error(f"Research error: {e}", exc_info=True)
+        send_message(channel, f"❌ Research failed: {e}")
+    finally:
+        if PIPELINE_DIR in sys.path:
+            sys.path.remove(PIPELINE_DIR)
+
+
+def handle_discovery_reaction(channel: str, ts: str, idea_index: int):
+    """Handle emoji reaction on a discovery message — approve an idea.
+
+    Writes the chosen idea to Airtable as 'Approved' and triggers
+    deep research automatically.
+
+    Args:
+        channel: Slack channel ID
+        ts: Message timestamp of the discovery results
+        idea_index: 0-based index of the chosen idea
+    """
+    ideas = _discovery_messages.get(ts, [])
+    if not ideas or idea_index >= len(ideas):
+        log.warning(f"No ideas found for message ts={ts} index={idea_index}")
+        return
+
+    idea = ideas[idea_index]
+    # Use first title option as the video title
+    title_options = idea.get("title_options", [])
+    title = title_options[0]["title"] if title_options else "Untitled"
+
+    send_message(
+        channel,
+        f"✅ Idea approved: _{title}_\n"
+        f"Writing to Airtable and starting research..."
+    )
+
+    try:
+        sys.path.insert(0, PIPELINE_DIR)
+        from clients.anthropic_client import AnthropicClient
+        from clients.airtable_client import AirtableClient
+        from research_agent import run_research
+
+        anthropic = AnthropicClient()
+        airtable = AirtableClient()
+
+        # Write idea to Airtable as Approved
+        idea_data = {
+            "viral_title": title,
+            "hook_script": idea.get("hook", ""),
+            "narrative_logic": {
+                "past_context": idea.get("historical_parallel_hint", ""),
+                "present_parallel": idea.get("our_angle", ""),
+                "future_prediction": "",
+            },
+            "writer_guidance": idea.get("our_angle", ""),
+            "original_dna": json.dumps({
+                "source": "discovery_scanner",
+                "headline_source": idea.get("headline_source", ""),
+                "formula_ids": [
+                    t.get("formula_id", "") for t in title_options
+                ],
+                "estimated_appeal": idea.get("estimated_appeal", 0),
+            }),
+        }
+
+        record = airtable.create_idea(idea_data, source="discovery_scanner")
+        record_id = record["id"]
+
+        # Set status to Approved (skip Idea Logged since Ryan just chose it)
+        airtable.update_idea_status(record_id, "Approved")
+
+        log.info(f"Idea written to Airtable: {record_id} — {title}")
+
+        # Auto-trigger deep research
+        send_message(channel, f"🔬 Auto-triggering deep research for: _{title}_")
+
+        payload = _run_async(run_research(
+            anthropic_client=anthropic,
+            topic=title,
+            context=idea.get("hook", "") + "\n" + idea.get("our_angle", ""),
+            airtable_client=None,  # Don't create a duplicate record
+        ))
+
+        # Write research payload back to the same record
+        research_json = json.dumps(payload)
+        try:
+            airtable.update_idea_field(record_id, "Research Payload", research_json)
+        except Exception as e:
+            if "UNKNOWN_FIELD_NAME" in str(e):
+                log.info("Research Payload field not yet in Airtable")
+            else:
+                log.warning(f"Could not write Research Payload: {e}")
+
+        # Advance status to Ready For Scripting
+        airtable.update_idea_status(record_id, "Ready For Scripting")
+
+        send_message(
+            channel,
+            f"✅ Research complete for: _{title}_\n"
+            f"Headline: {payload.get('headline', title)}\n"
+            f"Status: Ready For Scripting\n"
+            f"Use `run` to start the full pipeline."
+        )
+
+        # Clean up tracking
+        del _discovery_messages[ts]
+
+    except Exception as e:
+        log.error(f"Approval/research error: {e}", exc_info=True)
+        send_message(channel, f"❌ Error processing approval: {e}")
+    finally:
+        if PIPELINE_DIR in sys.path:
+            sys.path.remove(PIPELINE_DIR)
+
+
 def cmd_help(channel: str):
     """Show available commands."""
     help_text = """🤖 *Pipeline Control Bot*
 
-*Commands:*
+*Pipeline Commands:*
 • `status` — Pipeline queue status & running processes
 • `run` — Trigger pipeline immediately
 • `kill` — Kill running pipeline process
 • `logs` — Last 20 log lines (`logs 50` for more)
+
+*Discovery & Research:*
+• `discover` / `scan` — Scan headlines and present 2-3 video ideas
+• `discover [focus]` — Scan with focus keyword (e.g., `discover BRICS`)
+• `research` / `run research` — Run deep research on next approved idea
+• `research "topic"` — Run deep research on a specific topic
+
+*Scheduling & Admin:*
 • `cron` — Show current schedule
 • `cron 10m` — Set to every 10 min
 • `cron 1h` — Set to every hour
 • `cron off` — Disable auto-run
 • `update` — Pull latest code from GitHub
+
+*Animation:*
+• `animstatus` — Show animation pipeline status
+• `regen [N]` — Regenerate prompts for scene N
+• `approve [N]` / `approve all` — Approve animation prompts
+
 • `help` — This message"""
     send_message(channel, help_text)
 
@@ -323,12 +624,17 @@ def cmd_help(channel: str):
 
 COMMANDS = {
     "status": lambda ch, _: cmd_status(ch),
+    "run research": lambda ch, args: cmd_research(ch, args),
+    "run discover": lambda ch, args: cmd_discover(ch, args),
     "run": lambda ch, _: cmd_run(ch),
     "kill": lambda ch, _: cmd_kill(ch),
     "stop": lambda ch, _: cmd_kill(ch),
     "logs": lambda ch, args: cmd_logs(ch, int(args[0]) if args else 20),
     "cron": lambda ch, args: cmd_cron(ch, args[0] if args else None),
     "update": lambda ch, _: cmd_update(ch),
+    "discover": lambda ch, args: cmd_discover(ch, args),
+    "scan": lambda ch, args: cmd_discover(ch, args),
+    "research": lambda ch, args: cmd_research(ch, args),
     "animstatus": lambda ch, _: cmd_animstatus(ch),
     "regen": lambda ch, args: cmd_regen(ch, int(args[0])) if args else None,
     "approve all": lambda ch, _: cmd_approveall(ch),
@@ -337,21 +643,41 @@ COMMANDS = {
 }
 
 
+# Commands that run LLM calls and should execute in a background thread
+_ASYNC_COMMANDS = {"discover", "scan", "research", "run discover", "run research"}
+
+
 def handle_message(text: str, channel: str, user: str):
     """Route incoming message to command handler."""
     # Ignore bot's own messages
     if user == bot_user_id:
         return
 
-    text = text.strip().lower()
+    # Preserve original case for research topic parsing
+    original_text = text.strip()
+    text = original_text.lower()
 
     # Check if it's a command
     for cmd, handler in COMMANDS.items():
         if text.startswith(cmd):
-            args = text[len(cmd):].strip().split() if len(text) > len(cmd) else []
+            # For research command, use original case for topic
+            if cmd in ("research",):
+                args_text = original_text[len(cmd):].strip()
+            else:
+                args_text = text[len(cmd):].strip()
+            args = args_text.split() if args_text else []
             log.info(f"Command: {cmd} from user {user} in {channel}")
             try:
-                handler(channel, args)
+                # Run LLM-calling commands in a thread
+                if cmd in _ASYNC_COMMANDS:
+                    thread = threading.Thread(
+                        target=handler,
+                        args=(channel, args),
+                        daemon=True,
+                    )
+                    thread.start()
+                else:
+                    handler(channel, args)
             except Exception as e:
                 log.error(f"Command error: {e}")
                 send_message(channel, f"❌ Error: {e}")
@@ -403,13 +729,14 @@ class LogMonitor:
 # ── Socket Mode Handler ───────────────────────────────────────────────────
 
 def process_event(client: SocketModeClient, req: SocketModeRequest):
-    """Handle incoming Slack events."""
+    """Handle incoming Slack events (messages and emoji reactions)."""
     # Acknowledge immediately
     client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
 
     if req.type == "events_api":
         event = req.payload.get("event", {})
 
+        # Handle text messages
         if event.get("type") == "message" and "subtype" not in event:
             text = event.get("text", "")
             channel = event.get("channel", "")
@@ -420,6 +747,34 @@ def process_event(client: SocketModeClient, req: SocketModeRequest):
                 return
 
             handle_message(text, channel, user)
+
+        # Handle emoji reactions on discovery messages
+        elif event.get("type") == "reaction_added":
+            reaction = event.get("reaction", "")
+            user = event.get("user", "")
+            item = event.get("item", {})
+            item_ts = item.get("ts", "")
+            channel = item.get("channel", "")
+
+            # Ignore bot's own reactions
+            if user == bot_user_id:
+                return
+
+            # Map number emoji to idea index
+            reaction_map = {"one": 0, "two": 1, "three": 2}
+            if reaction in reaction_map and item_ts in _discovery_messages:
+                idea_index = reaction_map[reaction]
+                log.info(
+                    f"Discovery reaction: {reaction} from {user} "
+                    f"on {item_ts} -> idea {idea_index + 1}"
+                )
+                # Run in a thread to avoid blocking the event loop
+                thread = threading.Thread(
+                    target=handle_discovery_reaction,
+                    args=(channel, item_ts, idea_index),
+                    daemon=True,
+                )
+                thread.start()
 
 
 # ── Main ───────────────────────────────────────────────────────────────────

--- a/skills/video-pipeline/approval_watcher.py
+++ b/skills/video-pipeline/approval_watcher.py
@@ -1,0 +1,291 @@
+"""
+Approval Watcher — Polls Airtable for ideas with 'Approved' status
+and auto-triggers deep research.
+
+This provides Path B for auto-triggering research:
+  Path A: Slack reaction → discovery bot handles it directly
+  Path B: Manual Airtable status change → this watcher detects it
+
+Can run standalone or be integrated into the pipeline bot's polling loop.
+
+Usage (standalone):
+    python approval_watcher.py                    # Poll once
+    python approval_watcher.py --daemon           # Continuous polling
+    python approval_watcher.py --interval 120     # Poll every 2 minutes
+
+Usage (imported):
+    from approval_watcher import ApprovalWatcher
+    watcher = ApprovalWatcher(anthropic_client, airtable_client, slack_client)
+    await watcher.check_and_process()
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Track processed record IDs to prevent duplicate research runs
+_processed_ids: set[str] = set()
+
+
+class ApprovalWatcher:
+    """Watches Airtable for approved ideas and triggers deep research.
+
+    Provides idempotent processing — each approved idea is researched
+    exactly once, even if the watcher checks multiple times.
+
+    Usage:
+        watcher = ApprovalWatcher(anthropic, airtable, slack)
+        processed = await watcher.check_and_process()
+    """
+
+    def __init__(
+        self,
+        anthropic_client,
+        airtable_client,
+        slack_client=None,
+        model: str = "claude-sonnet-4-5-20250929",
+    ):
+        """Initialize the approval watcher.
+
+        Args:
+            anthropic_client: AnthropicClient for research LLM calls
+            airtable_client: AirtableClient for reading/writing ideas
+            slack_client: Optional SlackClient for notifications
+            model: Model to use for research (Sonnet 4.5 default)
+        """
+        self.anthropic = anthropic_client
+        self.airtable = airtable_client
+        self.slack = slack_client
+        self.model = model
+
+    def _notify(self, message: str):
+        """Send Slack notification if client is available."""
+        if self.slack:
+            try:
+                self.slack.send_message(message)
+            except Exception as e:
+                logger.warning(f"Slack notification failed: {e}")
+        logger.info(message)
+
+    async def check_and_process(self) -> list[dict]:
+        """Check for approved ideas and process them.
+
+        Finds all ideas with status 'Approved', runs deep research
+        on each, writes the payload back, and advances status.
+
+        Returns:
+            List of processed idea records (with research payloads)
+        """
+        from research_agent import run_research
+
+        # Find approved ideas
+        try:
+            approved = self.airtable.get_ideas_by_status("Approved", limit=5)
+        except Exception as e:
+            logger.error(f"Failed to fetch approved ideas: {e}")
+            return []
+
+        if not approved:
+            logger.debug("No approved ideas found")
+            return []
+
+        processed = []
+
+        for idea in approved:
+            record_id = idea.get("id", "")
+            title = idea.get("Video Title", "Untitled")
+
+            # Idempotency check — skip if already processed
+            if record_id in _processed_ids:
+                logger.debug(f"Skipping already-processed: {record_id}")
+                continue
+
+            logger.info(f"Processing approved idea: {title} ({record_id})")
+            self._notify(
+                f"🔬 Auto-researching approved idea: _{title}_"
+            )
+
+            try:
+                # Build context from idea fields
+                context_parts = []
+                if idea.get("Hook Script"):
+                    context_parts.append(idea["Hook Script"])
+                if idea.get("Writer Guidance"):
+                    context_parts.append(idea["Writer Guidance"])
+                context = "\n".join(context_parts) if context_parts else None
+
+                # Run deep research
+                payload = await run_research(
+                    anthropic_client=self.anthropic,
+                    topic=title,
+                    context=context,
+                    model=self.model,
+                )
+
+                # Write research payload back to the same record
+                research_json = json.dumps(payload)
+                try:
+                    self.airtable.update_idea_field(
+                        record_id, "Research Payload", research_json
+                    )
+                except Exception as e:
+                    if "UNKNOWN_FIELD_NAME" in str(e):
+                        logger.info(
+                            "Research Payload field not yet in Airtable — "
+                            "create it as a Long Text field"
+                        )
+                    else:
+                        logger.warning(f"Could not write Research Payload: {e}")
+
+                # Advance status to Ready For Scripting
+                self.airtable.update_idea_status(
+                    record_id, "Ready For Scripting"
+                )
+
+                self._notify(
+                    f"✅ Research complete for: _{title}_\n"
+                    f"Headline: {payload.get('headline', title)}\n"
+                    f"Status: Ready For Scripting"
+                )
+
+                # Mark as processed
+                _processed_ids.add(record_id)
+                payload["_record_id"] = record_id
+                processed.append(payload)
+
+            except Exception as e:
+                logger.error(
+                    f"Research failed for {title}: {e}", exc_info=True
+                )
+                # Status stays at Approved — don't advance on failure
+                self._notify(
+                    f"❌ Research failed for: _{title}_\n"
+                    f"Error: {str(e)[:200]}\n"
+                    f"Status remains: Approved"
+                )
+
+        return processed
+
+
+async def _poll_loop(
+    anthropic_client,
+    airtable_client,
+    slack_client=None,
+    interval: int = 300,
+):
+    """Continuous polling loop for approved ideas.
+
+    Args:
+        anthropic_client: AnthropicClient instance
+        airtable_client: AirtableClient instance
+        slack_client: Optional SlackClient for notifications
+        interval: Polling interval in seconds (default: 5 minutes)
+    """
+    watcher = ApprovalWatcher(
+        anthropic_client, airtable_client, slack_client
+    )
+
+    logger.info(
+        f"Approval watcher started (polling every {interval}s)"
+    )
+
+    while True:
+        try:
+            processed = await watcher.check_and_process()
+            if processed:
+                logger.info(
+                    f"Processed {len(processed)} approved ideas"
+                )
+        except Exception as e:
+            logger.error(f"Poll cycle error: {e}", exc_info=True)
+
+        await asyncio.sleep(interval)
+
+
+# === CLI Entry Point ===
+
+async def _cli_main():
+    """CLI entry point for standalone approval watcher."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Economy FastForward Approval Watcher",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  python approval_watcher.py                    # Poll once
+  python approval_watcher.py --daemon           # Continuous polling
+  python approval_watcher.py --interval 120     # Poll every 2 minutes
+""",
+    )
+    parser.add_argument(
+        "--daemon",
+        action="store_true",
+        help="Run continuously (poll loop)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=300,
+        help="Polling interval in seconds (default: 300 = 5 minutes)",
+    )
+
+    args = parser.parse_args()
+
+    # Load environment
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    from clients.anthropic_client import AnthropicClient
+    from clients.airtable_client import AirtableClient
+
+    anthropic = AnthropicClient()
+    airtable = AirtableClient()
+
+    # Optional Slack client
+    slack = None
+    try:
+        from clients.slack_client import SlackClient
+        slack = SlackClient()
+    except Exception:
+        logger.info("Slack client not available — notifications disabled")
+
+    print(f"\n{'=' * 60}")
+    print(f"APPROVAL WATCHER — Auto-Research on Approval")
+    print(f"{'=' * 60}")
+    print(f"Mode: {'Daemon' if args.daemon else 'Single poll'}")
+    if args.daemon:
+        print(f"Interval: {args.interval}s")
+    print(f"{'=' * 60}\n")
+
+    if args.daemon:
+        await _poll_loop(anthropic, airtable, slack, args.interval)
+    else:
+        watcher = ApprovalWatcher(anthropic, airtable, slack)
+        processed = await watcher.check_and_process()
+
+        if processed:
+            print(f"\nProcessed {len(processed)} ideas:")
+            for p in processed:
+                print(f"  - {p.get('headline', 'N/A')}")
+        else:
+            print("\nNo approved ideas to process.")
+
+    print(f"\n{'=' * 60}")
+    print("Approval watcher done.")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    asyncio.run(_cli_main())

--- a/skills/video-pipeline/discovery_prompt.md
+++ b/skills/video-pipeline/discovery_prompt.md
@@ -1,0 +1,203 @@
+# Discovery Scanner System Prompt
+
+You are the Editorial Director for **Economy FastForward**, a documentary-style
+YouTube channel that covers geopolitics, finance, technology, and economic
+policy through a **Machiavellian lens**.
+
+Your audience does not want the news. They want to see what's **behind** the
+news — the power dynamics, hidden systems, historical cycles, and strategic
+maneuvers that shape the world. They want to feel like insiders who see what
+the masses cannot.
+
+---
+
+## YOUR MISSION
+
+Scan the provided headlines and select the **2-3 stories** with the highest
+potential to become a viral Economy FastForward video. For each story, generate
+**2 title variants** using proven formula structures from the title pattern
+library.
+
+---
+
+## CHANNEL IDENTITY
+
+- Economy FastForward reveals hidden power systems, cycles, and patterns
+- We bridge **geopolitical analysis** (Economy Rewind style) with **Machiavellian
+  framing** (Mindplicit style)
+- Our audience wants to feel like they're seeing what others can't
+- Tone: **dark, authoritative, revelatory** — never clickbait without substance
+- We are NOT a news channel. We don't report events. We reveal the **systems
+  and strategies** behind events.
+
+---
+
+## STORY SELECTION CRITERIA
+
+Score each headline on these 6 dimensions (1-10 each):
+
+### 1. Power Dynamics (REQUIRED — minimum 6/10)
+- WHO is gaining power? Who is losing it? Who is manipulating?
+- Is there a clear power asymmetry being exploited?
+- Can we identify a Machiavellian actor or strategy?
+- "Who benefits from this?" is ALWAYS the first question.
+
+### 2. Hidden System or Pattern (REQUIRED — minimum 5/10)
+- Is this part of a **systemic** pattern, not just a one-off event?
+- Can we frame this as a repeating cycle (historical, economic, political)?
+- Is there a mechanism that most people don't understand?
+- Can we explain HOW this system works, not just THAT it happened?
+
+### 3. Historical Parallel (STRONGLY PREFERRED)
+- Can we draw illuminating parallels to past events?
+- Rome, British Empire, USSR, Weimar Republic, Asian Financial Crisis, etc.
+- The parallel should feel like a **revelation**, not a stretch
+- Best parallels: "This exact playbook was used before in [year] when [event]"
+
+### 4. Machiavellian Angle (REQUIRED — minimum 5/10)
+- Betrayal, strategic misdirection, manufactured crises
+- Power consolidation, controlled opposition, economic warfare
+- Can we reference The 48 Laws of Power, The Prince, or Art of War?
+- Not just "China did X" but "China is executing Law 3: Conceal Your Intentions"
+- Look for: strategic patience, calculated sacrifice, divide and conquer,
+  controlled demolition, weaponized dependencies
+
+### 5. Visual Storytelling Potential (PREFERRED)
+- Can we create compelling 3D mannequin render visuals?
+- Data/numbers that can become visual moments (charts, dollar amounts, maps)
+- Physical metaphors: traps, chess pieces, scales, chains, dominoes
+- Geographic scope: world maps, trade routes, pipelines, borders
+
+### 6. Emotional Trigger (PREFERRED)
+- Fear: "This threatens YOUR money/savings/retirement"
+- Outrage: "They did this SECRETLY and nobody noticed"
+- Curiosity: "I had no idea this was happening"
+- Vindication: "You were right to be suspicious"
+
+---
+
+## SELECTION RULES
+
+**MUST include stories that have:**
+- A clear power dynamics angle (not just news reporting)
+- Potential for historical parallels or cyclical framing
+- An angle that feels like a REVELATION, not a summary
+
+**MUST EXCLUDE stories that are:**
+- Surface-level news everyone already knows
+- Pure opinion without verifiable facts or historical grounding
+- Celebrity gossip, sports, entertainment (unless power dynamics angle)
+- Stories that are just "bad things happened" without a systemic explanation
+- Domestic partisan politics without geopolitical implications
+
+---
+
+## TITLE GENERATION RULES
+
+For each selected story, generate **2 title variants** using formulas from the
+title pattern library.
+
+### Title Requirements:
+1. **Always use formulas** from title_patterns.json (EFF-1 through EFF-9 preferred,
+   competitor formulas acceptable)
+2. Every title must imply the viewer will learn something **hidden**
+3. Numbers in titles perform well (stages, laws, rules, dollar amounts)
+4. Include implied personal threat where applicable ("Your X is next")
+5. Never use generic clickbait that doesn't deliver substance
+6. Titles should be **decomposable into the formula variables** — if you can't
+   map it back to a formula, rewrite it
+7. CAPS words should be limited to ONE per title for visual emphasis
+
+### Formula Priority (use EFF formulas first):
+1. **EFF-1**: N-Stage Power Play Pattern (for cyclical/staged stories)
+2. **EFF-2**: Entity's Dark Strategy (for named actor stories)
+3. **EFF-7**: Country's Machiavellian Trap (for country-level economic stories)
+4. **EFF-4**: Trusted Entity Betrayal (for betrayal/secret action stories)
+5. **EFF-8**: Country Is Xer Than You Think (for contrarian takes)
+6. **EFF-9**: Slow Death + Who Benefits (for declining system stories)
+7. **EFF-5**: System Death + Personal Threat (for urgent/breaking stories)
+8. **EFF-3**: Machiavellian Laws of Geopolitics (for analytical/framework stories)
+9. **EFF-6**: Counterintuitive System Reveal (for "why" explainer stories)
+
+---
+
+## MACHIAVELLIAN LENS APPLICATION
+
+Apply this analytical framework to every story:
+
+### Primary Questions:
+1. **Cui bono?** — Who benefits from this event/policy/crisis?
+2. **What's the real strategy?** — Is the stated reason the actual reason?
+3. **What historical playbook is being used?** — Has this been done before?
+4. **What are the second-order effects?** — What happens AFTER this headline?
+5. **Who is being deceived?** — Is public perception being managed?
+
+### Machiavellian Frameworks to Apply:
+- **Strategic Patience**: Long-term plans disguised as short-term events
+- **Controlled Demolition**: Deliberately destroying one thing to build another
+- **Weaponized Dependencies**: Making others dependent, then using that leverage
+- **Manufacturing Consent**: Creating conditions that make an outcome seem inevitable
+- **The Overton Window**: Gradually shifting what's considered acceptable
+- **Divide and Rule**: Fragmenting opposition to maintain control
+- **The Scapegoat Strategy**: Redirecting blame to consolidate power
+
+### Historical Archetypes:
+- Not just "Putin did X" but "Putin is executing a strategy of **strategic patience**
+  that mirrors Bismarck's approach to German unification"
+- Not just "The Fed raised rates" but "The Fed is applying a **controlled demolition**
+  of asset prices that follows the same 3-stage pattern used in 1980"
+- Not just "China is buying gold" but "China is building a **weaponized dependency**
+  on commodity reserves that mirrors how the US used the Petrodollar"
+
+---
+
+## OUTPUT FORMAT
+
+For each of the 2-3 selected stories, output:
+
+```json
+{
+  "ideas": [
+    {
+      "headline_source": "Original headline text — Source Name (URL if available)",
+      "our_angle": "2-3 sentences on the Machiavellian/power dynamics angle we'd take. This is NOT a summary of the news — it's our UNIQUE SPIN.",
+      "title_options": [
+        {
+          "title": "The generated title using a formula",
+          "formula_id": "EFF-2",
+          "formula_name": "Entity's Dark Strategy"
+        },
+        {
+          "title": "Second title variant using a different formula",
+          "formula_id": "EFF-7",
+          "formula_name": "Country's Machiavellian Trap"
+        }
+      ],
+      "hook": "2-3 sentence pitch for the video opening. Must create immediate curiosity gap.",
+      "estimated_appeal": 8,
+      "appeal_breakdown": {
+        "power_dynamics": 9,
+        "hidden_system": 7,
+        "historical_parallel": 8,
+        "machiavellian_angle": 9,
+        "visual_potential": 7,
+        "emotional_trigger": 8
+      },
+      "historical_parallel_hint": "Suggested historical parallel for the research phase (e.g., 'British Empire's decline after Suez Crisis 1956')"
+    }
+  ]
+}
+```
+
+---
+
+## QUALITY CHECKLIST (verify before outputting)
+
+- [ ] Every idea has a clear **power dynamics** angle (not generic news)
+- [ ] Every title follows a **formula structure** from the pattern library
+- [ ] Every idea has a **Machiavellian framing** (not just economic analysis)
+- [ ] The hook creates an **irresistible curiosity gap**
+- [ ] Ideas feel like they belong on **Economy FastForward** (not CNN, not WSJ)
+- [ ] Historical parallels are **illuminating** (not forced or superficial)
+- [ ] No more than **3 ideas** total (quality over quantity)
+- [ ] Each idea has **2 distinct title variants** using different formulas

--- a/skills/video-pipeline/discovery_scanner.py
+++ b/skills/video-pipeline/discovery_scanner.py
@@ -1,0 +1,553 @@
+"""
+Discovery Scanner — Scans headlines, filters through Machiavellian lens,
+and generates title variants using the pattern library.
+
+Scans current headlines across geopolitics, finance, tech, and economic
+policy, filters them through the channel's dark power dynamics lens, and
+formats the top 2-3 stories into proven title structures.
+
+Usage (standalone):
+    python discovery_scanner.py
+    python discovery_scanner.py --focus "BRICS currency"
+    python discovery_scanner.py --output discoveries.json
+
+Usage (imported):
+    from discovery_scanner import DiscoveryScanner, run_discovery
+
+    scanner = DiscoveryScanner(anthropic_client)
+    ideas = await scanner.scan()
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Source categories for headline scanning
+SCAN_SOURCES = {
+    "geopolitics": [
+        "Reuters world news",
+        "AP News international",
+        "BBC World",
+        "Al Jazeera",
+    ],
+    "finance": [
+        "Bloomberg markets",
+        "Financial Times",
+        "Wall Street Journal",
+        "CNBC",
+    ],
+    "tech_business": [
+        "TechCrunch",
+        "Ars Technica",
+        "Fortune",
+        "Forbes",
+    ],
+    "economic_policy": [
+        "Federal Reserve announcements",
+        "IMF reports",
+        "World Bank",
+        "central bank policy",
+    ],
+}
+
+
+def _load_title_patterns() -> dict:
+    """Load the title pattern library from title_patterns.json."""
+    patterns_path = Path(__file__).parent / "title_patterns.json"
+    if not patterns_path.exists():
+        raise FileNotFoundError(
+            f"title_patterns.json not found at {patterns_path}. "
+            f"Run Story 0 first to create it."
+        )
+    with open(patterns_path) as f:
+        return json.load(f)
+
+
+def _load_discovery_prompt() -> str:
+    """Load the discovery scanner system prompt from discovery_prompt.md."""
+    prompt_path = Path(__file__).parent / "discovery_prompt.md"
+    if not prompt_path.exists():
+        raise FileNotFoundError(
+            f"discovery_prompt.md not found at {prompt_path}. "
+            f"Run Story 4 first to create it."
+        )
+    with open(prompt_path) as f:
+        return f.read()
+
+
+def _build_scan_query(focus: Optional[str] = None) -> str:
+    """Build the search query for headline scanning.
+
+    Creates a query that covers all source categories and optionally
+    focuses on a specific niche keyword.
+    """
+    base_topics = [
+        "geopolitics",
+        "global finance",
+        "economic policy",
+        "central banks",
+        "trade wars",
+        "sanctions",
+        "currency",
+        "debt crisis",
+        "power dynamics",
+        "economic warfare",
+    ]
+
+    if focus:
+        return (
+            f"latest news headlines about {focus} "
+            f"related to geopolitics finance economics power dynamics 2026"
+        )
+
+    return (
+        "latest major headlines today: geopolitics, global finance, "
+        "economic policy, trade wars, sanctions, central banks, "
+        "tech power dynamics, currency wars, debt crises 2026"
+    )
+
+
+def _build_headline_scan_prompt(
+    headlines: str,
+    title_patterns: dict,
+    focus: Optional[str] = None,
+) -> str:
+    """Build the user prompt for the discovery scanner LLM call.
+
+    Combines the gathered headlines with the title pattern library
+    and instructions for analysis.
+    """
+    # Extract EFF formulas for inline reference
+    eff_formulas = title_patterns.get("economy_fastforward", {}).get(
+        "hybrid_formulas", []
+    )
+    formulas_summary = "\n".join(
+        f"- {f['id']}: {f['name']} — Template: \"{f['template']}\""
+        for f in eff_formulas
+    )
+
+    focus_instruction = ""
+    if focus:
+        focus_instruction = (
+            f"\n\nFOCUS KEYWORD: '{focus}' — prioritize stories related "
+            f"to this topic, but don't force it if no strong stories exist."
+        )
+
+    return f"""\
+Analyze these current headlines and select the 2-3 best stories for
+Economy FastForward videos. Apply the Machiavellian lens and generate
+title variants using the formula library.
+
+=== CURRENT HEADLINES ===
+{headlines}
+
+=== AVAILABLE TITLE FORMULAS (use EFF formulas first) ===
+{formulas_summary}
+
+=== FULL FORMULA LIBRARY (for variable reference) ===
+{json.dumps(eff_formulas, indent=2)}
+{focus_instruction}
+
+INSTRUCTIONS:
+1. Select exactly 2-3 stories (not more, not less)
+2. Each story must pass the power dynamics filter (minimum 6/10)
+3. Generate 2 title variants per story using DIFFERENT formulas
+4. Include formula_id for each title variant
+5. Rate each story's appeal (1-10) with breakdown by criterion
+6. Suggest a historical parallel for the research phase
+7. Write a 2-3 sentence hook that creates a curiosity gap
+
+Return your response as valid JSON following the output format specified
+in your system prompt. No markdown code blocks — raw JSON only.
+"""
+
+
+def _parse_scanner_output(response_text: str) -> dict:
+    """Parse the JSON output from the discovery scanner LLM.
+
+    Handles potential formatting issues (markdown code blocks, etc.)
+    """
+    text = response_text.strip()
+
+    # Strip markdown code block if present
+    if text.startswith("```"):
+        first_newline = text.index("\n")
+        text = text[first_newline + 1:]
+    if text.endswith("```"):
+        text = text[:-3].rstrip()
+
+    # Find JSON object
+    brace_start = text.find("{")
+    brace_end = text.rfind("}")
+    if brace_start != -1 and brace_end != -1:
+        text = text[brace_start:brace_end + 1]
+
+    result = json.loads(text)
+
+    # Validate structure
+    ideas = result.get("ideas", [])
+    if not ideas:
+        raise ValueError("Scanner output contains no ideas")
+
+    if len(ideas) > 3:
+        logger.warning(
+            f"Scanner returned {len(ideas)} ideas, trimming to 3"
+        )
+        result["ideas"] = ideas[:3]
+
+    # Validate each idea has required fields
+    required_fields = [
+        "headline_source",
+        "our_angle",
+        "title_options",
+        "hook",
+        "estimated_appeal",
+    ]
+    for i, idea in enumerate(result["ideas"]):
+        missing = [f for f in required_fields if f not in idea]
+        if missing:
+            logger.warning(f"Idea {i+1} missing fields: {missing}")
+
+        # Validate title_options have formula_id
+        for j, title_opt in enumerate(idea.get("title_options", [])):
+            if "formula_id" not in title_opt:
+                logger.warning(
+                    f"Idea {i+1}, title option {j+1} missing formula_id"
+                )
+
+    return result
+
+
+class DiscoveryScanner:
+    """Scans headlines and generates video ideas through the Machiavellian lens.
+
+    Usage:
+        scanner = DiscoveryScanner(anthropic_client)
+        result = await scanner.scan()
+        # result["ideas"] contains 2-3 curated ideas with title variants
+    """
+
+    def __init__(
+        self,
+        anthropic_client,
+        model: str = "claude-sonnet-4-5-20250929",
+    ):
+        """Initialize the discovery scanner.
+
+        Args:
+            anthropic_client: AnthropicClient instance for LLM calls
+            model: Model to use (Sonnet 4.5 for cost efficiency)
+        """
+        self.anthropic = anthropic_client
+        self.model = model
+        self.title_patterns = _load_title_patterns()
+        self.system_prompt = _load_discovery_prompt()
+
+    async def _gather_headlines(
+        self,
+        focus: Optional[str] = None,
+    ) -> str:
+        """Gather current headlines using LLM web search capabilities.
+
+        Uses the Anthropic client with a focused query to gather
+        headlines across all source categories.
+
+        Args:
+            focus: Optional niche keyword to focus the scan
+
+        Returns:
+            String containing gathered headlines
+        """
+        query = _build_scan_query(focus)
+
+        # Use the LLM to search and compile headlines
+        # The LLM has access to web search through its training data
+        # and can synthesize recent events
+        scan_prompt = f"""\
+You are a news aggregator. Your job is to compile the most important
+current headlines from the past 48 hours across these categories:
+
+1. GEOPOLITICS: {', '.join(SCAN_SOURCES['geopolitics'])}
+2. FINANCE: {', '.join(SCAN_SOURCES['finance'])}
+3. ECONOMIC POLICY: {', '.join(SCAN_SOURCES['economic_policy'])}
+4. TECH/BUSINESS: {', '.join(SCAN_SOURCES['tech_business'])}
+
+{"Focus especially on: " + focus if focus else ""}
+
+For each headline, include:
+- The headline text
+- The source (publication name)
+- A 1-sentence summary of the key facts
+- Any numbers, dollar amounts, or percentages mentioned
+
+List 15-25 headlines total, covering all 4 categories.
+Format as a simple numbered list. Focus on stories with:
+- Major power shifts between nations or institutions
+- Economic policy changes with global implications
+- Financial market disruptions or systemic risks
+- Technology moves that shift power dynamics
+- Trade wars, sanctions, or economic warfare
+
+DO NOT include: celebrity news, sports, entertainment, or
+purely domestic politics without global economic implications.
+"""
+
+        headlines = await self.anthropic.generate(
+            prompt=scan_prompt,
+            system_prompt=(
+                "You are a financial and geopolitical news aggregator. "
+                "Compile current headlines from major sources. Be factual "
+                "and specific — include numbers, names, and dates."
+            ),
+            model=self.model,
+            max_tokens=3000,
+            temperature=0.3,
+        )
+
+        return headlines
+
+    async def scan(
+        self,
+        focus: Optional[str] = None,
+        headlines: Optional[str] = None,
+    ) -> dict:
+        """Run the full discovery scan.
+
+        Gathers headlines (or uses provided ones), filters through the
+        Machiavellian lens, and generates title variants.
+
+        Args:
+            focus: Optional niche keyword to focus the scan
+            headlines: Optional pre-gathered headlines (skips gathering step)
+
+        Returns:
+            Dict with "ideas" list containing 2-3 curated video ideas,
+            each with title_options, hook, appeal score, etc.
+        """
+        logger.info(
+            f"Starting discovery scan"
+            + (f" (focus: {focus})" if focus else "")
+        )
+
+        # Step 1: Gather headlines
+        if headlines is None:
+            logger.info("Gathering current headlines...")
+            headlines = await self._gather_headlines(focus)
+            logger.info(
+                f"Gathered {len(headlines.splitlines())} headline lines"
+            )
+
+        # Step 2: Build analysis prompt
+        analysis_prompt = _build_headline_scan_prompt(
+            headlines=headlines,
+            title_patterns=self.title_patterns,
+            focus=focus,
+        )
+
+        # Step 3: Run through Machiavellian lens
+        logger.info("Analyzing headlines through Machiavellian lens...")
+        response = await self.anthropic.generate(
+            prompt=analysis_prompt,
+            system_prompt=self.system_prompt,
+            model=self.model,
+            max_tokens=4000,
+            temperature=0.7,
+        )
+
+        # Step 4: Parse and validate output
+        result = _parse_scanner_output(response)
+        idea_count = len(result.get("ideas", []))
+        logger.info(
+            f"Discovery scan complete: {idea_count} ideas generated"
+        )
+
+        # Add metadata
+        result["_metadata"] = {
+            "focus": focus,
+            "model": self.model,
+            "headline_count": len(headlines.splitlines()),
+            "source_categories": list(SCAN_SOURCES.keys()),
+        }
+
+        return result
+
+
+async def run_discovery(
+    anthropic_client,
+    focus: Optional[str] = None,
+    headlines: Optional[str] = None,
+    model: str = "claude-sonnet-4-5-20250929",
+) -> dict:
+    """Convenience function to run discovery scan.
+
+    This is the main entry point for external callers (Slack bot, pipeline).
+
+    Args:
+        anthropic_client: AnthropicClient instance
+        focus: Optional niche keyword to focus the scan
+        headlines: Optional pre-gathered headlines
+        model: LLM model to use (default: Sonnet 4.5)
+
+    Returns:
+        Dict with "ideas" list containing 2-3 curated video ideas
+    """
+    scanner = DiscoveryScanner(anthropic_client, model=model)
+    return await scanner.scan(focus=focus, headlines=headlines)
+
+
+def format_ideas_for_slack(result: dict) -> str:
+    """Format discovery results as a readable Slack message.
+
+    Produces a mobile-friendly Slack message with numbered ideas,
+    title options, hooks, and appeal scores.
+
+    Args:
+        result: Output from DiscoveryScanner.scan()
+
+    Returns:
+        Formatted Slack message string
+    """
+    ideas = result.get("ideas", [])
+    if not ideas:
+        return "No ideas found. Try running with a different focus keyword."
+
+    lines = ["*Discovery Scanner Results*\n"]
+
+    for i, idea in enumerate(ideas, 1):
+        emoji = ["1\ufe0f\u20e3", "2\ufe0f\u20e3", "3\ufe0f\u20e3"][i - 1]
+        appeal = idea.get("estimated_appeal", "?")
+
+        lines.append(f"{emoji} *Idea {i}* (Appeal: {appeal}/10)")
+        lines.append(f"_{idea.get('headline_source', 'Unknown source')}_\n")
+
+        # Title options
+        for j, title_opt in enumerate(idea.get("title_options", []), 1):
+            formula_id = title_opt.get("formula_id", "?")
+            title = title_opt.get("title", "Untitled")
+            lines.append(f"  *Title {j}* ({formula_id}): {title}")
+
+        lines.append("")
+
+        # Hook
+        hook = idea.get("hook", "")
+        if hook:
+            lines.append(f"  *Hook:* {hook}")
+
+        # Angle
+        angle = idea.get("our_angle", "")
+        if angle:
+            lines.append(f"  *Angle:* {angle}")
+
+        # Historical parallel hint
+        parallel = idea.get("historical_parallel_hint", "")
+        if parallel:
+            lines.append(f"  *Parallel:* {parallel}")
+
+        lines.append("\n" + "-" * 40 + "\n")
+
+    lines.append(
+        "React with 1\ufe0f\u20e3 2\ufe0f\u20e3 or 3\ufe0f\u20e3 "
+        "to approve an idea for deep research."
+    )
+
+    return "\n".join(lines)
+
+
+def format_ideas_for_json(result: dict) -> str:
+    """Format discovery results as pretty-printed JSON.
+
+    Args:
+        result: Output from DiscoveryScanner.scan()
+
+    Returns:
+        Pretty-printed JSON string
+    """
+    return json.dumps(result, indent=2)
+
+
+# === CLI Entry Point ===
+
+async def _cli_main():
+    """CLI entry point for standalone discovery scanner."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Economy FastForward Discovery Scanner",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  python discovery_scanner.py
+  python discovery_scanner.py --focus "BRICS currency"
+  python discovery_scanner.py --output discoveries.json
+  python discovery_scanner.py --focus "sanctions" --output discoveries.json
+""",
+    )
+    parser.add_argument(
+        "--focus",
+        help="Optional niche keyword to focus the scan",
+    )
+    parser.add_argument(
+        "--output",
+        help="Output file path (default: stdout as JSON)",
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-sonnet-4-5-20250929",
+        help="Model to use (default: claude-sonnet-4-5-20250929)",
+    )
+    parser.add_argument(
+        "--slack-format",
+        action="store_true",
+        help="Output in Slack message format instead of JSON",
+    )
+
+    args = parser.parse_args()
+
+    # Load environment
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    from clients.anthropic_client import AnthropicClient
+
+    anthropic = AnthropicClient()
+
+    print(f"\n{'=' * 60}")
+    print(f"DISCOVERY SCANNER — Headline Analysis")
+    print(f"{'=' * 60}")
+    if args.focus:
+        print(f"Focus: {args.focus}")
+    print(f"Model: {args.model}")
+    print(f"{'=' * 60}\n")
+
+    result = await run_discovery(
+        anthropic_client=anthropic,
+        focus=args.focus,
+        model=args.model,
+    )
+
+    # Format output
+    if args.slack_format:
+        output = format_ideas_for_slack(result)
+    else:
+        output = format_ideas_for_json(result)
+
+    if args.output:
+        Path(args.output).write_text(output)
+        idea_count = len(result.get("ideas", []))
+        print(f"\n{idea_count} ideas saved to: {args.output}")
+    else:
+        print(output)
+
+    print(f"\n{'=' * 60}")
+    print("Discovery scan complete.")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    asyncio.run(_cli_main())

--- a/skills/video-pipeline/title_patterns.json
+++ b/skills/video-pipeline/title_patterns.json
@@ -1,0 +1,435 @@
+{
+  "version": "1.0",
+  "last_updated": "2026-02-14",
+  "competitors": {
+    "economy_rewind": {
+      "channel_url": "TBD",
+      "focus": "Hidden systems, cycles, historical patterns in economics",
+      "formulas": [
+        {
+          "id": "ER-1",
+          "name": "N-Stage Pattern/Cycle",
+          "top_view_count": 3200000,
+          "template": "The [Number]-Stage [Event Type] [Pattern/Cycle]: [Historical Examples]...",
+          "variables": {
+            "Number": {"type": "integer", "range": [3, 7], "sweet_spot": [5, 7]},
+            "Event Type": {"type": "string", "examples": ["Collapse", "Revolution", "Currency Kill", "Debt Reset", "Sanction Trap"]},
+            "Pattern/Cycle": {"type": "string", "options": ["Pattern", "Cycle", "Playbook", "Blueprint"]},
+            "Historical Examples": {"type": "list", "count": [2, 4], "format": "comma separated"}
+          },
+          "implied_elements": ["USA/viewer country is next", "Current stage number shown"],
+          "examples": [
+            "The 7-Stage Collapse Pattern: Spain, Britain, USSR... USA Is at Stage 5",
+            "The 6-Stage Revolution Cycle: France, Russia, Cuba... 2025 = Next?"
+          ]
+        },
+        {
+          "id": "ER-2",
+          "name": "Trusted Entity Betrayal",
+          "top_view_count": 176000,
+          "template": "How [Trusted Entity] [Secretly/Quietly] [Betrayed/Looted/Built] [Shocking Target]",
+          "variables": {
+            "Trusted Entity": {"type": "string", "examples": ["America", "Wall Street", "The Fed", "NATO", "IMF"]},
+            "Action": {"type": "string", "examples": ["Looted", "Built", "Destroyed", "Funded", "Controls"]},
+            "Shocking Target": {"type": "string", "examples": ["the British Empire", "the Nazi War Machine", "Both Sides"]}
+          },
+          "implied_elements": ["Betrayal of trust", "Secret action revealed"],
+          "examples": [
+            "How America Looted the British Empire During WWII",
+            "How Wall Street Built the Nazi War Machine"
+          ]
+        },
+        {
+          "id": "ER-3",
+          "name": "Anonymous Architects",
+          "top_view_count": 1300000,
+          "template": "They [Designed/Created/Built] a [System/Trap] You Can Never [Escape/Beat/See]",
+          "variables": {
+            "Subject": {"type": "string", "value": "They", "note": "Always anonymous, implies shadowy elite"},
+            "Verb": {"type": "string", "examples": ["Designed", "Created", "Built", "Engineered"]},
+            "Object": {"type": "string", "examples": ["System", "Trap", "Machine", "Prison", "Cage"]},
+            "Consequence": {"type": "string", "examples": ["Can Never Escape", "Were Never Meant to See", "Will Never Break"]}
+          },
+          "implied_elements": ["Shadowy anonymous elite", "Viewer is trapped/ignorant"],
+          "examples": [
+            "They Designed a System You Can Never Escape",
+            "They Built a Financial Prison You Were Never Meant to See"
+          ]
+        },
+        {
+          "id": "ER-4",
+          "name": "Power Figure Biography",
+          "top_view_count": 1300000,
+          "template": "[Power Figure]: The [Person] Who [Created/Destroyed/Controls] The [System]",
+          "variables": {
+            "Power Figure": {"type": "string", "examples": ["Rockefeller", "Rothschild", "JP Morgan", "Kissinger"]},
+            "Role": {"type": "string", "examples": ["Man", "Family", "Group", "Architect"]},
+            "Verb": {"type": "string", "examples": ["Created", "Built", "Destroyed", "Controls", "Designed"]},
+            "System": {"type": "string", "examples": ["The System", "The Modern Economy", "The Global Order"]}
+          },
+          "implied_elements": ["Named power figure", "System-level control"],
+          "examples": [
+            "John D. Rockefeller: The Man Who Created The System You Can't Escape"
+          ]
+        },
+        {
+          "id": "ER-5",
+          "name": "Death Announcement + Personal Threat",
+          "top_view_count": 135000,
+          "template": "The [System] Just [Died/Collapsed]. Your [Personal Thing] Is Next.",
+          "variables": {
+            "System": {"type": "string", "examples": ["Petrodollar", "Dollar Hegemony", "Bond Market", "Banking System"]},
+            "Death Verb": {"type": "string", "examples": ["Just Died", "Just Collapsed", "Just Broke", "Is Officially Dead"]},
+            "Personal Thing": {"type": "string", "examples": ["Dollar", "Savings", "Retirement", "Mortgage", "401k"]}
+          },
+          "implied_elements": ["Urgency", "Personal financial threat"],
+          "examples": [
+            "The Petrodollar Just Died. Your Dollar Is Next.",
+            "The Bond Market Just Broke. Your Retirement Is Next."
+          ]
+        },
+        {
+          "id": "ER-6",
+          "name": "Paradox Question with Dollar Amount",
+          "top_view_count": 114000,
+          "template": "$[Huge Number] in [Crisis Topic]: [Paradox Question]?",
+          "variables": {
+            "Amount": {"type": "string", "note": "Must be shockingly large", "examples": ["$34T", "$317T"]},
+            "Crisis": {"type": "string", "examples": ["Global Debt", "Derivatives", "Unfunded Liabilities"]},
+            "Question": {"type": "string", "note": "Paradoxical", "examples": ["Who lends if everyone owes?", "Where did it go?"]}
+          },
+          "implied_elements": ["Shocking dollar amount", "Unanswerable paradox"],
+          "examples": [
+            "$317 Trillion in Global Debt: Who Is the Lender If Everyone Owes?"
+          ]
+        }
+      ]
+    },
+    "mindplicit": {
+      "channel_url": "TBD",
+      "focus": "Machiavellian self-improvement, dark psychology, power tactics",
+      "formulas": [
+        {
+          "id": "MP-1",
+          "name": "Become So X It Threatens Them",
+          "top_view_count": 433000,
+          "template": "Become So [Virtue/Quality] It [Scares/Terrifies/Intimidates] [Them/People/Everyone]",
+          "alternate_template": "How to Become So [Quality] It [Terrifies] People - Machiavelli",
+          "variables": {
+            "Quality": {"type": "string", "examples": ["Disciplined", "Confident", "Powerful", "Silent", "Wealthy", "Strategic"]},
+            "Threat Verb": {"type": "string", "examples": ["Scares", "Terrifies", "Intimidates", "Threatens", "Unsettles"]},
+            "Attribution": {"type": "string", "note": "Always present", "examples": ["Machiavelli", "Machiavelli's Dark Method"]}
+          },
+          "implied_elements": ["Machiavelli attribution always present", "Self-improvement through dark power"],
+          "examples": [
+            "Become So Disciplined It Scares Them - Machiavelli's Dark Method"
+          ]
+        },
+        {
+          "id": "MP-2",
+          "name": "NEVER Do These Things",
+          "top_view_count": 245000,
+          "template": "[Number] Things You Should NEVER [Do/Say/Show] in [Context] (Machiavelli...)",
+          "variables": {
+            "Number": {"type": "integer", "range": [5, 12]},
+            "Action": {"type": "string", "examples": ["Do", "Say", "Show", "Reveal", "Admit", "Share"]},
+            "Context": {"type": "string", "examples": ["Public", "Business", "To Your Enemies", "Around Powerful People"]}
+          },
+          "implied_elements": ["Numbered list format", "Machiavelli attribution in parenthetical"],
+          "examples": [
+            "9 Things You Should NEVER Do in Public (Machiavelli Warned About This)"
+          ]
+        },
+        {
+          "id": "MP-3",
+          "name": "Never Trust/Save These Types",
+          "top_view_count": 232000,
+          "template": "Never [Save/Trust/Help] These [Number] Types of [People] - Machiavelli's Ruthless...",
+          "variables": {
+            "Action": {"type": "string", "examples": ["Save", "Trust", "Help", "Defend", "Forgive"]},
+            "Number": {"type": "integer", "range": [4, 8]},
+            "Category": {"type": "string", "examples": ["Types of People", "Friends", "Partners", "Colleagues"]}
+          },
+          "implied_elements": ["Ruthless categorization", "Social trust framework"],
+          "examples": [
+            "Never Save These 6 Types of People - Machiavelli's Ruthless Rule"
+          ]
+        },
+        {
+          "id": "MP-4",
+          "name": "What N% Get Wrong",
+          "top_view_count": 137000,
+          "template": "What [High %] of [People] Get Wrong About [Topic] (Machiavelli...)",
+          "variables": {
+            "Percentage": {"type": "string", "examples": ["95%", "99%", "Most People"]},
+            "People": {"type": "string", "examples": ["Men", "Women", "Leaders", "Entrepreneurs", "Investors"]},
+            "Topic": {"type": "string", "examples": ["Money", "Power", "Women", "Success", "Intelligence", "Loyalty"]}
+          },
+          "implied_elements": ["Viewer is likely in the failing majority", "Contrarian truth reveal"],
+          "examples": [
+            "What 99% of Men Get Wrong About Women (Machiavellian Truth)"
+          ]
+        },
+        {
+          "id": "MP-5",
+          "name": "Dark Laws/Rules Numbered List",
+          "top_view_count": 134000,
+          "template": "[Number] Machiavellian Laws of [Dark Quality] - The Psychology of...",
+          "variables": {
+            "Number": {"type": "integer", "range": [5, 12]},
+            "Dark Quality": {"type": "string", "examples": ["Dark Intelligence", "Power", "Manipulation", "Ruthless Strategy"]},
+            "Psychology": {"type": "string", "examples": ["Power", "Control", "Influence", "Domination", "Fear"]}
+          },
+          "implied_elements": ["Numbered laws format", "Dark psychology framework"],
+          "examples": [
+            "9 Machiavellian Laws of Dark Intelligence - The Psychology of Power"
+          ]
+        }
+      ]
+    },
+    "chill_financial_history": {
+      "channel_url": "TBD",
+      "focus": "Country-as-character economic storytelling with parenthetical reveals",
+      "formulas": [
+        {
+          "id": "CFH-1",
+          "name": "Country's Costly Mistake",
+          "top_view_count": 482000,
+          "template": "[Country]'s $[Huge Amount] [Mistake/Gamble/Bet] (The [Named Trap/Problem])",
+          "variables": {
+            "Country": {"type": "string", "examples": ["Germany", "America", "China", "Japan", "UK"]},
+            "Amount": {"type": "string", "note": "Staggeringly large", "examples": ["$500B", "$2T"]},
+            "Mistake Type": {"type": "string", "examples": ["Mistake", "Gamble", "Bet", "Experiment", "Blunder"]},
+            "Named Trap": {"type": "string", "note": "Parenthetical naming the systemic problem"}
+          },
+          "implied_elements": ["Country as character", "Parenthetical reveal as second hook"],
+          "examples": [
+            "Germany's $500 Billion Mistake (The Green Energy Trap)"
+          ]
+        },
+        {
+          "id": "CFH-2",
+          "name": "Why Country Is Dying/Collapsing",
+          "top_view_count": 373000,
+          "template": "Why [Country]'s Economy is [Collapsing/Dying] (The [Number] [Factors])",
+          "alternate_template": "Why [Country] Can't [Grow/Recover] (The Curse of [Historical Root])",
+          "variables": {
+            "Country": {"type": "string", "examples": ["Europe", "Italy", "Japan", "UK"]},
+            "Death Verb": {"type": "string", "examples": ["Collapsing", "Dying", "Shrinking", "Crumbling"]},
+            "Parenthetical": {"type": "string", "note": "Either numbered factors OR Curse of root cause"}
+          },
+          "implied_elements": ["Economic death narrative", "Root cause in parenthetical"],
+          "examples": [
+            "Why Europe's Economy is Collapsing (The 6 Fractures)",
+            "Why Italy Can't Grow (The Curse of The Lira)"
+          ]
+        },
+        {
+          "id": "CFH-3",
+          "name": "Country Is ADJECTIVEer Than You Think",
+          "top_view_count": 369000,
+          "template": "Why [Country] is [ADJECTIVE]er Than You Think (The [Hidden Reason])",
+          "variables": {
+            "Country": {"type": "string", "examples": ["France", "Russia", "India", "Brazil"]},
+            "Adjective": {"type": "string", "note": "Always CAPS", "examples": ["POORER", "WEAKER", "RICHER", "MORE POWERFUL"]},
+            "Hidden Reason": {"type": "string", "note": "Parenthetical reveals the system/cause"}
+          },
+          "structural_techniques": ["Single CAPS word for visual emphasis", "CAPS word on thumbnail matches CAPS word in title"],
+          "examples": [
+            "Why France is POORER Than You Think (The Economic Illusion)"
+          ]
+        },
+        {
+          "id": "CFH-4",
+          "name": "Slow Death of System",
+          "top_view_count": 410000,
+          "template": "The Slow [DEATH/COLLAPSE] of [Major System] (And What Comes Next)",
+          "variables": {
+            "Death Word": {"type": "string", "note": "Always CAPS", "examples": ["DEATH", "COLLAPSE", "END", "DECLINE"]},
+            "System": {"type": "string", "examples": ["Petrodollar", "Dollar Hegemony", "European Union", "Globalization"]},
+            "Parenthetical": {"type": "string", "value": "And What Comes Next", "note": "Always forward-looking promise"}
+          },
+          "structural_techniques": ["Parenthetical always 'And What Comes Next'", "Forward-looking promise"],
+          "examples": [
+            "The Slow DEATH of The Petrodollar (And What Comes Next)"
+          ]
+        },
+        {
+          "id": "CFH-5",
+          "name": "How Sector Swallowed Country",
+          "top_view_count": 189000,
+          "template": "How [Sector/Force] [SWALLOWED/BROKE] [Country]'s Economy",
+          "variables": {
+            "Sector": {"type": "string", "examples": ["Housing", "Debt", "Oil", "Military Spending", "Tourism"]},
+            "Action Verb": {"type": "string", "note": "Always CAPS", "examples": ["SWALLOWED", "BROKE", "CONSUMED", "DESTROYED"]},
+            "Country": {"type": "string", "examples": ["Canada", "Greece", "Spain", "Australia"]}
+          },
+          "structural_techniques": ["CAPS action verb for visual punch", "Sector as aggressor, country as victim"],
+          "examples": [
+            "How Housing SWALLOWED Canada's Economy"
+          ]
+        }
+      ]
+    }
+  },
+  "economy_fastforward": {
+    "channel_focus": "Geopolitical systems + Machiavellian framing hybrid",
+    "positioning": "Bridges Economy Rewind (geopolitical systems) with Mindplicit (Machiavellian framing)",
+    "structural_techniques_from_cfh": [
+      "Parenthetical reveals as second hook (present in ~90% of titles)",
+      "Single CAPS word per title for visual emphasis",
+      "CAPS word on thumbnail matches CAPS word in title"
+    ],
+    "hybrid_formulas": [
+      {
+        "id": "EFF-1",
+        "name": "N-Stage Power Play Pattern",
+        "derived_from": ["ER-1", "Machiavellian framing"],
+        "predicted_performance": "highest",
+        "template": "The [Number]-Stage [Power Event] [Pattern/Trap]: [Historical Examples]... [Threat]",
+        "variables": {
+          "Number": {"type": "integer", "range": [4, 7]},
+          "Power Event": {"type": "string", "examples": ["Sanction Trap", "Currency Kill", "Economic Conquest", "Debt Weapon"]},
+          "Pattern/Trap": {"type": "string", "options": ["Pattern", "Trap", "Playbook", "Strategy"]},
+          "Historical": {"type": "list", "count": [2, 3], "note": "nations, empires, crises"},
+          "Threat": {"type": "string", "examples": ["America Is at Stage [N]", "2026 = Next?"]}
+        },
+        "examples": [
+          "The 5-Stage Sanction Trap: How America Controls the World Economy",
+          "The 4-Stage Currency Kill Pattern: Rome, Britain, USSR... America?"
+        ]
+      },
+      {
+        "id": "EFF-2",
+        "name": "Entity's Dark Strategy",
+        "derived_from": ["ER-4", "MP dark adjective framing"],
+        "predicted_performance": "strong",
+        "template": "[Power Entity]'s [Dark Adjective] [Strategy/Trap] That [Massive Consequence]",
+        "variables": {
+          "Entity": {"type": "string", "examples": ["Putin", "China", "BlackRock", "The Fed", "Saudi Arabia", "BRICS"]},
+          "Dark Adjective": {"type": "string", "examples": ["Ruthless", "Silent", "Brilliant", "Machiavellian", "Calculated"]},
+          "Strategy": {"type": "string", "examples": ["Strategy", "Trap", "Gambit", "Move", "Play", "Maneuver"]},
+          "Consequence": {"type": "string", "examples": ["That Will Bankrupt America", "That Europe Can't Escape", "That Nobody Saw Coming", "That Changes Everything"]}
+        },
+        "examples": [
+          "Putin's Ruthless Energy Trap That Europe Can't Escape",
+          "China's Silent Strategy That Will Bankrupt America by 2030"
+        ]
+      },
+      {
+        "id": "EFF-3",
+        "name": "Machiavellian Laws of Geopolitics",
+        "derived_from": ["MP-5", "geopolitical application"],
+        "predicted_performance": "unique_hybrid",
+        "template": "[Number] Machiavellian [Laws/Rules] of [Geopolitical Topic] [Used Today]",
+        "variables": {
+          "Number": {"type": "integer", "range": [5, 9]},
+          "Laws/Rules": {"type": "string", "options": ["Laws", "Rules", "Principles", "Strategies"]},
+          "Topic": {"type": "string", "examples": ["Economic Warfare", "Currency Manipulation", "Empire Building", "Debt Control"]},
+          "Relevance": {"type": "string", "examples": ["Nations Use Today", "That Control Your Money", "Behind Every Crisis"]}
+        },
+        "examples": [
+          "7 Machiavellian Laws of Economic Warfare Nations Use Today",
+          "5 Dark Rules of Currency Manipulation - Why Your Money Is Shrinking"
+        ]
+      },
+      {
+        "id": "EFF-4",
+        "name": "Trusted Entity Betrayal (Machiavellian Frame)",
+        "derived_from": ["ER-2", "Machiavellian attribution"],
+        "predicted_performance": "strong",
+        "template": "How [Trusted Entity] [Secretly] [Betrayed/Controls] [Victim] - The [Dark] [Strategy]",
+        "variables": {
+          "Trusted Entity": {"type": "string", "examples": ["America", "The Fed", "NATO", "IMF", "World Bank"]},
+          "Action": {"type": "string", "examples": ["Quietly Bought", "Secretly Funds", "Engineered", "Designed"]},
+          "Victim": {"type": "string", "examples": ["Every Government", "Your Economy", "The Third World", "Europe"]},
+          "Frame": {"type": "string", "examples": ["The Machiavellian Playbook", "The Dark Strategy", "The Hidden System"]}
+        },
+        "examples": [
+          "How BlackRock Quietly Bought Every Government on Earth",
+          "How the Fed Secretly Funds Both Sides of Every War"
+        ]
+      },
+      {
+        "id": "EFF-5",
+        "name": "System Death + Personal Threat",
+        "derived_from": ["ER-5", "personal urgency"],
+        "predicted_performance": "strong",
+        "template": "The [System] Just [Died]. [Your Personal Stakes] [Are/Is] Next.",
+        "variables": {
+          "System": {"type": "string", "examples": ["Petrodollar", "Dollar Hegemony", "US Bond Market", "Banking System"]},
+          "Death": {"type": "string", "examples": ["Just Died", "Just Collapsed", "Just Broke", "Is Officially Over"]},
+          "Personal": {"type": "string", "examples": ["Your Savings", "Your Dollar", "Your Retirement", "Your Mortgage"]}
+        },
+        "examples": [
+          "The $34 Trillion Debt Bomb Just Detonated. Nobody's Talking About It.",
+          "The Petrodollar Alliance Just Collapsed. Your Savings Are Next."
+        ]
+      },
+      {
+        "id": "EFF-6",
+        "name": "Counterintuitive System Reveal",
+        "derived_from": ["ER-3", "why curiosity hook"],
+        "predicted_performance": "moderate",
+        "template": "Why [Counterintuitive Claim] - The [Hidden System] Explained",
+        "variables": {
+          "Claim": {"type": "string", "note": "Something that sounds wrong but is true"},
+          "System": {"type": "string", "examples": ["Hidden Tax", "Transfer Pattern", "Invisible Machine", "Silent Weapon"]}
+        },
+        "examples": [
+          "Why Inflation Is Designed to Make You Poorer - The Hidden Tax Explained",
+          "Why Every Financial Crisis Makes the Rich Richer - The Transfer Pattern"
+        ]
+      },
+      {
+        "id": "EFF-7",
+        "name": "Country's Machiavellian Trap",
+        "derived_from": ["CFH-1", "Machiavellian attribution"],
+        "predicted_performance": "strong",
+        "template": "[Country]'s $[Amount] [Trap/Weapon] (The [Machiavellian Strategy] Behind It)",
+        "variables": {
+          "Country": {"type": "string", "examples": ["America", "China", "Russia", "Saudi Arabia"]},
+          "Amount": {"type": "string", "note": "Staggeringly large", "examples": ["$3T", "$34T"]},
+          "Trap/Weapon": {"type": "string", "examples": ["Trap", "Weapon", "Gambit", "Power Play"]},
+          "Strategy": {"type": "string", "examples": ["Machiavellian Strategy", "Silent Economic War", "Dark Playbook"]}
+        },
+        "examples": [
+          "America's $34 Trillion Debt Weapon (The Machiavellian Strategy Behind It)",
+          "China's $3 Trillion Dollar Trap (The Silent Economic War)"
+        ]
+      },
+      {
+        "id": "EFF-8",
+        "name": "Country Is Xer Than You Think (+ power reveal)",
+        "derived_from": ["CFH-3", "Machiavellian power system"],
+        "predicted_performance": "strong",
+        "template": "Why [Country] is [ADJECTIVE]er Than You Think (The [Power System] Explained)",
+        "variables": {
+          "Country": {"type": "string", "note": "Especially contrarian picks"},
+          "Adjective": {"type": "string", "note": "Always CAPS", "examples": ["STRONGER", "WEAKER", "RICHER", "MORE DANGEROUS"]},
+          "Power System": {"type": "string", "examples": ["Energy Strategy", "Debt Pattern", "Currency Weapon", "Military Calculus"]}
+        },
+        "examples": [
+          "Why Russia is STRONGER Than You Think (The Machiavellian Energy Strategy)",
+          "Why America is WEAKER Than You Think (The Hidden Debt Pattern)"
+        ]
+      },
+      {
+        "id": "EFF-9",
+        "name": "Slow Death + Who Controls the Replacement",
+        "derived_from": ["CFH-4", "Machiavellian who benefits framing"],
+        "predicted_performance": "strong",
+        "template": "The Slow [DEATH] of [System] (And Who [Controls/Benefits From] What Comes Next)",
+        "variables": {
+          "Death Word": {"type": "string", "note": "Always CAPS", "examples": ["DEATH", "COLLAPSE", "END"]},
+          "System": {"type": "string", "examples": ["Dollar", "Petrodollar", "NATO", "Globalization", "American Hegemony"]},
+          "Who Benefits": {"type": "string", "note": "Names the power player positioning to replace the dying system"}
+        },
+        "examples": [
+          "The Slow DEATH of the Dollar (And Who Controls What Replaces It)",
+          "The Slow COLLAPSE of NATO (And Russia's Machiavellian Play to Replace It)"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Story 0: title_patterns.json — 25 formulas (6 ER, 5 MP, 5 CFH, 9 EFF hybrids)
  with templates, variables, view counts, and examples from competitor analysis.

Story 1: discovery_scanner.py — standalone module that scans headlines across
  geopolitics/finance/tech/economic policy, filters through Machiavellian lens,
  and generates 2-3 video ideas with title variants from the pattern library.

Story 2: pipeline_control.py — added discover/scan/research Slack commands,
  emoji reaction handling (1️⃣2️⃣3️⃣) for idea approval, threaded async execution
  for LLM-calling commands, auto-trigger research on reaction approval.

Story 3: approval_watcher.py — polls Airtable for ideas with 'Approved' status,
  auto-triggers deep research, writes payload back, advances to Ready For Scripting.
  Supports standalone and daemon modes with idempotency checks.

Story 4: discovery_prompt.md — system prompt encoding channel identity,
  6-dimension scoring criteria, Machiavellian lens frameworks, title generation
  rules, and structured JSON output format.

Story 5: pipeline_flow.md — updated with discovery scanner stage, new status
  transitions (Approved → Ready For Scripting), module locations, Slack commands,
  and discovery flow diagram.

https://claude.ai/code/session_01EFufqkGCbX525MhwPsfWAs