### PR TITLE
Add thumbnail & title generation system with template-based prompts

### DIFF
--- a/skills/video-pipeline/run_thumbnail_bot.py
+++ b/skills/video-pipeline/run_thumbnail_bot.py
@@ -4,8 +4,12 @@ Run the Thumbnail Bot on an idea marked "Ready For Thumbnail" in Airtable.
 Called by: pipeline_control.py (Slack bot)
 Commands: thumbnail
 
-Generates a thumbnail image using house style + optional reference analysis,
-uploads to Google Drive, and advances status to "Done".
+Generates a matched thumbnail + title pair using the ThumbnailTitleEngine:
+- Selects template (CFH Split / Mindplicit Banner / Power Dynamic)
+- Generates title from proven formula patterns
+- Builds thumbnail prompt with CAPS word as red highlight
+- Generates image via Nano Banana Pro (up to 3 attempts)
+- Uploads to Google Drive and advances status to "Ready To Render"
 """
 
 import os
@@ -22,7 +26,7 @@ from pipeline import VideoPipeline
 
 async def main():
     print("=" * 60)
-    print("🎨 RUNNING THUMBNAIL BOT")
+    print("RUNNING THUMBNAIL + TITLE BOT")
     print("=" * 60)
 
     pipeline = VideoPipeline()
@@ -31,19 +35,24 @@ async def main():
         result = await pipeline.run_thumbnail_bot()
 
         if result.get("error"):
-            print(f"\n❌ {result['error']}")
+            print(f"\n{result['error']}")
             sys.exit(1)
 
         print("\n" + "=" * 60)
-        print("✅ THUMBNAIL BOT COMPLETE!")
+        print("THUMBNAIL + TITLE BOT COMPLETE!")
         print("=" * 60)
-        print(f"\n🎬 Video: {result.get('video_title')}")
-        print(f"🖼️  Thumbnail: {result.get('thumbnail_url')}")
-        print(f"📋 New status: {result.get('new_status')}")
-        print(f"📸 Used reference: {result.get('used_reference')}")
+        print(f"\n  Video: {result.get('video_title')}")
+        print(f"  Title: {result.get('generated_title')}")
+        print(f"  CAPS word: {result.get('caps_word')}")
+        print(f"  Formula: {result.get('formula_used')}")
+        print(f"  Template: {result.get('template_name')} ({result.get('template_used')})")
+        print(f"  Thumbnail text: {result.get('line_1')} / {result.get('line_2')}")
+        print(f"  Thumbnail: {result.get('thumbnail_url')}")
+        print(f"  Attempt: {result.get('thumbnail_attempt')}")
+        print(f"  New status: {result.get('new_status')}")
 
     except Exception as e:
-        print(f"\n❌ Error: {e}")
+        print(f"\nError: {e}")
         import traceback
         traceback.print_exc()
         sys.exit(1)

--- a/skills/video-pipeline/thumbnail_title/__init__.py
+++ b/skills/video-pipeline/thumbnail_title/__init__.py
@@ -1,0 +1,30 @@
+"""Thumbnail & Title generation system for Economy FastForward.
+
+Generates matched thumbnail/title pairs using three prompt templates
+(CFH Split, Mindplicit Banner, Power Dynamic) and six title formulas.
+Integrates into the Airtable pipeline at Stage 6: Ready For Thumbnail.
+"""
+
+from thumbnail_title.templates import (
+    TEMPLATE_A_CFH_SPLIT,
+    TEMPLATE_B_MINDPLICIT_BANNER,
+    TEMPLATE_C_POWER_DYNAMIC,
+    TEMPLATES,
+)
+from thumbnail_title.selector import select_template
+from thumbnail_title.title_generator import TitleGenerator
+from thumbnail_title.prompt_builder import ThumbnailPromptBuilder
+from thumbnail_title.validator import validate_thumbnail
+from thumbnail_title.engine import ThumbnailTitleEngine
+
+__all__ = [
+    "TEMPLATE_A_CFH_SPLIT",
+    "TEMPLATE_B_MINDPLICIT_BANNER",
+    "TEMPLATE_C_POWER_DYNAMIC",
+    "TEMPLATES",
+    "select_template",
+    "TitleGenerator",
+    "ThumbnailPromptBuilder",
+    "validate_thumbnail",
+    "ThumbnailTitleEngine",
+]

--- a/skills/video-pipeline/thumbnail_title/engine.py
+++ b/skills/video-pipeline/thumbnail_title/engine.py
@@ -1,0 +1,169 @@
+"""ThumbnailTitleEngine — orchestrates matched title + thumbnail generation.
+
+This is the main entry point for the thumbnail/title system. It:
+1. Selects the appropriate template based on video metadata
+2. Generates a title using proven formula patterns
+3. Builds a thumbnail prompt with the title's CAPS word as the red highlight
+4. Generates the thumbnail image via Nano Banana Pro
+5. Validates the result
+6. Returns a complete package ready for pipeline integration
+
+Usage from pipeline.py:
+    engine = ThumbnailTitleEngine(anthropic_client, image_client)
+    result = await engine.generate(video_metadata)
+"""
+
+import json
+from typing import Optional
+
+from thumbnail_title.selector import select_template
+from thumbnail_title.title_generator import TitleGenerator
+from thumbnail_title.prompt_builder import ThumbnailPromptBuilder
+from thumbnail_title.validator import validate_thumbnail, validate_title_thumbnail_pair
+
+
+# Maximum generation attempts before flagging for manual review
+MAX_GENERATION_ATTEMPTS = 3
+
+
+class ThumbnailTitleEngine:
+    """Orchestrates matched title + thumbnail generation.
+
+    Produces title/thumbnail pairs where the CAPS word in the title
+    matches the red_word in the thumbnail, creating a unified visual hook.
+    """
+
+    def __init__(self, anthropic_client, image_client):
+        """Initialize with existing pipeline clients.
+
+        Args:
+            anthropic_client: An initialized AnthropicClient.
+            image_client: An initialized ImageClient (Kie.ai).
+        """
+        self.title_gen = TitleGenerator(anthropic_client)
+        self.prompt_builder = ThumbnailPromptBuilder(anthropic_client)
+        self.image_client = image_client
+
+    async def generate(
+        self,
+        video_metadata: dict,
+        preferred_formula: Optional[str] = None,
+        preferred_template: Optional[str] = None,
+    ) -> dict:
+        """Generate a matched title + thumbnail pair.
+
+        Args:
+            video_metadata: Dict with at least:
+                - Video Title: str
+                - Summary: str
+                Optional:
+                - tags: list[str]
+                - topic: str
+                - Framework Angle: str
+            preferred_formula: Force a specific title formula (formula_1..formula_6).
+            preferred_template: Force a specific template (template_a..template_c).
+
+        Returns:
+            Dict with:
+                title: str — full YouTube title
+                caps_word: str — the ALL CAPS word (= red_word)
+                formula_used: str — title formula key
+                template_used: str — thumbnail template key
+                template_name: str — human-readable template name
+                thumbnail_prompt: str — complete Nano Banana Pro prompt
+                thumbnail_urls: list[str] | None — generated image URLs
+                thumbnail_attempt: int — generation attempt number (1-3)
+                line_1: str — thumbnail primary text
+                line_2: str — thumbnail secondary text
+                validation: dict — validation results
+                needs_manual_review: bool — True if max attempts reached
+        """
+        video_title = video_metadata.get("Video Title", "")
+        video_summary = video_metadata.get("Summary", "")
+        tags = video_metadata.get("tags", [])
+
+        # Step 1: Select template
+        template_key = preferred_template or select_template(video_metadata)
+        from thumbnail_title.templates import TEMPLATES
+        template_name = TEMPLATES[template_key]["name"]
+        print(f"  Template selected: {template_name} ({template_key})")
+
+        # Step 2: Generate title
+        print(f"  Generating title...")
+        title_data = await self.title_gen.generate(
+            video_title=video_title,
+            video_summary=video_summary,
+            tags=tags,
+            preferred_formula=preferred_formula,
+        )
+        print(f"  Title: {title_data['title']}")
+        print(f"  CAPS word: {title_data['caps_word']}")
+        print(f"  Thumbnail text: {title_data['line_1']} / {title_data['line_2']}")
+
+        # Step 3: Validate title-thumbnail pairing
+        pair_valid, pair_issues = validate_title_thumbnail_pair(title_data, template_key)
+        if not pair_valid:
+            for issue in pair_issues:
+                print(f"  WARNING: {issue}")
+
+        # Step 4: Build thumbnail prompt
+        print(f"  Building thumbnail prompt...")
+        thumbnail_prompt = await self.prompt_builder.build(
+            template_key=template_key,
+            title_data=title_data,
+            video_title=video_title,
+            video_summary=video_summary,
+        )
+        print(f"  Prompt built ({len(thumbnail_prompt)} chars)")
+
+        # Step 5: Generate thumbnail image (with retry)
+        thumbnail_urls = None
+        attempt = 0
+        needs_manual_review = False
+
+        for attempt in range(1, MAX_GENERATION_ATTEMPTS + 1):
+            print(f"  Generating thumbnail (attempt {attempt}/{MAX_GENERATION_ATTEMPTS})...")
+            thumbnail_urls = await self.image_client.generate_thumbnail(thumbnail_prompt)
+
+            if thumbnail_urls:
+                print(f"  Thumbnail generated: {thumbnail_urls[0][:60]}...")
+
+                # Step 6: Download and validate
+                try:
+                    image_data = await self.image_client.download_image(thumbnail_urls[0])
+                    img_valid, img_checks = validate_thumbnail(image_data)
+                    if img_valid:
+                        print(f"  Validation passed")
+                        break
+                    else:
+                        failed = [k for k, v in img_checks.items() if not v]
+                        print(f"  Validation failed: {failed}. Retrying...")
+                        thumbnail_urls = None
+                except Exception as e:
+                    print(f"  Validation error: {e}. Accepting image.")
+                    # Accept the image if we can't validate it
+                    break
+            else:
+                print(f"  Generation failed. {'Retrying...' if attempt < MAX_GENERATION_ATTEMPTS else 'Flagging for manual review.'}")
+
+        if not thumbnail_urls:
+            needs_manual_review = True
+            print(f"  FLAGGED FOR MANUAL REVIEW after {MAX_GENERATION_ATTEMPTS} attempts")
+
+        return {
+            "title": title_data["title"],
+            "caps_word": title_data["caps_word"],
+            "formula_used": title_data["formula_used"],
+            "template_used": template_key,
+            "template_name": template_name,
+            "thumbnail_prompt": thumbnail_prompt,
+            "thumbnail_urls": thumbnail_urls,
+            "thumbnail_attempt": attempt,
+            "line_1": title_data["line_1"],
+            "line_2": title_data["line_2"],
+            "validation": {
+                "pair_valid": pair_valid,
+                "pair_issues": pair_issues,
+            },
+            "needs_manual_review": needs_manual_review,
+        }

--- a/skills/video-pipeline/thumbnail_title/prompt_builder.py
+++ b/skills/video-pipeline/thumbnail_title/prompt_builder.py
@@ -1,0 +1,209 @@
+"""Thumbnail prompt builder for Economy FastForward.
+
+Takes title generation output (caps_word, line_1, line_2) and video metadata,
+then uses Claude to fill template variables and produce the final Nano Banana Pro
+prompt from one of the three templates.
+"""
+
+import json
+from typing import Optional
+
+from thumbnail_title.templates import TEMPLATES, TEMPLATE_A_CFH_SPLIT, TEMPLATE_B_MINDPLICIT_BANNER, TEMPLATE_C_POWER_DYNAMIC
+from thumbnail_title.selector import select_template
+
+
+# System prompt for Claude to fill template variables
+VARIABLE_FILL_SYSTEM_PROMPT = """\
+You are the visual director for Economy FastForward thumbnail illustrations.
+
+Your job: Fill in the template variables to produce a compelling thumbnail that pairs
+with the given title. The thumbnail should show the HUMAN COST visually while the
+title explains the system or cause verbally.
+
+STYLE RULES:
+- Editorial comic illustration, bold graphic novel style
+- Dark navy background (#0A0F1A) with dramatic amber/golden lighting
+- Bold black outlines, high color saturation
+- 16:9 landscape, 1280x720
+- Maximum 3 colors: dark background, bright accent, white text
+- Face must be readable at 160x90 (YouTube search size)
+
+TEXT RULES (already in template, but guide your choices):
+- line_1 and line_2 are PROVIDED — use them exactly as given
+- red_word is PROVIDED — use it exactly as given
+- All text ALL CAPS, bold condensed sans-serif, heavy black outline
+
+EMOTION GUIDE:
+- Match the emotion to the caps_word:
+  TRAP/CRISIS/COLLAPSE → panicked, shocked
+  DEATH/DYING → worried, fearful
+  WEAPON/SWALLOWED → angry, frustrated
+  LIES/MISTAKE → frustrated, betrayed
+  STRONGER/RICHER/WEAKER → determined, defiant
+
+OUTPUT FORMAT (JSON only, no markdown):
+Return a JSON object with ALL required variable names as keys.
+"""
+
+
+class ThumbnailPromptBuilder:
+    """Builds thumbnail generation prompts from templates + AI-filled variables.
+
+    Uses Claude to intelligently fill template variables based on video content,
+    then formats the final prompt for Nano Banana Pro image generation.
+    """
+
+    def __init__(self, anthropic_client):
+        """Initialize with an existing AnthropicClient instance.
+
+        Args:
+            anthropic_client: An initialized AnthropicClient from the pipeline.
+        """
+        self.anthropic = anthropic_client
+
+    async def build(
+        self,
+        template_key: str,
+        title_data: dict,
+        video_title: str,
+        video_summary: str,
+    ) -> str:
+        """Build a complete thumbnail prompt.
+
+        Args:
+            template_key: One of 'template_a', 'template_b', 'template_c'.
+            title_data: Output from TitleGenerator.generate() containing
+                caps_word, line_1, line_2.
+            video_title: The video's working title.
+            video_summary: Brief video description.
+
+        Returns:
+            Complete prompt string ready for Nano Banana Pro.
+        """
+        template_info = TEMPLATES[template_key]
+        variables_needed = template_info["variables"]
+
+        # Pre-fill the text variables from title_data
+        prefilled = {
+            "line_1": title_data["line_1"],
+            "line_2": title_data["line_2"],
+            "red_word": title_data["caps_word"],
+        }
+
+        # Determine which variables still need to be filled by Claude
+        remaining = [v for v in variables_needed if v not in prefilled]
+
+        if remaining:
+            filled = await self._fill_variables(
+                template_key=template_key,
+                template_name=template_info["name"],
+                variables=remaining,
+                video_title=video_title,
+                video_summary=video_summary,
+                title_data=title_data,
+            )
+            prefilled.update(filled)
+
+        # Format the template with all variables
+        template_str = template_info["prompt"]
+        try:
+            prompt = template_str.format(**prefilled)
+        except KeyError as e:
+            raise ValueError(
+                f"Template '{template_key}' missing variable {e}. "
+                f"Filled: {list(prefilled.keys())}, "
+                f"Required: {variables_needed}"
+            )
+
+        return prompt
+
+    async def _fill_variables(
+        self,
+        template_key: str,
+        template_name: str,
+        variables: list[str],
+        video_title: str,
+        video_summary: str,
+        title_data: dict,
+    ) -> dict:
+        """Use Claude to fill remaining template variables.
+
+        Args:
+            template_key: Template identifier.
+            template_name: Human-readable template name.
+            variables: List of variable names to fill.
+            video_title: Video title for context.
+            video_summary: Video summary for context.
+            title_data: Title generation data for context.
+
+        Returns:
+            Dict mapping variable name -> value.
+        """
+        # Build variable descriptions based on template
+        var_descriptions = self._get_variable_descriptions(template_key)
+
+        var_guidance = "\n".join([
+            f'  "{v}": {var_descriptions.get(v, "Fill based on context")}'
+            for v in variables
+        ])
+
+        user_prompt = (
+            f"Fill the thumbnail template variables for this video:\n\n"
+            f'VIDEO TITLE: "{video_title}"\n'
+            f'VIDEO SUMMARY: {video_summary}\n'
+            f'YOUTUBE TITLE: "{title_data["title"]}"\n'
+            f'CAPS WORD: {title_data["caps_word"]}\n'
+            f'THUMBNAIL TEXT LINE 1: {title_data["line_1"]}\n'
+            f'THUMBNAIL TEXT LINE 2: {title_data["line_2"]}\n\n'
+            f'TEMPLATE: {template_name} ({template_key})\n\n'
+            f'Fill these variables (return JSON object with these exact keys):\n'
+            f'{var_guidance}\n\n'
+            f'Return JSON only.'
+        )
+
+        response = await self.anthropic.generate(
+            prompt=user_prompt,
+            system_prompt=VARIABLE_FILL_SYSTEM_PROMPT,
+            model="claude-sonnet-4-5-20250929",
+            max_tokens=800,
+        )
+
+        clean = response.replace("```json", "").replace("```", "").strip()
+        result = json.loads(clean)
+
+        # Validate all requested variables are present
+        missing = [v for v in variables if v not in result]
+        if missing:
+            raise ValueError(
+                f"Claude did not fill all variables. Missing: {missing}"
+            )
+
+        return result
+
+    @staticmethod
+    def _get_variable_descriptions(template_key: str) -> dict:
+        """Return human-readable descriptions for each template's variables."""
+        if template_key == "template_a":
+            return {
+                "nationality": "Country/region context (e.g., American, European, Chinese)",
+                "worker_type": "Character archetype (e.g., blue-collar worker, businessman, citizen)",
+                "emotion": "Primary facial emotion (e.g., panicked, shocked, frustrated, angry)",
+                "cultural_signifier": "Instant recognition prop (e.g., hard hat, Uncle Sam hat, business suit)",
+                "mouth_expression": "Reinforces emotion (e.g., open in shock, gritted in anger)",
+                "secondary_element": "Right-side visual that contrasts with figure (e.g., sleek robot in golden glow, crumbling bank building)",
+            }
+        elif template_key == "template_b":
+            return {
+                "power_scene": "Central dramatic scene (e.g., worker looking up at massive robot shadow, figure at chess board)",
+                "ground_detail": "Floor-level context detail (e.g., scattered tools and fallen hard hat, cracked floor tiles)",
+            }
+        elif template_key == "template_c":
+            return {
+                "victim_type": "Displaced figure (e.g., panicked blue-collar worker, shocked small business owner)",
+                "emotion": "Victim's emotion (e.g., shock, panic, fear, anger)",
+                "cultural_signifier": "Flying prop (e.g., hard hat, briefcase, apron, glasses)",
+                "power_figure": "Controller figure (e.g., calm man in dark suit sitting in leather chair with fingers steepled)",
+                "instrument": "Tool of power (e.g., golden glowing robot, stack of contracts, money printer)",
+                "relationship": "Arrow label suggesting dynamics (e.g., REPLACEMENT, EXTRACTION, CONTROL)",
+            }
+        return {}

--- a/skills/video-pipeline/thumbnail_title/selector.py
+++ b/skills/video-pipeline/thumbnail_title/selector.py
@@ -1,0 +1,52 @@
+"""Template selection logic for thumbnail generation.
+
+Selects one of the three thumbnail templates based on video metadata
+(topic keywords and tags). Falls back to Template A (CFH Split) as default.
+"""
+
+
+# Keywords that trigger Template C: Power Dynamic
+POWER_KEYWORDS = [
+    "robot", "ai replace", "monopoly", "inequality",
+    "corporate", "billionaire", "oligarch", "who owns",
+    "who controls", "who profits",
+]
+
+# Keywords that trigger Template B: Mindplicit Banner
+STRATEGY_KEYWORDS = [
+    "machiavelli", "strategy", "hidden", "secret",
+    "never do", "warning", "dark", "manipulation",
+    "power play", "puppet",
+]
+
+
+def select_template(video_metadata: dict) -> str:
+    """Select thumbnail template based on video content type.
+
+    Args:
+        video_metadata: Dict with at least 'topic' (str) and optionally 'tags' (list[str]).
+            Also accepts standard Airtable fields: 'Video Title', 'Summary',
+            'Framework Angle', etc.
+
+    Returns:
+        One of 'template_a', 'template_b', 'template_c'.
+    """
+    # Build a searchable text blob from all relevant fields
+    topic = video_metadata.get("topic", "").lower()
+    title = video_metadata.get("Video Title", "").lower()
+    summary = video_metadata.get("Summary", "").lower()
+    framework = video_metadata.get("Framework Angle", "").lower()
+    tags = [t.lower() for t in video_metadata.get("tags", [])]
+
+    searchable = f"{topic} {title} {summary} {framework} {' '.join(tags)}"
+
+    # Template C: Power Dynamic — winners vs losers narratives
+    if any(kw in searchable for kw in POWER_KEYWORDS):
+        return "template_c"
+
+    # Template B: Mindplicit Banner — strategy/warning content
+    if any(kw in searchable for kw in STRATEGY_KEYWORDS):
+        return "template_b"
+
+    # Template A: CFH Split — default for everything else
+    return "template_a"

--- a/skills/video-pipeline/thumbnail_title/templates.py
+++ b/skills/video-pipeline/thumbnail_title/templates.py
@@ -1,0 +1,117 @@
+"""Thumbnail prompt templates for Economy FastForward.
+
+Three templates, each producing a distinct visual layout:
+  - Template A: CFH Split (default, ~70% usage)
+  - Template B: Mindplicit Banner (~20% usage)
+  - Template C: Power Dynamic (~10% usage, EFF exclusive)
+
+All templates produce 1280x720 (16:9) editorial comic illustrations
+via Nano Banana Pro with text baked directly into the image.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Template A: CFH Split
+# ---------------------------------------------------------------------------
+TEMPLATE_A_CFH_SPLIT = (
+    "Editorial comic illustration, bold graphic novel style, dark navy background "
+    "with dramatic amber side lighting, 16:9 landscape aspect ratio,\n\n"
+    "Left 60% of frame: {nationality} {worker_type} with {emotion} facial expression, "
+    "wearing {cultural_signifier}, mouth {mouth_expression}, waist-up framing, "
+    "face is large and clearly readable, bold black outlines, high color saturation, "
+    "sweat drops or motion lines reinforcing the emotion,\n\n"
+    "Right side: {secondary_element}, this element tells the second half of the story "
+    "and contrasts with the figure's emotion,\n\n"
+    'Bold text in upper right area reading "{line_1}" in large white bold condensed '
+    'all-caps font with heavy black outline stroke, the word "{red_word}" is bright red, '
+    'below it smaller white bold text "{line_2}" with black outline,\n\n'
+    "Dark navy gradient background, simple composition, thick confident black linework, "
+    "bold saturated colors, magazine cover composition"
+)
+
+
+# ---------------------------------------------------------------------------
+# Template B: Mindplicit Banner
+# ---------------------------------------------------------------------------
+TEMPLATE_B_MINDPLICIT_BANNER = (
+    "Editorial comic illustration, dark dramatic scene, deep navy black background "
+    "with warm amber lighting from below, 16:9 landscape aspect ratio,\n\n"
+    'Bold text banner across top of frame reading "{line_1}" in large white bold '
+    'condensed all-caps font with heavy black outline stroke, the word "{red_word}" '
+    'is bright red, below it smaller white text "{line_2}" with black outline,\n\n'
+    "Center and lower frame: {power_scene}, dramatic shadows with warm amber accent "
+    "lighting on key focal points,\n\n"
+    "{ground_detail}, editorial illustration with noir influence, bold blacks, "
+    "dramatic contrast, thick black linework"
+)
+
+
+# ---------------------------------------------------------------------------
+# Template C: Power Dynamic (EFF Exclusive)
+# ---------------------------------------------------------------------------
+TEMPLATE_C_POWER_DYNAMIC = (
+    "Editorial comic illustration, bold graphic novel style, dark navy background "
+    "with dramatic golden amber lighting, 16:9 landscape aspect ratio,\n\n"
+    "Left side: {victim_type} stumbling backward in {emotion}, {cultural_signifier} "
+    "flying off, mouth open, eyes wide, bold black outlines, high color saturation, "
+    "waist-up framing with large readable facial expression, cold blue lighting on "
+    "this figure,\n\n"
+    "Right side: {power_figure}, a {instrument} standing beside the power figure like "
+    "a loyal servant, warm golden amber lighting on this side, floating dollar signs "
+    "in the golden glow,\n\n"
+    "A large bold red arrow pointing from the victim toward the instrument suggesting "
+    "{relationship},\n\n"
+    'Bold text reading "{line_1}" in large white bold condensed all-caps font with '
+    'heavy black outline stroke at top of frame, the word "{red_word}" is bright red, '
+    'below it smaller white text "{line_2}" with black outline,\n\n'
+    "Simple composition, thick confident black linework, magazine cover style, "
+    "dramatic contrast between cold blue victim side and warm golden power side"
+)
+
+
+# ---------------------------------------------------------------------------
+# Template registry
+# ---------------------------------------------------------------------------
+TEMPLATES = {
+    "template_a": {
+        "name": "CFH Split",
+        "prompt": TEMPLATE_A_CFH_SPLIT,
+        "usage_weight": 0.70,
+        "variables": [
+            "nationality", "worker_type", "emotion", "cultural_signifier",
+            "mouth_expression", "secondary_element", "line_1", "red_word",
+            "line_2",
+        ],
+    },
+    "template_b": {
+        "name": "Mindplicit Banner",
+        "prompt": TEMPLATE_B_MINDPLICIT_BANNER,
+        "usage_weight": 0.20,
+        "variables": [
+            "line_1", "red_word", "line_2", "power_scene", "ground_detail",
+        ],
+    },
+    "template_c": {
+        "name": "Power Dynamic",
+        "prompt": TEMPLATE_C_POWER_DYNAMIC,
+        "usage_weight": 0.10,
+        "variables": [
+            "victim_type", "emotion", "cultural_signifier", "power_figure",
+            "instrument", "relationship", "line_1", "red_word", "line_2",
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Color palette
+# ---------------------------------------------------------------------------
+COLOR_PALETTE = {
+    "background_default": "#0A0F1A",      # deep navy black
+    "background_crisis": "#8B1A1A",        # deep crimson (crisis/collapse)
+    "background_geopolitical": "#1A2A4A",  # midnight blue (geopolitical)
+    "accent_gold": "#FFB800",              # dollar amounts, wealth symbols
+    "alert_red": "#E63946",                # ONE highlighted word
+    "accent_green": "#22C55E",             # wealth/growth (sparingly)
+    "text_white": "#FFFFFF",               # all body text (+ black stroke)
+}

--- a/skills/video-pipeline/thumbnail_title/title_generator.py
+++ b/skills/video-pipeline/thumbnail_title/title_generator.py
@@ -1,0 +1,219 @@
+"""Title generator for Economy FastForward videos.
+
+Produces titles that follow proven formula patterns.  Each title contains
+exactly ONE CAPS word that becomes the red_word in the paired thumbnail.
+
+Six formula families:
+  1. The [Noun] TRAP Nobody Sees Coming (Parenthetical)
+  2. [Country]'s $[Amount] [Mistake/Gamble] (The [Named Trap])
+  3. The Slow DEATH of [System] (And Who Controls What Comes Next)
+  4. Why [Country] is [ADJECTIVE]er Than You Think (The Hidden Strategy)
+  5. [Number] [Noun] [Warning] (Machiavelli Warned You)
+  6. How [Entity] SWALLOWED [Target] (The [X]-Stage Playbook)
+"""
+
+import json
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Title formula definitions
+# ---------------------------------------------------------------------------
+TITLE_FORMULAS = {
+    "formula_1": {
+        "name": "The [Noun] TRAP Nobody Sees Coming",
+        "pattern": "The {noun} {caps_word} Nobody Sees Coming ({parenthetical})",
+        "examples": [
+            "The Robot TRAP Nobody Sees Coming (A 4-Stage Monopoly)",
+            "The Dollar TRAP Nobody Sees Coming (Why Cash Is a Weapon)",
+            "The Housing TRAP Nobody Sees Coming (And Who Profits)",
+        ],
+    },
+    "formula_2": {
+        "name": "[Country]'s $[Amount] [Mistake/Gamble]",
+        "pattern": "{country}'s {amount} {caps_word} ({parenthetical})",
+        "examples": [
+            "America's $34 Trillion Debt WEAPON (The Machiavellian Strategy)",
+            "China's $3 Trillion Dollar TRAP (The Silent Economic War)",
+            "Germany's $500 Billion MISTAKE (Why Green Energy Failed)",
+        ],
+    },
+    "formula_3": {
+        "name": "The Slow DEATH of [System]",
+        "pattern": "The Slow {caps_word} of {system} ({parenthetical})",
+        "examples": [
+            "The Slow DEATH of the Dollar (And Who Controls What Replaces It)",
+            "The Slow COLLAPSE of NATO (And Russia's Play to Replace It)",
+            "The Slow DEATH of the Middle Class (And Who's Engineering It)",
+        ],
+    },
+    "formula_4": {
+        "name": "Why [Country] is [ADJECTIVE]er Than You Think",
+        "pattern": "Why {country} is {caps_word} Than You Think ({parenthetical})",
+        "examples": [
+            "Why Russia is STRONGER Than You Think (The Machiavellian Energy Play)",
+            "Why America is WEAKER Than You Think (The Hidden Debt Pattern)",
+            "Why China is RICHER Than You Think (The Strategy Nobody Discusses)",
+        ],
+    },
+    "formula_5": {
+        "name": "[Number] [Noun] [Warning]",
+        "pattern": "{number} {noun} {caps_word} ({parenthetical})",
+        "examples": [
+            "7 Economic LIES They Need You to Believe (Machiavelli Warned You)",
+            "5 Signs Your Country's Economy is DYING (The Pattern Repeats)",
+            "9 Financial TRAPS Designed to Keep You Poor (The System Explained)",
+        ],
+    },
+    "formula_6": {
+        "name": "How [Entity] SWALLOWED [Target]",
+        "pattern": "How {entity} {caps_word} {target} ({parenthetical})",
+        "examples": [
+            "How Blackrock SWALLOWED the Housing Market (The 3-Stage Playbook)",
+            "How AI SWALLOWED Your Job Market (The 4-Stage Monopoly Trap)",
+            "How Debt SWALLOWED the American Dream (The Machiavellian Design)",
+        ],
+    },
+}
+
+
+# System prompt for Claude to generate title + variables
+TITLE_GENERATION_SYSTEM_PROMPT = """\
+You are the title strategist for Economy FastForward, a finance/economics YouTube channel.
+
+Your job: Generate a click-worthy title that follows one of the proven formula patterns.
+
+RULES:
+1. The title MUST contain exactly ONE word in ALL CAPS — this is the curiosity trigger.
+2. The CAPS word becomes the red highlight in the thumbnail. Pick a word with emotional weight:
+   TRAP, DEATH, COLLAPSE, WEAPON, CRISIS, LIES, DYING, SWALLOWED, MISTAKE, STRONGER, WEAKER, RICHER, etc.
+3. The main hook (before the parenthetical) should be 6-8 words.
+4. The parenthetical reveal should create a curiosity gap.
+5. Total title length should be under 70 characters for the main hook.
+
+FORMULA OPTIONS:
+1. "The [Noun] {CAPS} Nobody Sees Coming (Parenthetical)"
+2. "[Country]'s $[Amount] {CAPS} (Parenthetical)"
+3. "The Slow {CAPS} of [System] (Parenthetical)"
+4. "Why [Country] is {CAPS} Than You Think (Parenthetical)"
+5. "[Number] [Noun] {CAPS} (Parenthetical)"
+6. "How [Entity] {CAPS} [Target] (Parenthetical)"
+
+Pick the formula that best fits the video topic. The CAPS word must feel like a revelation.
+
+OUTPUT FORMAT (JSON only, no markdown):
+{
+  "title": "The full title with ONE CAPS word and parenthetical",
+  "caps_word": "THE_CAPS_WORD",
+  "formula_used": "formula_1",
+  "line_1": "3-4 WORD THUMBNAIL TEXT",
+  "line_2": "2-3 WORD SUBTITLE"
+}
+
+CRITICAL:
+- line_1 and line_2 are for the THUMBNAIL, not the YouTube title
+- line_1 should be max 4 words, ALL CAPS, derived from the title's core hook
+- line_2 should be max 3 words, ALL CAPS, a question or kicker
+- The caps_word MUST appear in line_1
+- Together line_1 + line_2 must not exceed 5 words total
+"""
+
+
+class TitleGenerator:
+    """Generates matched titles for Economy FastForward videos.
+
+    Uses Anthropic Claude to produce titles following proven formula patterns.
+    Each title includes a CAPS word that becomes the red_word in the thumbnail.
+    """
+
+    def __init__(self, anthropic_client):
+        """Initialize with an existing AnthropicClient instance.
+
+        Args:
+            anthropic_client: An initialized AnthropicClient from the pipeline.
+        """
+        self.anthropic = anthropic_client
+
+    async def generate(
+        self,
+        video_title: str,
+        video_summary: str,
+        tags: Optional[list[str]] = None,
+        preferred_formula: Optional[str] = None,
+    ) -> dict:
+        """Generate a title + thumbnail text pair.
+
+        Args:
+            video_title: Working title or topic of the video.
+            video_summary: Brief description of the video content.
+            tags: Optional list of topic tags.
+            preferred_formula: Optional formula key (formula_1 through formula_6)
+                to force a specific pattern.
+
+        Returns:
+            Dict with keys:
+                title: str — full YouTube title
+                caps_word: str — the ALL CAPS word
+                formula_used: str — which formula was selected
+                line_1: str — thumbnail primary text (3-4 words, ALL CAPS)
+                line_2: str — thumbnail secondary text (2-3 words, ALL CAPS)
+        """
+        prompt_parts = [
+            f'Generate a title for this Economy FastForward video:',
+            f'',
+            f'WORKING TITLE: "{video_title}"',
+            f'VIDEO SUMMARY: {video_summary}',
+        ]
+
+        if tags:
+            prompt_parts.append(f'TAGS: {", ".join(tags)}')
+
+        if preferred_formula and preferred_formula in TITLE_FORMULAS:
+            formula = TITLE_FORMULAS[preferred_formula]
+            prompt_parts.extend([
+                f'',
+                f'USE THIS FORMULA: {formula["name"]}',
+                f'Pattern: {formula["pattern"]}',
+                f'Examples:',
+            ])
+            for ex in formula["examples"]:
+                prompt_parts.append(f'  - {ex}')
+
+        prompt_parts.extend([
+            f'',
+            f'Generate the title now. Return JSON only.',
+        ])
+
+        user_prompt = '\n'.join(prompt_parts)
+
+        response = await self.anthropic.generate(
+            prompt=user_prompt,
+            system_prompt=TITLE_GENERATION_SYSTEM_PROMPT,
+            model="claude-sonnet-4-5-20250929",
+            max_tokens=500,
+        )
+
+        # Parse JSON response
+        clean = response.replace("```json", "").replace("```", "").strip()
+        result = json.loads(clean)
+
+        # Validate required fields
+        required = ["title", "caps_word", "formula_used", "line_1", "line_2"]
+        for field in required:
+            if field not in result:
+                raise ValueError(f"Title generation missing required field: {field}")
+
+        # Ensure caps_word is uppercase
+        result["caps_word"] = result["caps_word"].upper()
+
+        # Ensure line_1 and line_2 are uppercase
+        result["line_1"] = result["line_1"].upper()
+        result["line_2"] = result["line_2"].upper()
+
+        # Validate total word count for thumbnail text (max 5 words)
+        total_words = len(result["line_1"].split()) + len(result["line_2"].split())
+        if total_words > 5:
+            print(f"  WARNING: Thumbnail text has {total_words} words (max 5). "
+                  f"line_1='{result['line_1']}', line_2='{result['line_2']}'")
+
+        return result

--- a/skills/video-pipeline/thumbnail_title/validator.py
+++ b/skills/video-pipeline/thumbnail_title/validator.py
@@ -1,0 +1,104 @@
+"""Thumbnail validation for Economy FastForward.
+
+Runs automated checks on generated thumbnails before advancing the pipeline.
+Flags images for manual review when automated checks can't cover subjective quality.
+"""
+
+import io
+from typing import Optional
+
+
+def validate_thumbnail(image_data: bytes) -> tuple[bool, dict]:
+    """Validate a thumbnail image passes all automated checks.
+
+    Args:
+        image_data: Raw image bytes (PNG or JPEG).
+
+    Returns:
+        Tuple of (passes_all_checks: bool, check_results: dict).
+        check_results maps check name -> bool.
+    """
+    try:
+        from PIL import Image
+        img = Image.open(io.BytesIO(image_data))
+    except ImportError:
+        # PIL not available — skip image-level checks, return pass
+        print("  WARNING: Pillow not installed, skipping image validation")
+        return True, {"pillow_available": False}
+    except Exception as e:
+        return False, {"image_load": False, "error": str(e)}
+
+    w, h = img.size
+
+    checks = {
+        "aspect_ratio": abs((w / h) - (16 / 9)) < 0.05,
+        "min_width": w >= 1280,
+        "min_height": h >= 720,
+    }
+
+    # Log manual review items (can't be automated)
+    manual_review_notes = [
+        "Is the face emotion readable at 160x90?",
+        "Is the text readable at 160x90?",
+        "Are there 3 or fewer dominant colors?",
+        "Is there ONE clear focal point?",
+    ]
+
+    passes = all(checks.values())
+
+    if not passes:
+        failed = [k for k, v in checks.items() if not v]
+        print(f"  VALIDATION FAILED: {failed}")
+        print(f"  Image dimensions: {w}x{h}, aspect ratio: {w/h:.3f}")
+
+    return passes, checks
+
+
+def validate_title_thumbnail_pair(title_data: dict, template_key: str) -> tuple[bool, list[str]]:
+    """Validate that the title and thumbnail are properly paired.
+
+    Checks:
+    - The CAPS word in the title matches the red_word in the thumbnail
+    - Thumbnail text doesn't exceed 5 words total
+    - line_1 and line_2 are ALL CAPS
+
+    Args:
+        title_data: Output from TitleGenerator.generate().
+        template_key: The template used for the thumbnail.
+
+    Returns:
+        Tuple of (is_valid: bool, issues: list[str]).
+    """
+    issues = []
+
+    caps_word = title_data.get("caps_word", "")
+    line_1 = title_data.get("line_1", "")
+    line_2 = title_data.get("line_2", "")
+    title = title_data.get("title", "")
+
+    # Check caps_word appears in the title
+    if caps_word and caps_word not in title:
+        issues.append(f"CAPS word '{caps_word}' not found in title '{title}'")
+
+    # Check caps_word appears in line_1
+    if caps_word and caps_word not in line_1:
+        issues.append(f"CAPS word '{caps_word}' not found in thumbnail line_1 '{line_1}'")
+
+    # Check total thumbnail text word count (max 5)
+    total_words = len(line_1.split()) + len(line_2.split())
+    if total_words > 5:
+        issues.append(f"Thumbnail text has {total_words} words (max 5): '{line_1}' + '{line_2}'")
+
+    # Check ALL CAPS
+    if line_1 != line_1.upper():
+        issues.append(f"line_1 is not ALL CAPS: '{line_1}'")
+    if line_2 != line_2.upper():
+        issues.append(f"line_2 is not ALL CAPS: '{line_2}'")
+
+    # Check line lengths
+    if len(line_1.split()) > 4:
+        issues.append(f"line_1 exceeds 4 words: '{line_1}'")
+    if len(line_2.split()) > 3:
+        issues.append(f"line_2 exceeds 3 words: '{line_2}'")
+
+    return len(issues) == 0, issues


### PR DESCRIPTION
Introduces a new thumbnail_title module that generates matched
title/thumbnail pairs for the YouTube pipeline. The system selects
from three visual templates (CFH Split, Mindplicit Banner, Power
Dynamic) based on video content, generates titles using six proven
formula patterns, and ensures the CAPS word in the title matches
the red highlight word in the thumbnail.

Key components:
- templates.py: Three prompt templates with variable placeholders
- selector.py: Content-aware template selection logic
- title_generator.py: Six title formula patterns via Claude
- prompt_builder.py: AI-driven variable filling for templates
- validator.py: Automated image and pair validation checks
- engine.py: Orchestrator with retry logic (max 3 attempts)

Pipeline integration updated in pipeline.py run_thumbnail_bot()
to use ThumbnailTitleEngine instead of the previous single-prompt
approach. Airtable, Google Drive, and Slack integration preserved.

https://claude.ai/code/session_01Eh7YHcHtYUYr3dgb3MEikB