### PR TITLE
Refactor Airtable error handling and fix Source field type

### DIFF
--- a/fix_airtable_fields.py
+++ b/fix_airtable_fields.py
@@ -48,7 +48,7 @@ CODE_FIELDS: dict[str, dict] = {
     "Thumbnail Prompt":   {"type": "multilineText"},
     "Writer Guidance":    {"type": "multilineText"},
     "Original DNA":       {"type": "multilineText"},
-    "Source":             {"type": "singleSelect"},
+    "Source":             {"type": "singleLineText"},
     # --- optional fields (create_idea) ---
     "Reference URL":      {"type": "url"},
     "Idea Reasoning":     {"type": "multilineText"},
@@ -71,7 +71,7 @@ CODE_FIELDS: dict[str, dict] = {
 
 # User-specified type overrides (from the issue)
 USER_TYPE_OVERRIDES = {
-    "Source":             {"type": "singleSelect"},
+    "Source":             {"type": "singleLineText"},
     "Research Payload":   {"type": "multilineText"},
     "Thematic Framework": {"type": "singleLineText"},
     "Hook Script":        {"type": "multilineText"},      # "Hook = long text"


### PR DESCRIPTION
## Summary
This PR improves the robustness of Airtable field validation and error recovery by extracting field name parsing logic into a reusable method, and corrects the field type definition for the "Source" field.

## Key Changes

- **Extract field name parsing logic**: Created `_extract_bad_field()` static method to centralize the logic for extracting unknown field names from Airtable error messages. This method handles multiple error message formats ("UNKNOWN_FIELD_NAME" and "Unknown field name") and uses regex fallback patterns.

- **Improve error handling in `create_idea()`**: Refactored the exception handling to use the new `_extract_bad_field()` method, reducing code duplication and improving maintainability. Enhanced the retry logic to:
  - Track dropped fields explicitly
  - Handle cases where the bad field cannot be identified
  - Provide a more robust final fallback with guaranteed minimal fields (Status + Video Title)
  - Support both error message formats

- **Fix Source field type**: Changed the "Source" field type from `singleSelect` to `singleLineText` in both `FIELD_DEFINITIONS` and `USER_TYPE_OVERRIDES` in `fix_airtable_fields.py`. This aligns the field definition with how the field is actually being used in the codebase.

## Implementation Details

- The `_extract_bad_field()` method uses regex to extract quoted field names from error messages, with a fallback pattern that searches for field names after the word "field"
- The retry loop now has an absolute upper bound (`max_retries = len(all_fields)`) to prevent infinite loops
- The final fallback creates a minimal record with only the two guaranteed Airtable fields rather than attempting to save core fields that may also be invalid

https://claude.ai/code/session_01ETTxKUPE5KwApXNG9pdV5f