### PR TITLE
Add resume logic to skip completed images and prompts

### DIFF
--- a/skills/video-pipeline/pipeline_control.py
+++ b/skills/video-pipeline/pipeline_control.py
@@ -268,7 +268,7 @@ async def handle_prompts(message, say):
     await say(":art: Starting prompts and images generation...")
 
     try:
-        returncode, stdout, stderr = await run_script_async("run_youtube_prompts.py", "prompts", say, timeout=600)
+        returncode, stdout, stderr = await run_script_async("run_youtube_prompts.py", "prompts", say, timeout=1800)
 
         if returncode == 0:
             output = stdout[-3000:] if len(stdout) > 3000 else stdout
@@ -278,7 +278,7 @@ async def handle_prompts(message, say):
             await say(f":x: Prompts error:\n```{error}```")
 
     except subprocess.TimeoutExpired:
-        await say(":warning: Prompts generation timed out after 10 minutes")
+        await say(":warning: Prompts generation timed out after 30 minutes")
     except asyncio.CancelledError:
         await say(":stop_sign: Prompts generation was stopped")
     except Exception as e:
@@ -297,7 +297,7 @@ async def handle_end_images(message, say):
     await say(":frame_with_picture: Starting end images generation...")
 
     try:
-        returncode, stdout, stderr = await run_script_async("run_end_images.py", "end images", say, timeout=900)
+        returncode, stdout, stderr = await run_script_async("run_end_images.py", "end images", say, timeout=1800)
 
         if returncode == 0:
             output = stdout[-3000:] if len(stdout) > 3000 else stdout
@@ -307,7 +307,7 @@ async def handle_end_images(message, say):
             await say(f":x: End images error:\n```{error}```")
 
     except subprocess.TimeoutExpired:
-        await say(":warning: End images generation timed out after 15 minutes")
+        await say(":warning: End images generation timed out after 30 minutes")
     except asyncio.CancelledError:
         await say(":stop_sign: End images generation was stopped")
     except Exception as e:
@@ -326,7 +326,7 @@ async def handle_images(message, say):
     await say(":frame_with_picture: Starting image bot... This will take several minutes.")
 
     try:
-        returncode, stdout, stderr = await run_script_async("run_image_bot.py", "images", say, timeout=900)
+        returncode, stdout, stderr = await run_script_async("run_image_bot.py", "images", say, timeout=1800)
 
         if returncode == 0:
             output = stdout[-3000:] if len(stdout) > 3000 else stdout
@@ -336,7 +336,7 @@ async def handle_images(message, say):
             await say(f":x: Image bot error:\n```{error}```")
 
     except subprocess.TimeoutExpired:
-        await say(":warning: Image bot timed out after 15 minutes")
+        await say(":warning: Image bot timed out after 30 minutes")
     except asyncio.CancelledError:
         await say(":stop_sign: Image bot was stopped")
     except Exception as e:


### PR DESCRIPTION
## Summary
Implements resumable workflows for image prompt generation and image bot processing. Both pipelines now detect and skip already-completed work, allowing interrupted jobs to resume without regenerating existing content.

## Key Changes

**Pipeline Resume Logic (`pipeline.py`)**
- Modified `_run_image_bot()` to fetch all images and filter for "Pending" status, skipping "Done" images
  - Added resume messaging to Slack when completed images are detected
  - Displays count of already-done vs. remaining images
  
- Refactored `run_styled_image_prompts()` to implement comprehensive resume logic:
  - Pre-filters expanded scenes against existing Image Prompts before generation
  - Only generates prompts for scenes missing Image Prompt data
  - Maps generated prompts back to correct scene indices
  - Returns skipped count in response for tracking
  - Updated Slack notification to show new vs. existing prompt counts

**Script Updates (`run_youtube_prompts.py`)**
- Enhanced error handling to gracefully resume image generation if prompts are already complete
- Improved console output to distinguish between new and resumed work
- Updated final summary to show both created and skipped counts

**Timeout Adjustments (`pipeline_control.py`)**
- Increased all generation timeouts from 10-15 minutes to 30 minutes to accommodate longer runs and resume operations
- Updated timeout warning messages to reflect new limits

## Implementation Details
- Resume detection uses `(Scene, Image Index)` tuples as unique keys to identify completed work
- Existing prompts are only counted if they have populated Image Prompt fields
- Scene index mapping preserves correct data association when filtering scenes
- All resume operations are transparent to the user with clear console and Slack messaging

https://claude.ai/code/session_01Wy4eWmcDQZYpMzumUxr7zM