### PR TITLE
Setup daily cron jobs: 5 AM discovery + 8 AM pipeline execution

### DIFF
--- a/skills/video-pipeline/bot_healthcheck.sh
+++ b/skills/video-pipeline/bot_healthcheck.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Bot Health Check — verifies pipeline_control.py (Slack bot) is running.
+# If the bot is down, restarts it and sends a Slack alert.
+#
+# Called every 15 minutes by cron.
+# The bot MUST be running for emoji reactions on discovery messages to work.
+#
+# Logs: /tmp/pipeline-bot-health.log
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON3="$(which python3 2>/dev/null || echo python3)"
+PID_FILE="/tmp/pipeline-bot.pid"
+BOT_SCRIPT="pipeline_control.py"
+
+# Check if bot process is alive
+bot_is_running() {
+    # Check PID file first
+    if [ -f "$PID_FILE" ]; then
+        local pid
+        pid=$(cat "$PID_FILE" 2>/dev/null)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+    fi
+
+    # Fallback: check if any python process is running pipeline_control.py
+    if pgrep -f "$BOT_SCRIPT" > /dev/null 2>&1; then
+        # Update PID file with found process
+        pgrep -f "$BOT_SCRIPT" | head -1 > "$PID_FILE"
+        return 0
+    fi
+
+    return 1
+}
+
+# Send Slack alert using curl (doesn't depend on Python being working)
+send_slack_alert() {
+    local message="$1"
+    local webhook_url
+
+    # Try to read Slack webhook from .env file
+    if [ -f "$SCRIPT_DIR/../../.env" ]; then
+        local bot_token
+        bot_token=$(grep '^SLACK_BOT_TOKEN=' "$SCRIPT_DIR/../../.env" | cut -d'=' -f2- | tr -d '"' | tr -d "'")
+        local channel_id
+        channel_id=$(grep '^SLACK_CHANNEL_ID=' "$SCRIPT_DIR/../../.env" | cut -d'=' -f2- | tr -d '"' | tr -d "'" || echo "C0A9U1X8NSW")
+
+        if [ -n "$bot_token" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+                -H "Authorization: Bearer $bot_token" \
+                -H "Content-Type: application/json" \
+                -d "{\"channel\": \"${channel_id:-C0A9U1X8NSW}\", \"text\": \"$message\"}" \
+                > /dev/null 2>&1
+        fi
+    fi
+}
+
+# Main check
+if bot_is_running; then
+    echo "[$(date)] Bot is running (PID: $(cat "$PID_FILE" 2>/dev/null || echo '?'))"
+else
+    echo "[$(date)] Bot is DOWN! Attempting restart..."
+
+    # Start the bot in the background
+    cd "$SCRIPT_DIR"
+    nohup $PYTHON3 "$BOT_SCRIPT" > /tmp/pipeline-bot.log 2>&1 &
+    NEW_PID=$!
+    echo "$NEW_PID" > "$PID_FILE"
+
+    # Wait a moment and verify it started
+    sleep 3
+
+    if kill -0 "$NEW_PID" 2>/dev/null; then
+        echo "[$(date)] Bot restarted successfully (PID: $NEW_PID)"
+        send_slack_alert ":warning: *Pipeline Bot Restarted*\nThe Slack bot (pipeline_control.py) was found dead and has been auto-restarted.\nEmoji reactions on discovery messages should work again.\nPID: $NEW_PID"
+    else
+        echo "[$(date)] FAILED to restart bot!"
+        send_slack_alert ":rotating_light: *Pipeline Bot FAILED to Restart*\nThe Slack bot is down and could not be restarted automatically.\nEmoji reactions on discovery messages will NOT work.\nPlease SSH in and start it manually: cd $SCRIPT_DIR && python3 pipeline_control.py"
+    fi
+fi

--- a/skills/video-pipeline/discovery_tracker.py
+++ b/skills/video-pipeline/discovery_tracker.py
@@ -1,0 +1,101 @@
+"""Shared discovery message tracker — persists Slack message → idea mappings.
+
+When the cron job (pipeline.py --discover) posts discovery ideas to Slack,
+it saves the message timestamp and idea data here. When the Slack bot
+(pipeline_control.py) receives an emoji reaction, it reads from here to
+find which ideas correspond to which message.
+
+This bridges the gap between the cron process and the long-running Slack bot.
+
+Storage: /tmp/pipeline-discovery-messages.json
+"""
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+TRACKER_FILE = "/tmp/pipeline-discovery-messages.json"
+
+# Auto-expire entries older than 48 hours (user should have picked by then)
+EXPIRY_SECONDS = 48 * 3600
+
+
+def _load_tracker() -> dict:
+    """Load the tracker file, returning empty dict if missing/corrupt."""
+    try:
+        if os.path.exists(TRACKER_FILE):
+            with open(TRACKER_FILE, "r") as f:
+                data = json.load(f)
+            # Prune expired entries
+            now = time.time()
+            pruned = {
+                ts: entry for ts, entry in data.items()
+                if now - entry.get("created_at", 0) < EXPIRY_SECONDS
+            }
+            return pruned
+        return {}
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Could not load tracker file: {e}")
+        return {}
+
+
+def _save_tracker(data: dict):
+    """Write tracker data to file."""
+    try:
+        with open(TRACKER_FILE, "w") as f:
+            json.dump(data, f, indent=2)
+    except OSError as e:
+        logger.error(f"Could not save tracker file: {e}")
+
+
+def save_discovery_message(
+    message_ts: str,
+    ideas: list[dict],
+    airtable_record_ids: list[Optional[str]] = None,
+):
+    """Save a discovery message for later reaction handling.
+
+    Args:
+        message_ts: Slack message timestamp (unique ID)
+        ideas: List of idea dicts from discovery scanner
+        airtable_record_ids: List of Airtable record IDs (parallel to ideas)
+    """
+    data = _load_tracker()
+    data[message_ts] = {
+        "ideas": ideas,
+        "airtable_record_ids": airtable_record_ids or [],
+        "created_at": time.time(),
+    }
+    _save_tracker(data)
+    logger.info(f"Saved discovery message ts={message_ts} with {len(ideas)} ideas")
+
+
+def get_discovery_message(message_ts: str) -> Optional[dict]:
+    """Get a tracked discovery message by its Slack timestamp.
+
+    Args:
+        message_ts: Slack message timestamp
+
+    Returns:
+        Dict with 'ideas' and 'airtable_record_ids', or None if not found
+    """
+    data = _load_tracker()
+    return data.get(message_ts)
+
+
+def remove_discovery_message(message_ts: str):
+    """Remove a tracked discovery message (after approval).
+
+    Args:
+        message_ts: Slack message timestamp
+    """
+    data = _load_tracker()
+    if message_ts in data:
+        del data[message_ts]
+        _save_tracker(data)
+        logger.info(f"Removed discovery message ts={message_ts}")

--- a/skills/video-pipeline/setup_cron.sh
+++ b/skills/video-pipeline/setup_cron.sh
@@ -3,14 +3,14 @@
 #
 # Usage: bash setup_cron.sh
 #
-# This installs two cron jobs:
-#   1. 5:00 AM — Daily idea discovery scan (finds new video ideas from headlines)
-#              Sends interactive Slack message with emoji reactions for idea selection
-#   2. 8:00 AM — Daily pipeline queue run (processes all queued videos to completion)
-#              Scans all tables, runs every stage from scripting through to Ready To Render
+# This installs four cron jobs:
+#   1. 5:00 AM  — Daily idea discovery scan (posts ideas to Slack for approval)
+#   2. 8:00 AM  — Daily pipeline queue run (processes all stages through to Ready To Render)
+#   3. Every 15 min — Bot health check (restarts Slack bot if it died, notifies you)
+#   4. Every 30 min — Approval watcher (catches manual Airtable approvals)
 #
 # Times are in the system's local timezone.
-# Logs are written to /tmp/pipeline-discover.log and /tmp/pipeline-queue.log
+# Logs are written to /tmp/pipeline-*.log
 #
 # To view installed cron jobs: crontab -l
 # To remove all cron jobs:    crontab -r
@@ -39,18 +39,29 @@ CRON_ENTRIES=$(cat <<EOF
 # 5:00 AM — Daily idea discovery scan
 # Pulls latest code, then runs discovery scanner to find new video ideas
 # Posts interactive Slack message with emoji reactions so you wake up and choose an idea
-0 5 * * * cd $REPO_DIR && git pull origin main --ff-only >> /tmp/pipeline-discover.log 2>&1; cd $PIPELINE_DIR && $PYTHON3 pipeline.py --discover >> /tmp/pipeline-discover.log 2>&1
+# Timeout: 10 minutes max (discovery should take <2 min)
+0 5 * * * cd $REPO_DIR && git pull origin main --ff-only >> /tmp/pipeline-discover.log 2>&1; cd $PIPELINE_DIR && timeout 600 $PYTHON3 pipeline.py --discover >> /tmp/pipeline-discover.log 2>&1
 
 # 8:00 AM — Daily pipeline queue run
-# Scans all Airtable tables and processes every video through ALL stages:
+# First processes any pending approvals, then runs all stages:
 # Ready For Scripting → Script → Voice → Image Prompts → Images → Thumbnail → Ready To Render
-# Continues until all queued work is complete
-0 8 * * * cd $REPO_DIR && git pull origin main --ff-only >> /tmp/pipeline-queue.log 2>&1; cd $PIPELINE_DIR && $PYTHON3 pipeline.py --run-queue >> /tmp/pipeline-queue.log 2>&1
+# Timeout: 4 hours max (image generation can be slow)
+0 8 * * * cd $REPO_DIR && git pull origin main --ff-only >> /tmp/pipeline-queue.log 2>&1; cd $PIPELINE_DIR && timeout 14400 $PYTHON3 pipeline.py --run-queue >> /tmp/pipeline-queue.log 2>&1
+
+# Every 15 min — Slack bot health check
+# Verifies pipeline_control.py is running. If it died, restarts it and sends alert.
+# Without the bot, emoji reactions on discovery messages won't work.
+*/15 * * * * cd $PIPELINE_DIR && bash bot_healthcheck.sh >> /tmp/pipeline-bot-health.log 2>&1
+
+# Every 30 min — Approval watcher
+# Catches ideas manually approved in Airtable (status set to "Approved")
+# Runs research and advances to "Ready For Scripting" automatically
+*/30 * * * * cd $PIPELINE_DIR && timeout 600 $PYTHON3 approval_watcher.py >> /tmp/pipeline-approval.log 2>&1
 EOF
 )
 
 # Preserve any existing cron entries not from this script
-EXISTING=$(crontab -l 2>/dev/null | grep -v "pipeline-discover\|pipeline-queue\|Pipeline Cron\|setup_cron\|Daily idea discovery\|Daily pipeline queue" || true)
+EXISTING=$(crontab -l 2>/dev/null | grep -v "pipeline-discover\|pipeline-queue\|pipeline-bot-health\|pipeline-approval\|Pipeline Cron\|setup_cron\|Daily idea\|Daily pipeline\|bot health\|Approval watcher" || true)
 
 # Install combined crontab
 if [ -n "$EXISTING" ]; then
@@ -62,12 +73,21 @@ fi
 echo "  ✅ Cron jobs installed!"
 echo ""
 echo "  Scheduled:"
-echo "    • 5:00 AM daily → python3 pipeline.py --discover"
-echo "    • 8:00 AM daily → python3 pipeline.py --run-queue"
+echo "    • 5:00 AM daily    → Discovery scan (post ideas to Slack)"
+echo "    • 8:00 AM daily    → Pipeline queue (process all stages to render)"
+echo "    • Every 15 min     → Bot health check (auto-restart if down)"
+echo "    • Every 30 min     → Approval watcher (catch manual approvals)"
+echo ""
+echo "  Timeouts:"
+echo "    • Discovery: 10 min max"
+echo "    • Pipeline:  4 hours max"
+echo "    • Approval:  10 min max"
 echo ""
 echo "  Logs:"
 echo "    • /tmp/pipeline-discover.log"
 echo "    • /tmp/pipeline-queue.log"
+echo "    • /tmp/pipeline-bot-health.log"
+echo "    • /tmp/pipeline-approval.log"
 echo ""
 echo "  Verify with: crontab -l"
 echo "=================================================="


### PR DESCRIPTION
- Fix cron schedule: 5:00 AM daily discovery scan, 8:00 AM pipeline queue run
- Discovery cron now posts interactive Slack message with emoji reactions
  so user wakes up and picks an idea + specific title by clicking a number
- Each title option gets its own numbered reaction (not just per-idea)
- Add discovery_tracker.py for persistent message tracking between
  cron process and Slack bot (shared via /tmp JSON file)
- Pipeline queue runner now sends Slack summary of what's in the pipeline
  at start and detailed completion report at end
- Update pipeline_control.py cron commands to match new 5 AM / 8 AM times
- Both Slack bot and cron paths handle the new title selection flow

https://claude.ai/code/session_01Dchf8WHREJcdzAaNimRYXL