### PR TITLE
Fix wrong dict key in image retry phase causing all retries to silently fail

### DIFF
--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -1277,8 +1277,8 @@ class VideoPipeline:
                             print(f"        ❌ No Core Image — skipping retry")
                             continue
                         result = await self.image_client.generate_scene_image(prompt, self.core_image_url)
-                        if result and result.get("image_url"):
-                            image_url = result["image_url"]
+                        if result and result.get("url"):
+                            image_url = result["url"]
                             
                             # Download and upload to Drive
                             image_content = await self.image_client.download_image(image_url)


### PR DESCRIPTION
The retry loop in _run_image_bot() checked for result.get("image_url")
but generate_scene_image() returns {"url": ..., "seed": ...}. This meant
every retry appeared to succeed at the API level but the result was
discarded, leaving all failed images permanently stuck as "Pending".

https://claude.ai/code/session_012KPsDaWvFeWDfwP6N15n6g