### PR TITLE
Add standalone thumbnail_generator module for EFF pipeline

### DIFF
--- a/skills/video-pipeline/thumbnail_generator/.env.example
+++ b/skills/video-pipeline/thumbnail_generator/.env.example
@@ -1,0 +1,4 @@
+# Kie.ai API key for Nano Banana Pro thumbnail generation
+# Copy this file to .env and fill in your key:
+#   cp .env.example .env
+KIE_API_KEY=your_kie_api_key_here

--- a/skills/video-pipeline/thumbnail_generator/__init__.py
+++ b/skills/video-pipeline/thumbnail_generator/__init__.py
@@ -1,0 +1,52 @@
+"""EFF Thumbnail & Title Generator.
+
+Standalone module for generating matched thumbnail/title pairs for the
+Economy FastForward YouTube pipeline. Uses Nano Banana Pro (via Kie.ai)
+for image generation with three editorial comic templates.
+
+Quick start:
+    from thumbnail_generator import produce_thumbnail_and_title
+
+    result = produce_thumbnail_and_title(
+        topic="China's $140 Billion Dollar Trap",
+        tags=["china", "dollar", "trap"],
+        template_vars={...},
+        title_formula="country_dollar",
+        title_vars={...},
+    )
+"""
+
+from thumbnail_generator.generator import generate_thumbnail, produce_thumbnail_and_title
+from thumbnail_generator.templates import (
+    TEMPLATE_A,
+    TEMPLATE_B,
+    TEMPLATE_C,
+    TEMPLATES,
+    select_template,
+)
+from thumbnail_generator.titles import TITLE_FORMULAS, generate_title, extract_caps_word
+from thumbnail_generator.validator import validate_thumbnail
+from thumbnail_generator.config import (
+    ASPECT_RATIO,
+    COST_PER_IMAGE,
+    MAX_ATTEMPTS,
+    COLORS,
+)
+
+__all__ = [
+    "generate_thumbnail",
+    "produce_thumbnail_and_title",
+    "TEMPLATE_A",
+    "TEMPLATE_B",
+    "TEMPLATE_C",
+    "TEMPLATES",
+    "select_template",
+    "TITLE_FORMULAS",
+    "generate_title",
+    "extract_caps_word",
+    "validate_thumbnail",
+    "ASPECT_RATIO",
+    "COST_PER_IMAGE",
+    "MAX_ATTEMPTS",
+    "COLORS",
+]

--- a/skills/video-pipeline/thumbnail_generator/config.py
+++ b/skills/video-pipeline/thumbnail_generator/config.py
@@ -1,0 +1,38 @@
+"""Configuration constants for EFF Thumbnail Generator.
+
+API settings, color palette, and generation parameters for Nano Banana Pro
+thumbnail generation via Kie.ai.
+"""
+
+# ---------------------------------------------------------------------------
+# Nano Banana Pro API (via Kie.ai)
+# ---------------------------------------------------------------------------
+# Kie.ai uses a task-based API: create task -> poll for result
+API_BASE_URL = "https://api.kie.ai/api/v1/jobs"
+CREATE_TASK_URL = f"{API_BASE_URL}/createTask"
+RECORD_INFO_URL = f"{API_BASE_URL}/recordInfo"
+MODEL_NAME = "nano-banana-pro"
+
+ASPECT_RATIO = "16:9"  # NEVER change this — wrong ratio causes black bars
+RESOLUTION = "2K"
+OUTPUT_FORMAT = "png"
+MAX_ATTEMPTS = 3  # Max regenerations before flagging for manual review
+COST_PER_IMAGE = 0.09  # USD at 2K resolution
+
+# Polling settings
+POLL_INITIAL_WAIT = 5.0  # Seconds before first poll
+POLL_INTERVAL = 2.0  # Seconds between polls
+POLL_MAX_ATTEMPTS = 45  # Max poll iterations (~90 seconds total)
+
+# ---------------------------------------------------------------------------
+# Color palette (for reference/validation — colors are baked into prompts)
+# ---------------------------------------------------------------------------
+COLORS = {
+    "bg_navy": "#0A0F1A",
+    "bg_crimson": "#8B1A1A",
+    "bg_midnight": "#1A2A4A",
+    "accent_gold": "#FFB800",
+    "accent_red": "#E63946",
+    "accent_green": "#22C55E",
+    "text_white": "#FFFFFF",
+}

--- a/skills/video-pipeline/thumbnail_generator/generator.py
+++ b/skills/video-pipeline/thumbnail_generator/generator.py
@@ -1,0 +1,247 @@
+"""Main entry point for EFF Thumbnail & Title Generator.
+
+Generates thumbnails via Nano Banana Pro (Kie.ai) and pairs them with
+matched titles using proven formula patterns.
+
+Usage:
+    from thumbnail_generator.generator import produce_thumbnail_and_title
+
+    result = produce_thumbnail_and_title(
+        topic="China's $140 Billion Dollar Trap",
+        tags=["china", "dollar", "trap"],
+        template_vars={...},
+        title_formula="country_dollar",
+        title_vars={...},
+    )
+"""
+
+import json
+import os
+import time
+
+import requests
+from pathlib import Path
+
+from .templates import TEMPLATE_A, TEMPLATE_B, TEMPLATE_C, select_template
+from .titles import TITLE_FORMULAS, generate_title
+from .validator import validate_thumbnail
+from .config import (
+    CREATE_TASK_URL,
+    RECORD_INFO_URL,
+    MODEL_NAME,
+    ASPECT_RATIO,
+    OUTPUT_FORMAT,
+    MAX_ATTEMPTS,
+    COST_PER_IMAGE,
+    POLL_INITIAL_WAIT,
+    POLL_INTERVAL,
+    POLL_MAX_ATTEMPTS,
+)
+
+
+def _get_api_key(api_key: str = None) -> str:
+    """Resolve API key from argument, then environment.
+
+    Checks KIE_API_KEY first (spec convention), then KIE_AI_API_KEY
+    (existing pipeline convention).
+    """
+    key = api_key or os.environ.get("KIE_API_KEY") or os.environ.get("KIE_AI_API_KEY")
+    if not key:
+        raise ValueError(
+            "API key not set. Provide api_key argument or set "
+            "KIE_API_KEY / KIE_AI_API_KEY environment variable."
+        )
+    return key
+
+
+def generate_thumbnail(
+    prompt: str,
+    output_path: str,
+    api_key: str = None,
+) -> dict:
+    """Call Nano Banana Pro API and save the result.
+
+    Uses Kie.ai's task-based API: create task -> poll for completion ->
+    download result image.
+
+    Args:
+        prompt: The full image generation prompt.
+        output_path: Local file path to save the PNG thumbnail.
+        api_key: Optional API key override.
+
+    Returns:
+        Dict with 'path', 'prompt', 'cost' keys.
+
+    Raises:
+        ValueError: If API key is not available.
+        requests.HTTPError: If API call fails.
+        TimeoutError: If polling exceeds max attempts.
+    """
+    key = _get_api_key(api_key)
+
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+
+    # Step 1: Create the generation task
+    payload = {
+        "model": MODEL_NAME,
+        "input": {
+            "prompt": prompt,
+            "aspect_ratio": ASPECT_RATIO,  # Always "16:9"
+            "output_format": OUTPUT_FORMAT,  # Always "png"
+        },
+    }
+
+    response = requests.post(CREATE_TASK_URL, json=payload, headers=headers, timeout=60)
+    response.raise_for_status()
+
+    task_data = response.json()
+    task_id = task_data.get("data", {}).get("taskId")
+    if not task_id:
+        raise ValueError(f"No task ID returned from API: {task_data}")
+
+    # Step 2: Poll for completion
+    time.sleep(POLL_INITIAL_WAIT)
+    image_url = _poll_for_result(task_id, key)
+
+    # Step 3: Download and save the image
+    if image_url:
+        img_response = requests.get(image_url, timeout=60)
+        img_response.raise_for_status()
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(img_response.content)
+
+    return {
+        "path": output_path,
+        "prompt": prompt,
+        "cost": COST_PER_IMAGE,
+    }
+
+
+def _poll_for_result(task_id: str, api_key: str) -> str:
+    """Poll Kie.ai for task completion and return the image URL.
+
+    Args:
+        task_id: The task ID from create_image.
+        api_key: API key for authentication.
+
+    Returns:
+        Image URL string.
+
+    Raises:
+        TimeoutError: If polling exceeds max attempts.
+        RuntimeError: If the task reports failure.
+    """
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    for attempt in range(POLL_MAX_ATTEMPTS):
+        response = requests.get(
+            RECORD_INFO_URL,
+            headers=headers,
+            params={"taskId": task_id},
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        data = response.json().get("data", {})
+        task_status = data.get("status")
+        task_state = data.get("state")
+
+        # Status codes: 0=Queue, 1=Running, 2=Success, 3=Failed
+        if task_status == 3 or str(task_state).lower() in ("fail", "failed", "failure", "error"):
+            raise RuntimeError(f"Image generation failed (state={task_state}, status={task_status})")
+
+        result_json = data.get("resultJson")
+        if result_json:
+            if isinstance(result_json, str):
+                result_data = json.loads(result_json)
+            else:
+                result_data = result_json
+
+            result_urls = result_data.get("resultUrls", [])
+            if result_urls:
+                return result_urls[0]
+
+        time.sleep(POLL_INTERVAL)
+
+    raise TimeoutError(f"Polling timed out after {POLL_MAX_ATTEMPTS} attempts for task {task_id}")
+
+
+def produce_thumbnail_and_title(
+    topic: str,
+    tags: list[str] = None,
+    template_vars: dict = None,
+    title_formula: str = None,
+    title_vars: dict = None,
+    output_dir: str = "./thumbnails",
+    api_key: str = None,
+) -> dict:
+    """Full pipeline: select template, fill variables, generate image, validate.
+
+    Args:
+        topic: Video topic string.
+        tags: Optional list of tags for template selection.
+        template_vars: Dict of variables to fill the selected template.
+        title_formula: Key from TITLE_FORMULAS (e.g. "trap", "slow_death").
+        title_vars: Dict of variables to fill the title formula.
+        output_dir: Where to save the thumbnail.
+        api_key: Optional API key override.
+
+    Returns:
+        Dict with title, thumbnail_path, template_used, prompt,
+        attempts, passed_validation, total_cost, and optionally
+        needs_manual_review.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    # 1. Select template
+    template_key = select_template(topic, tags)
+
+    # 2. Fill prompt template
+    templates = {
+        "template_a": TEMPLATE_A,
+        "template_b": TEMPLATE_B,
+        "template_c": TEMPLATE_C,
+    }
+    prompt = templates[template_key].format(**(template_vars or {}))
+
+    # 3. Generate title
+    title = None
+    if title_formula and title_vars:
+        title = generate_title(title_formula, title_vars)
+
+    # 4. Generate thumbnail with retry and validation
+    slug = topic.lower().replace(" ", "-")[:30]
+    passed = False
+    checks = {}
+    result = {}
+    attempt = 0
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        output_path = os.path.join(output_dir, f"{slug}_thumbnail_v{attempt}.png")
+        try:
+            result = generate_thumbnail(prompt, output_path, api_key=api_key)
+            passed, checks = validate_thumbnail(output_path)
+            if passed:
+                break
+        except Exception as e:
+            result = {"path": output_path, "prompt": prompt, "cost": COST_PER_IMAGE, "error": str(e)}
+            passed = False
+
+    output = {
+        "title": title,
+        "thumbnail_path": result.get("path", ""),
+        "template_used": template_key,
+        "prompt": prompt,
+        "attempts": attempt,
+        "passed_validation": passed,
+        "validation_checks": checks,
+        "total_cost": attempt * COST_PER_IMAGE,
+    }
+
+    if not passed:
+        output["needs_manual_review"] = True
+
+    return output

--- a/skills/video-pipeline/thumbnail_generator/templates.py
+++ b/skills/video-pipeline/thumbnail_generator/templates.py
@@ -1,0 +1,134 @@
+"""Thumbnail prompt templates for Economy FastForward.
+
+Three templates, each producing a distinct visual layout:
+  - Template A: CFH Split (default, ~70% usage)
+  - Template B: Mindplicit Banner (~20% usage)
+  - Template C: Power Dynamic (~10% usage, EFF exclusive)
+
+All templates produce 16:9 editorial comic illustrations via Nano Banana Pro
+with text baked directly into the image.
+
+TEXT PLACEMENT FIX: Both text lines are always described as one stacked unit
+in the same sentence. Never describe line_1 and line_2 as separate instructions
+in different paragraphs — Nano Banana Pro places them unpredictably otherwise.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Template A: CFH Split (default — 70% of thumbnails)
+# Select when: Country stories, economic explanations, system breakdowns,
+#               human-impact hook.
+# ---------------------------------------------------------------------------
+TEMPLATE_A = """Editorial comic illustration, bold graphic novel style, dark navy background with dramatic amber side lighting, 16:9 landscape aspect ratio,
+
+Left 60% of frame: {nationality} {worker_type} with {emotion} facial expression, wearing {cultural_signifier}, mouth {mouth_expression}, waist-up framing, face is large and clearly readable, bold black outlines, high color saturation, sweat drops or motion lines reinforcing the emotion,
+
+Right side: {secondary_element}, this element tells the second half of the story and contrasts with the figure's emotion,
+
+Bold text stacked in upper right reading "{line_1}" in large white bold condensed all-caps font with heavy black outline stroke, the word "{red_word}" is bright red, and directly below it in smaller white bold text "{line_2}" with the same black outline, both lines tightly grouped together in the same area,
+
+Dark navy gradient background, simple composition, thick confident black linework, bold saturated colors, magazine cover composition"""
+
+# Template A required variables
+TEMPLATE_A_VARS = [
+    "nationality", "worker_type", "emotion", "cultural_signifier",
+    "mouth_expression", "secondary_element", "line_1", "red_word", "line_2",
+]
+
+
+# ---------------------------------------------------------------------------
+# Template B: Mindplicit Banner (20% of thumbnails)
+# Select when: Machiavellian strategy, power dynamics, hidden systems,
+#               warning/command style.
+# ---------------------------------------------------------------------------
+TEMPLATE_B = """Editorial comic illustration, dark dramatic scene, deep navy black background with warm amber lighting from below, 16:9 landscape aspect ratio,
+
+Bold text banner across top 20 percent of frame reading "{line_1}" in large white bold condensed all-caps font with heavy black outline stroke, the word "{red_word}" is bright red, and directly below it in smaller white text "{line_2}" with black outline, both lines at the top of the frame,
+
+Center and lower frame: {power_scene}, dramatic shadows with warm amber accent lighting on key focal points,
+
+{ground_detail}, editorial illustration with noir influence, bold blacks, dramatic contrast, thick black linework"""
+
+# Template B required variables
+TEMPLATE_B_VARS = [
+    "line_1", "red_word", "line_2", "power_scene", "ground_detail",
+]
+
+
+# ---------------------------------------------------------------------------
+# Template C: Power Dynamic (10% of thumbnails — EFF exclusive)
+# Select when: Robot/AI replacement, wealth inequality, corporate power,
+#               winners vs losers narratives.
+# ---------------------------------------------------------------------------
+TEMPLATE_C = """Editorial comic illustration, bold graphic novel style, dark navy background with dramatic golden amber lighting, 16:9 landscape aspect ratio,
+
+Left side: {victim_type} stumbling backward in {emotion}, {cultural_signifier} flying off, mouth open, eyes wide, bold black outlines, high color saturation, waist-up framing with large readable facial expression, cold blue lighting on this figure,
+
+Right side: {power_figure}, a {instrument} standing beside the power figure like a loyal servant, warm golden amber lighting on this side, floating dollar signs in the golden glow,
+
+A large bold red arrow pointing from the victim toward the instrument suggesting {relationship},
+
+Bold text stacked at top of frame reading "{line_1}" in large white bold condensed all-caps font with heavy black outline stroke, the word "{red_word}" is bright red, and directly below it in smaller white text "{line_2}" with black outline, both lines tightly grouped,
+
+Simple composition, thick confident black linework, magazine cover style, dramatic contrast between cold blue victim side and warm golden power side"""
+
+# Template C required variables
+TEMPLATE_C_VARS = [
+    "victim_type", "emotion", "cultural_signifier", "power_figure",
+    "instrument", "relationship", "line_1", "red_word", "line_2",
+]
+
+
+# ---------------------------------------------------------------------------
+# Template registry
+# ---------------------------------------------------------------------------
+TEMPLATES = {
+    "template_a": {"name": "CFH Split", "prompt": TEMPLATE_A, "variables": TEMPLATE_A_VARS},
+    "template_b": {"name": "Mindplicit Banner", "prompt": TEMPLATE_B, "variables": TEMPLATE_B_VARS},
+    "template_c": {"name": "Power Dynamic", "prompt": TEMPLATE_C, "variables": TEMPLATE_C_VARS},
+}
+
+
+# ---------------------------------------------------------------------------
+# Template selection
+# ---------------------------------------------------------------------------
+
+# Keywords that trigger Template C: Power Dynamic
+_POWER_KEYWORDS = [
+    "robot", "ai replace", "monopoly", "inequality",
+    "corporate", "billionaire", "oligarch", "who owns",
+    "who controls", "who profits", "replacement",
+]
+
+# Keywords that trigger Template B: Mindplicit Banner
+_STRATEGY_KEYWORDS = [
+    "machiavelli", "strategy", "hidden", "secret",
+    "never do", "warning", "dark", "manipulation",
+    "power play", "puppet", "behind the curtain",
+]
+
+
+def select_template(topic: str, tags: list[str] = None) -> str:
+    """Select thumbnail template based on topic and tags.
+
+    Args:
+        topic: Video topic string.
+        tags: Optional list of tags for template selection.
+
+    Returns:
+        One of 'template_a', 'template_b', 'template_c'.
+    """
+    topic_lower = topic.lower()
+    tags_lower = [t.lower() for t in (tags or [])]
+    all_text = topic_lower + " " + " ".join(tags_lower)
+
+    # Template C: Power Dynamic — winners vs losers
+    if any(kw in all_text for kw in _POWER_KEYWORDS):
+        return "template_c"
+
+    # Template B: Mindplicit Banner — strategy/warning
+    if any(kw in all_text for kw in _STRATEGY_KEYWORDS):
+        return "template_b"
+
+    # Template A: CFH Split — default
+    return "template_a"

--- a/skills/video-pipeline/thumbnail_generator/test_generator.py
+++ b/skills/video-pipeline/thumbnail_generator/test_generator.py
@@ -1,0 +1,341 @@
+"""Test script for EFF Thumbnail & Title Generator.
+
+Tests template selection, title generation, prompt building, and the
+full produce_thumbnail_and_title pipeline (with API call mocked unless
+KIE_API_KEY is set).
+
+Run:
+    cd skills/video-pipeline
+    python -m thumbnail_generator.test_generator
+"""
+
+import os
+import sys
+import json
+import tempfile
+
+# Ensure parent dir is on path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from thumbnail_generator.templates import select_template, TEMPLATES, TEMPLATE_A
+from thumbnail_generator.titles import generate_title, extract_caps_word, TITLE_FORMULAS
+from thumbnail_generator.config import ASPECT_RATIO, COST_PER_IMAGE
+from thumbnail_generator.validator import validate_thumbnail
+
+
+def test_template_selection():
+    """Test that template selection logic routes correctly."""
+    print("--- Template Selection ---")
+
+    # Template C: Power Dynamic keywords
+    assert select_template("Robot AI replacement economy", ["monopoly"]) == "template_c"
+    assert select_template("Who owns the robots?") == "template_c"
+    assert select_template("corporate inequality") == "template_c"
+    print("  template_c selection: PASS")
+
+    # Template B: Mindplicit Banner keywords
+    assert select_template("Machiavelli's hidden strategy") == "template_b"
+    assert select_template("The dark manipulation") == "template_b"
+    assert select_template("Power play puppet masters", ["warning"]) == "template_b"
+    print("  template_b selection: PASS")
+
+    # Template A: Default fallback
+    assert select_template("China's economy explained") == "template_a"
+    assert select_template("Dollar crisis", ["economics"]) == "template_a"
+    print("  template_a selection (default): PASS")
+
+    print("  ALL TEMPLATE SELECTION TESTS PASSED\n")
+
+
+def test_title_generation():
+    """Test title formula generation."""
+    print("--- Title Generation ---")
+
+    # Test trap formula
+    title = generate_title("trap", {
+        "noun": "Robot",
+        "caps_word": "TRAP",
+        "parenthetical": "A 4-Stage Monopoly",
+    })
+    assert "TRAP" in title
+    assert "Robot" in title
+    assert "(A 4-Stage Monopoly)" in title
+    print(f"  trap: '{title}' - PASS")
+
+    # Test country_dollar formula
+    title = generate_title("country_dollar", {
+        "country": "China",
+        "amount": "140 Billion",
+        "noun": "Dollar",
+        "caps_word": "TRAP",
+        "parenthetical": "The Silent Economic War",
+    })
+    assert "TRAP" in title
+    assert "China" in title
+    assert "$140 Billion" in title
+    print(f"  country_dollar: '{title}' - PASS")
+
+    # Test slow_death formula
+    title = generate_title("slow_death", {
+        "caps_word": "DEATH",
+        "system": "the Dollar",
+        "parenthetical": "And Who Controls What Replaces It",
+    })
+    assert "DEATH" in title
+    assert "Dollar" in title
+    print(f"  slow_death: '{title}' - PASS")
+
+    # Test stronger_than formula
+    title = generate_title("stronger_than", {
+        "country": "Russia",
+        "caps_word": "STRONGER",
+        "parenthetical": "The Machiavellian Energy Play",
+    })
+    assert "STRONGER" in title
+    assert "Russia" in title
+    print(f"  stronger_than: '{title}' - PASS")
+
+    # Test list_warning formula
+    title = generate_title("list_warning", {
+        "number": "7",
+        "noun": "Economic",
+        "caps_word": "LIES",
+        "parenthetical": "Machiavelli Warned You",
+    })
+    assert "LIES" in title
+    assert "7" in title
+    print(f"  list_warning: '{title}' - PASS")
+
+    # Test swallowed formula
+    title = generate_title("swallowed", {
+        "entity": "Blackrock",
+        "caps_word": "SWALLOWED",
+        "target": "the Housing Market",
+        "parenthetical": "The 3-Stage Playbook",
+    })
+    assert "SWALLOWED" in title
+    assert "Blackrock" in title
+    print(f"  swallowed: '{title}' - PASS")
+
+    print("  ALL TITLE GENERATION TESTS PASSED\n")
+
+
+def test_extract_caps_word():
+    """Test CAPS word extraction from titles."""
+    print("--- CAPS Word Extraction ---")
+
+    assert extract_caps_word("The Robot TRAP Nobody Sees Coming") == "TRAP"
+    assert extract_caps_word("The Slow DEATH of the Dollar") == "DEATH"
+    assert extract_caps_word("Why Russia is STRONGER Than You Think") == "STRONGER"
+    assert extract_caps_word("How Blackrock SWALLOWED the Housing Market") == "SWALLOWED"
+    assert extract_caps_word("7 Economic LIES They Need You to Believe") == "LIES"
+    print("  ALL CAPS EXTRACTION TESTS PASSED\n")
+
+
+def test_prompt_template_filling():
+    """Test that template variables fill correctly."""
+    print("--- Prompt Template Filling ---")
+
+    vars_a = {
+        "nationality": "Chinese",
+        "worker_type": "businessman",
+        "emotion": "panicked",
+        "cultural_signifier": "a dark business suit",
+        "mouth_expression": "open in shock",
+        "secondary_element": "a massive glowing golden dollar sign",
+        "line_1": "CHINA'S $140B TRAP",
+        "red_word": "TRAP",
+        "line_2": "DOLLAR WEAPON",
+    }
+    prompt = TEMPLATE_A.format(**vars_a)
+    assert "Chinese" in prompt
+    assert "businessman" in prompt
+    assert "panicked" in prompt
+    assert "CHINA'S $140B TRAP" in prompt
+    assert "TRAP" in prompt
+    assert "DOLLAR WEAPON" in prompt
+    assert "16:9" in prompt
+    print(f"  Template A fill ({len(prompt)} chars): PASS")
+
+    from thumbnail_generator.templates import TEMPLATE_B
+    vars_b = {
+        "line_1": "THE ROBOT TRAP",
+        "red_word": "TRAP",
+        "line_2": "NOBODY SEES COMING",
+        "power_scene": "worker looking up at massive robot shadow on wall",
+        "ground_detail": "scattered tools and fallen hard hat",
+    }
+    prompt_b = TEMPLATE_B.format(**vars_b)
+    assert "THE ROBOT TRAP" in prompt_b
+    assert "worker looking up" in prompt_b
+    print(f"  Template B fill ({len(prompt_b)} chars): PASS")
+
+    from thumbnail_generator.templates import TEMPLATE_C
+    vars_c = {
+        "victim_type": "panicked blue-collar worker",
+        "emotion": "shock",
+        "cultural_signifier": "hard hat",
+        "power_figure": "calm man in dark suit in leather chair with steepled fingers",
+        "instrument": "golden glowing robot",
+        "relationship": "replacement",
+        "line_1": "MONOPOLY TRAP",
+        "red_word": "TRAP",
+        "line_2": "WHO OWNS THE ROBOTS?",
+    }
+    prompt_c = TEMPLATE_C.format(**vars_c)
+    assert "panicked blue-collar worker" in prompt_c
+    assert "golden glowing robot" in prompt_c
+    assert "replacement" in prompt_c
+    print(f"  Template C fill ({len(prompt_c)} chars): PASS")
+
+    print("  ALL TEMPLATE FILLING TESTS PASSED\n")
+
+
+def test_title_thumbnail_pairing():
+    """Test that CAPS word matches between title and thumbnail red_word."""
+    print("--- Title-Thumbnail Pairing ---")
+
+    title = generate_title("trap", {
+        "noun": "Robot",
+        "caps_word": "TRAP",
+        "parenthetical": "A 4-Stage Monopoly",
+    })
+    caps = extract_caps_word(title)
+    red_word = "TRAP"
+    assert caps == red_word, f"CAPS word '{caps}' != red_word '{red_word}'"
+    print(f"  Title: '{title}'")
+    print(f"  CAPS word: {caps}, red_word: {red_word} - MATCH")
+
+    print("  PAIRING TEST PASSED\n")
+
+
+def test_config_constants():
+    """Verify critical config values."""
+    print("--- Config Constants ---")
+
+    assert ASPECT_RATIO == "16:9", f"ASPECT_RATIO must be 16:9, got {ASPECT_RATIO}"
+    assert COST_PER_IMAGE == 0.09
+    print("  ASPECT_RATIO=16:9: PASS")
+    print("  COST_PER_IMAGE=0.09: PASS")
+    print("  CONFIG TESTS PASSED\n")
+
+
+def test_end_to_end_dry_run():
+    """Test the full pipeline without API calls (dry run).
+
+    This verifies template selection, prompt building, and title generation
+    work together. The actual API call is skipped unless KIE_API_KEY is set.
+    """
+    print("--- End-to-End Dry Run ---")
+
+    topic = "China's $140 Billion Dollar Trap"
+    tags = ["china", "dollar", "trap", "economics"]
+
+    # Step 1: Template selection
+    template_key = select_template(topic, tags)
+    print(f"  Topic: {topic}")
+    print(f"  Tags: {tags}")
+    print(f"  Selected template: {template_key}")
+    # "trap" keyword triggers template_c (power dynamic) due to "trap" not being
+    # in power keywords. Actually "dollar" and "trap" alone don't match power keywords.
+    # This should default to template_a.
+
+    # Step 2: Build prompt
+    template_vars = {
+        "nationality": "Chinese",
+        "worker_type": "businessman",
+        "emotion": "panicked",
+        "cultural_signifier": "a dark business suit",
+        "mouth_expression": "open in shock",
+        "secondary_element": "a massive glowing golden dollar sign looming behind him with yuan bills scattered in the air",
+        "line_1": "CHINA'S $140B TRAP",
+        "red_word": "TRAP",
+        "line_2": "DOLLAR WEAPON",
+    }
+    prompt = TEMPLATE_A.format(**template_vars)
+    print(f"  Prompt length: {len(prompt)} chars")
+    assert len(prompt) > 200, "Prompt too short"
+
+    # Step 3: Generate title
+    title = generate_title("country_dollar", {
+        "country": "China",
+        "amount": "140 Billion",
+        "noun": "Dollar",
+        "caps_word": "TRAP",
+        "parenthetical": "The Silent Economic War",
+    })
+    print(f"  Title: {title}")
+    caps = extract_caps_word(title)
+    assert caps == "TRAP"
+    print(f"  CAPS/red_word match: {caps} == TRAP")
+
+    # Step 4: Verify pairing
+    assert "TRAP" in prompt, "red_word TRAP must appear in prompt"
+    assert "TRAP" in title, "CAPS word TRAP must appear in title"
+    print("  Title-thumbnail pairing: VERIFIED")
+
+    print("  END-TO-END DRY RUN PASSED\n")
+
+
+def test_produce_thumbnail_and_title_integration():
+    """Full integration test — calls API only if KIE_API_KEY is set."""
+    api_key = os.environ.get("KIE_API_KEY") or os.environ.get("KIE_AI_API_KEY")
+
+    if not api_key:
+        print("--- Integration Test (SKIPPED — no API key) ---")
+        print("  Set KIE_API_KEY to run the full integration test.\n")
+        return
+
+    print("--- Integration Test (LIVE API) ---")
+    from thumbnail_generator.generator import produce_thumbnail_and_title
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = produce_thumbnail_and_title(
+            topic="China's $140 Billion Dollar Trap",
+            tags=["china", "dollar", "trap", "economics"],
+            template_vars={
+                "nationality": "Chinese",
+                "worker_type": "businessman",
+                "emotion": "panicked",
+                "cultural_signifier": "a dark business suit",
+                "mouth_expression": "open in shock",
+                "secondary_element": "a massive glowing golden dollar sign looming behind him with yuan bills scattered in the air",
+                "line_1": "CHINA'S $140B TRAP",
+                "red_word": "TRAP",
+                "line_2": "DOLLAR WEAPON",
+            },
+            title_formula="country_dollar",
+            title_vars={
+                "country": "China",
+                "amount": "140 Billion",
+                "noun": "Dollar",
+                "caps_word": "TRAP",
+                "parenthetical": "The Silent Economic War",
+            },
+            output_dir=tmpdir,
+            api_key=api_key,
+        )
+        print(f"  Result: {json.dumps(result, indent=2, default=str)}")
+        assert result["title"] is not None
+        assert result["template_used"] in ("template_a", "template_b", "template_c")
+        assert result["attempts"] >= 1
+        print("  INTEGRATION TEST PASSED\n")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("EFF Thumbnail & Title Generator — Test Suite")
+    print("=" * 60 + "\n")
+
+    test_config_constants()
+    test_template_selection()
+    test_title_generation()
+    test_extract_caps_word()
+    test_prompt_template_filling()
+    test_title_thumbnail_pairing()
+    test_end_to_end_dry_run()
+    test_produce_thumbnail_and_title_integration()
+
+    print("=" * 60)
+    print("ALL TESTS PASSED")
+    print("=" * 60)

--- a/skills/video-pipeline/thumbnail_generator/titles.py
+++ b/skills/video-pipeline/thumbnail_generator/titles.py
@@ -1,0 +1,146 @@
+"""Title formulas for Economy FastForward videos.
+
+Every title follows the structure:
+    [Main Hook — 6-8 words, ONE CAPS word] (Parenthetical Reveal)
+
+The CAPS word in the title MUST match the `red_word` in the thumbnail prompt.
+This creates visual-verbal coherence between title and thumbnail.
+
+Six formula families:
+  1. trap     — The [Noun] TRAP Nobody Sees Coming
+  2. country_dollar — [Country]'s $[Amount] [Noun] WEAPON
+  3. slow_death — The Slow DEATH of [System]
+  4. stronger_than — Why [Country] is [ADJECTIVE]er Than You Think
+  5. list_warning — [Number] [Noun] [Warning]
+  6. swallowed — How [Entity] SWALLOWED [Target]
+"""
+
+import re
+
+
+# ---------------------------------------------------------------------------
+# Title formula definitions
+# ---------------------------------------------------------------------------
+TITLE_FORMULAS = {
+    "trap": {
+        "pattern": "The {{noun}} {caps_word} Nobody Sees Coming ({{parenthetical}})",
+        "examples": [
+            "The Robot TRAP Nobody Sees Coming (A 4-Stage Monopoly)",
+            "The Dollar TRAP Nobody Sees Coming (Why Cash Is a Weapon)",
+            "The Housing TRAP Nobody Sees Coming (And Who Profits)",
+        ],
+    },
+    "country_dollar": {
+        "pattern": "{{country}}'s ${{amount}} {{noun}} {caps_word} ({{parenthetical}})",
+        "examples": [
+            "America's $34 Trillion Debt WEAPON (The Machiavellian Strategy)",
+            "China's $3 Trillion Dollar TRAP (The Silent Economic War)",
+            "Germany's $500 Billion MISTAKE (Why Green Energy Failed)",
+        ],
+    },
+    "slow_death": {
+        "pattern": "The Slow {caps_word} of {{system}} ({{parenthetical}})",
+        "examples": [
+            "The Slow DEATH of the Dollar (And Who Controls What Replaces It)",
+            "The Slow COLLAPSE of NATO (And Russia's Play to Replace It)",
+            "The Slow DEATH of the Middle Class (And Who's Engineering It)",
+        ],
+    },
+    "stronger_than": {
+        "pattern": "Why {{country}} is {caps_word} Than You Think ({{parenthetical}})",
+        "examples": [
+            "Why Russia is STRONGER Than You Think (The Machiavellian Energy Play)",
+            "Why America is WEAKER Than You Think (The Hidden Debt Pattern)",
+            "Why China is RICHER Than You Think (The Strategy Nobody Discusses)",
+        ],
+    },
+    "list_warning": {
+        "pattern": "{{number}} {{noun}} {caps_word} ({{parenthetical}})",
+        "examples": [
+            "7 Economic LIES They Need You to Believe (Machiavelli Warned You)",
+            "5 Signs Your Country's Economy is DYING (The Pattern Repeats)",
+            "9 Financial TRAPS Designed to Keep You Poor (The System Explained)",
+        ],
+    },
+    "swallowed": {
+        "pattern": "How {{entity}} {caps_word} {{target}} ({{parenthetical}})",
+        "examples": [
+            "How Blackrock SWALLOWED the Housing Market (The 3-Stage Playbook)",
+            "How AI SWALLOWED Your Job Market (The 4-Stage Monopoly Trap)",
+            "How Debt SWALLOWED the American Dream (The Machiavellian Design)",
+        ],
+    },
+}
+
+
+def generate_title(formula_key: str, title_vars: dict) -> str:
+    """Generate a title from a formula and variables.
+
+    The `title_vars` dict must contain all placeholder names used in the
+    formula pattern PLUS `caps_word` which is inserted as the ALL-CAPS word.
+
+    Args:
+        formula_key: Key from TITLE_FORMULAS (e.g. "trap", "slow_death").
+        title_vars: Dict of variables to fill the formula. Must include
+            'caps_word' for the ALL-CAPS word that matches the thumbnail
+            red_word.
+
+    Returns:
+        The formatted title string.
+
+    Raises:
+        KeyError: If formula_key is not found or required vars are missing.
+    """
+    if formula_key not in TITLE_FORMULAS:
+        raise KeyError(
+            f"Unknown title formula '{formula_key}'. "
+            f"Available: {list(TITLE_FORMULAS.keys())}"
+        )
+
+    formula = TITLE_FORMULAS[formula_key]
+    pattern = formula["pattern"]
+
+    caps_word = title_vars.get("caps_word") or title_vars.get("CAPS_WORD", "")
+    caps_word = caps_word.upper()
+
+    # First replace {caps_word} in the pattern
+    filled = pattern.replace("{caps_word}", caps_word)
+
+    # Then replace {{var}} placeholders with title_vars values
+    # Pattern uses {{var}} to distinguish from the {caps_word} placeholder
+    for key, value in title_vars.items():
+        if key in ("caps_word", "CAPS_WORD"):
+            continue
+        filled = filled.replace("{{" + key + "}}", str(value))
+
+    # Verify no unfilled placeholders remain
+    remaining = re.findall(r"\{\{(\w+)\}\}", filled)
+    if remaining:
+        raise KeyError(
+            f"Missing title variables: {remaining}. "
+            f"Provided: {list(title_vars.keys())}"
+        )
+
+    return filled
+
+
+def extract_caps_word(title: str) -> str:
+    """Extract the ALL-CAPS word from a title string.
+
+    Finds the single word that is entirely uppercase (length >= 2),
+    excluding common short words like "A", "I".
+
+    Args:
+        title: The full title string.
+
+    Returns:
+        The CAPS word, or empty string if none found.
+    """
+    # Get text before parenthetical (main hook)
+    main_hook = title.split("(")[0] if "(" in title else title
+    words = main_hook.split()
+    for word in words:
+        clean = word.strip("$,.'\"!?")
+        if len(clean) >= 2 and clean.isupper() and clean.isalpha():
+            return clean
+    return ""

--- a/skills/video-pipeline/thumbnail_generator/validator.py
+++ b/skills/video-pipeline/thumbnail_generator/validator.py
@@ -1,0 +1,30 @@
+"""Post-generation validation for EFF thumbnails.
+
+Validates thumbnail dimensions, aspect ratio, and orientation.
+Flags images for manual review when automated checks fail.
+"""
+
+from PIL import Image
+
+
+def validate_thumbnail(image_path: str) -> tuple[bool, dict]:
+    """Validate thumbnail dimensions and aspect ratio.
+
+    Args:
+        image_path: Path to the generated thumbnail image file.
+
+    Returns:
+        Tuple of (passes_all_checks: bool, check_results: dict).
+        check_results maps check name -> bool.
+    """
+    img = Image.open(image_path)
+    w, h = img.size
+
+    checks = {
+        "aspect_ratio_16_9": abs((w / h) - (16 / 9)) < 0.05,
+        "min_width_1280": w >= 1280,
+        "min_height_720": h >= 720,
+        "is_landscape": w > h,
+    }
+
+    return all(checks.values()), checks


### PR DESCRIPTION
Builds a self-contained Python module that generates thumbnails via
Nano Banana Pro (Kie.ai) and pairs them with matched YouTube titles.

Module structure:
- config.py: API endpoints, aspect ratio (16:9), polling settings
- templates.py: Three prompt templates (CFH Split, Mindplicit Banner,
  Power Dynamic) with keyword-based selection logic
- titles.py: Six title formula families with CAPS word extraction
  for title-thumbnail visual coherence
- validator.py: PIL-based dimension/aspect ratio validation
- generator.py: Main entry point with task-based API integration
  (create task -> poll -> download), retry logic, and validation
- test_generator.py: Comprehensive test suite covering template
  selection, title generation, prompt filling, and pairing rules

https://claude.ai/code/session_01XLfgbBhBAajm91uQnfy2nf