### PR TITLE
Enforce concrete visual descriptions and strip duplicate style language

### DIFF
--- a/skills/video-pipeline/brief_translator/prompts/scene_expand.txt
+++ b/skills/video-pipeline/brief_translator/prompts/scene_expand.txt
@@ -49,8 +49,10 @@ For EACH scene, provide:
    "slow pan right" | "slow drift up" | "slow drift down")
 9. mood (1-2 word mood descriptor, e.g., "tension", "revelation", "dread",
    "hope", "foreboding", "triumph")
-10. description (1-2 sentences describing the PRIMARY visual concept for
-    this segment — be SPECIFIC about setting, lighting, objects)
+10. description (20-35 words describing the PRIMARY visual concept for
+    this segment — be SPECIFIC about setting, people, objects. Do NOT
+    include lighting, camera, or style language — those are added
+    automatically by the style system)
 
 CRITICAL RULES:
 - Each scene's narration_text must be an exact, continuous excerpt from
@@ -65,6 +67,167 @@ CRITICAL RULES:
 - First scene and last scene must be dossier style
 - Never more than 4 consecutive scenes of the same style
 - Vary compositions — don't put 3+ of the same composition in a row
+
+--- VISUAL DESCRIPTION RULES ---
+
+CRITICAL RULE — THE DOCUMENTARY CAMERA TEST:
+Before writing any scene description, ask yourself: "Could a real documentary
+camera crew physically go to a location and film this scene?"
+If YES → good description. Write it.
+If NO → bad description. Rewrite it.
+
+This means:
+- A camera crew CAN film a government building at night → ✅
+- A camera crew CANNOT film "rivers of liquid capital" → ❌
+- A camera crew CAN film a boardroom with documents on the table → ✅
+- A camera crew CANNOT film "power radiating from a chess piece" → ❌
+- A camera crew CAN film a trader staring at screens in a dark office → ✅
+- A camera crew CANNOT film "data streams flowing between buildings" → ❌
+- A camera crew CAN film a military convoy on a highway at dawn → ✅
+- A camera crew CANNOT film "invisible hands manipulating puppet strings" → ❌
+
+The ONLY exception is Schema-style images, which intentionally include data
+overlay elements (glowing network lines, hierarchy charts). But even Schema
+images must have a real, filmable environment as the base layer. The data
+overlay is the only non-real element — everything else in the scene must pass
+the documentary camera test.
+
+NEVER use these patterns in scene descriptions:
+
+LITERAL METAPHOR VISUALIZATION:
+- "rivers/streams/flows of money/capital/data/power"
+- "liquid gold/silver flowing through" anything
+- "chains/strings/threads connecting" abstract concepts
+- "cracks/fractures forming in" abstract things (economies, alliances)
+- "shadows/darkness consuming/engulfing" abstract things
+- "light/energy/power radiating/emanating from" objects
+- "invisible hands/forces manipulating" anything
+- "walls/barriers crumbling/dissolving"
+- "scales/balance tipping" (unless it's a literal physical scale)
+- "puppet strings" on anyone
+- "chess pieces" unless the scene is literally about someone playing chess
+  or there's a physical chess set in the scene
+
+ABSTRACT MACHINERY:
+- "machinery of government/state/power"
+- "gears/cogs/mechanisms of" anything abstract
+- "pressure gauges displaying" anything metaphorical
+- "pipelines/valves of capital/money/influence"
+- "engines/turbines of economic growth"
+- Any industrial equipment used as metaphor for non-industrial concepts
+
+SURREAL/SCI-FI ELEMENTS (in Dossier and Echo styles):
+- "transparent sections" showing anything inside
+- "holographic" anything (except in Schema style)
+- "glowing" objects that wouldn't glow in real life
+- "floating" objects
+- "ethereal/spectral/ghostly" anything
+- "morphing/transforming" between things
+- Objects that are impossibly large or small for dramatic effect
+
+WHAT TO SHOW — THE SUBSTITUTION TABLE:
+When the narration discusses abstract concepts, show the CONCRETE REALITY
+behind them. Here is how to translate abstract narration into filmable scenes:
+
+| Narration About...      | DON'T Show                          | DO Show                                                                                      |
+|-------------------------|-------------------------------------|----------------------------------------------------------------------------------------------|
+| Money/capital moving    | Flowing liquid gold, money rivers   | The institution doing it: central bank building, trading floor, vault, wire transfer terminal |
+| Power consolidation     | Glowing energy, crushing fists      | The person/building: figure at a desk, corporate HQ at night, signing ceremony               |
+| Economic pressure       | Cracking structures, weights        | The human impact: empty factory floor, closed shopfronts, long queues, cargo ships idle       |
+| Political manipulation  | Puppet strings, chess pieces        | The setting: backroom meeting, whispered conversation, phone call in a dark office            |
+| Military threat         | Glowing weapons, red warning lights | The hardware: carrier group at sea, jets on a runway, troops at a border                     |
+| Data/surveillance       | Matrix-style data streams           | The equipment: server room, CCTV bank, analyst at monitors, antenna array                    |
+| Historical parallel     | Time portals, morphing timelines    | The historical scene itself: the actual place, the actual people, the actual moment           |
+| Systemic risk           | Crumbling buildings, dominoes       | The indicator: a specific chart on a screen, an emergency meeting, empty trading floor        |
+| Secrecy/corruption      | Shadowy demons, dark clouds         | The evidence: a locked door, a shredder, a burner phone, a meeting in an unusual location    |
+| Alliance/partnership    | Hands merging, bridges forming      | The moment: handshake at a podium, joint press conference, flags side by side                 |
+
+The principle: show THE PEOPLE, THE PLACES, and THE OBJECTS involved in the
+real-world event. Not the abstract concept itself.
+
+SCENE DESCRIPTION FORMAT RULES:
+
+Your scene descriptions should ONLY describe:
+- WHAT is in the scene (people, objects, environment, setting)
+- WHERE the scene takes place (specific location)
+- WHAT is happening (action, if any)
+- KEY VISUAL DETAILS (specific objects, textures, materials, weather)
+
+Your scene descriptions must NEVER include:
+- Lighting direction (e.g., "Rembrandt lighting", "dramatic side lighting")
+- Camera/lens references (e.g., "shot on Arri Alexa", "35mm lens")
+- Color grading language (e.g., "desaturated palette", "cold teal accent")
+- Depth of field references (e.g., "shallow depth of field", "bokeh")
+- Film stock references (e.g., "film grain", "cinematic")
+- Composition terminology (e.g., "rule of thirds", "leading lines")
+- Mood/atmosphere adjectives (e.g., "moody", "ominous", "foreboding")
+- Art style references (e.g., "photorealistic", "documentary style")
+
+These elements are ALL handled by the style suffix system. The prompt builder
+appends them automatically. If you include them in the scene description, they
+will be duplicated in the final prompt and degrade image quality.
+
+GOOD scene description: "The People's Bank of China headquarters building at
+night, massive modernist facade, a single illuminated floor near the top, wet
+pavement reflecting streetlights below, dark government sedans parked in a row"
+
+BAD scene description: "Cinematic photorealistic shot of the People's Bank of
+China building, dramatic Rembrandt lighting, moody atmosphere, cold teal accent
+lights on wet pavement, shallow depth of field, shot on Arri Alexa, desaturated
+color palette with dark government sedans"
+
+The good description gives the image model CONTENT to render. The bad
+description wastes tokens on style instructions that will be appended anyway,
+and confuses the model with duplicate/conflicting directives.
+
+KEEP SCENE DESCRIPTIONS BETWEEN 20-35 WORDS.
+
+Be specific but concise. Every word must add visual information. Remove any word
+that doesn't change what the image looks like.
+
+TOO LONG (58 words): "A vast underground command center with rows of curved
+display screens showing financial data and world maps, a single figure in a dark
+suit standing with hands clasped behind their back, viewing the screens from a
+raised platform, banks of smaller monitors flanking both sides of the room,
+cables running across the ceiling, emergency lights on the walls"
+
+JUST RIGHT (28 words): "A figure in a dark suit stands on a raised platform in
+an underground command center, facing a massive curved wall of financial data
+screens and world maps"
+
+Both produce virtually the same image. The short version lets the model fill in
+environmental details naturally, which usually looks better than over-specifying
+every element.
+
+MATCH YOUR DESCRIPTION TO THE COMPOSITION HINT:
+
+- "wide": Describe the full environment. The figure (if present) is
+  small in frame. Emphasize architecture, landscape, or room scale.
+  Start the description with the environment, not the person.
+
+- "medium": Describe a person in context. Figure visible from roughly
+  waist up. Include enough environment to establish location.
+  Start the description with the person, then their setting.
+
+- "closeup": Describe a specific detail. Hands, objects, documents,
+  screens, faces (partially shadowed). No full environment.
+  Start the description with the specific object or detail.
+
+- "environmental": No human figure at all. Just the space — an empty
+  room, a building exterior, a landscape, objects on a desk.
+  Describe only the environment and objects.
+
+- "portrait": A person from chest up, face partially visible or in
+  shadow. Emphasis on posture, clothing, silhouette.
+  Start the description with the person's appearance and posture.
+
+- "overhead": Bird's-eye or high-angle view looking down. Maps,
+  documents on a table, a city from above, a room from ceiling height.
+  Describe what's visible from above.
+
+- "low_angle": Looking up at something imposing. A building, a figure
+  on a stage, a monument, a tall structure.
+  Describe what looms above the camera.
 
 Output as a JSON object with nested acts:
 
@@ -88,7 +251,7 @@ Output as a JSON object with nested acts:
           "composition": "wide",
           "ken_burns": "slow zoom in",
           "mood": "tension",
-          "description": "A lone figure in a dark suit stands before floor-to-ceiling windows overlooking a city at night, cold teal city lights reflecting on the glass"
+          "description": "A lone figure in a dark suit stands before floor-to-ceiling windows overlooking a city skyline at night, city lights reflecting on the glass"
         }}
       ]
     }}


### PR DESCRIPTION
## Summary
This PR significantly strengthens the visual description guidelines for the scene expansion prompt and adds runtime safeguards to prevent style language duplication in generated image prompts.

## Key Changes

**Prompt Updates (`scene_expand.txt`):**
- Tightened description length requirement from "1-2 sentences" to "20-35 words" for consistency and conciseness
- Added comprehensive "VISUAL DESCRIPTION RULES" section with the "Documentary Camera Test" — a critical principle that scene descriptions must depict what a real camera crew could physically film
- Provided extensive examples of anti-patterns to avoid:
  - Literal metaphor visualizations (e.g., "rivers of capital", "puppet strings")
  - Abstract machinery metaphors (e.g., "gears of government")
  - Surreal/sci-fi elements inappropriate for most styles
- Added a "Substitution Table" mapping abstract narration concepts to concrete, filmable alternatives (e.g., show a trading floor instead of "flowing liquid gold")
- Clarified what descriptions should and must NOT include (no lighting, camera, color grading, composition terminology, or mood adjectives — these are handled by the style system)
- Added composition-specific guidance for how to structure descriptions based on the composition hint (wide, medium, closeup, environmental, portrait, overhead, low_angle)
- Updated example description to remove style language ("cold teal city lights" → "city lights")

**Code Changes (`prompt_builder.py`):**
- Added `_STYLE_STRIP_PATTERNS` regex list to detect and remove common style/lighting/camera language patterns that may leak into scene descriptions
- Implemented `_strip_style_language()` function to clean descriptions before appending style suffixes, preventing duplication and conflicting directives
- Integrated stripping into `build_prompt()` to automatically clean all scene descriptions
- Patterns cover: lighting terminology, camera/lens references, color grading, depth of field, film stock, composition terminology, and style meta-language

## Implementation Details
The regex-based stripping acts as a safety net to enforce the prompt guidelines at runtime. Even if the LLM includes style language in descriptions, it will be removed before the final prompt is constructed, ensuring the image model receives clean content descriptions without duplicate or conflicting style directives.

https://claude.ai/code/session_01JZvBup4qTDqT4gjN75rjSc