### PR TITLE
Add YouTube cinematic dossier style support to video pipeline

### DIFF
--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -950,7 +950,8 @@ class VideoPipeline:
 
             print(f"  Scene {scene_number}: {voice_duration:.0f}s → {target_images} images (~{words_per_segment} words each)")
 
-            # Call Anthropic to segment into concepts (uses Documentary Animation Prompt System v2)
+            # Call Anthropic to segment into concepts
+            # YouTube pipeline uses cinematic dossier style (NOT mannequin)
             concepts = await self.anthropic.segment_scene_into_concepts(
                 scene_text=scene_text,
                 target_count=target_images,
@@ -958,6 +959,7 @@ class VideoPipeline:
                 max_count=max_images,
                 words_per_segment=words_per_segment,
                 scene_number=scene_number,
+                pipeline_type="youtube",
             )
 
             # Create records with calculated durations (capped at 6-10s range)


### PR DESCRIPTION
## Summary
This PR adds support for a new "YouTube cinematic dossier" visual style to the video pipeline, enabling photorealistic documentary-style image generation alongside the existing 3D mannequin render style. The pipeline now intelligently selects between two distinct visual approaches based on the `pipeline_type` parameter.

## Key Changes

- **New style constants import**: Added imports from `image_prompt_engine.style_config` for YouTube-specific style configuration (prefix, suffixes, composition directives)

- **Pipeline-aware style selection**: Modified `segment_scene_into_concepts()` to accept a `pipeline_type` parameter ("youtube" or "animation") that controls which visual style system is used

- **Dual system prompts**: Implemented separate system prompts for each pipeline:
  - **YouTube style**: Cinematic photorealistic dossier with desaturated colors, Rembrandt lighting, documentary photography, Arri Alexa aesthetic
  - **Animation style**: Existing 3D editorial mannequin render approach with faceless gray figures and studio lighting

- **Dynamic style prefix/suffix**: Style constants are now selected at runtime based on pipeline type, with accent color customization (cold teal for YouTube)

- **Updated documentation**: Clarified docstring to explain the two supported visual styles and their characteristics

- **Pipeline integration**: Updated `run_image_prompt_bot_legacy()` in pipeline.py to explicitly pass `pipeline_type="youtube"` when calling the segmentation function

## Implementation Details

The YouTube cinematic style emphasizes:
- Real-world photorealistic environments (trading floors, vaults, corridors) instead of 3D renders
- Dramatic lighting contrasts and atmospheric details (dust, haze, film grain)
- Real people and objects as visual metaphors rather than mannequins
- 120-150 word prompts with style prefix positioned first for optimal model weighting

The system maintains backward compatibility with the animation pipeline while enabling future expansion to additional visual styles through the `pipeline_type` parameter.

https://claude.ai/code/session_01UkXsTLa5uU17q9F49hHkML