### PR TITLE
feat: Add audio_sync module for Whisper-driven image timing

### DIFF
--- a/skills/video-pipeline/audio_sync/__init__.py
+++ b/skills/video-pipeline/audio_sync/__init__.py
@@ -1,0 +1,208 @@
+"""
+audio_sync — Whisper-driven image timing for Remotion.
+
+High-level API consumed by the pipeline orchestrator::
+
+    from audio_sync import AudioSyncPipeline
+
+    sync = AudioSyncPipeline()
+    words       = sync.transcribe(audio_path)
+    aligned     = sync.align(scene_list, words)
+    timed       = sync.adjust_timing(aligned)
+    config      = sync.generate_render_config(video_id, audio_path, timed, image_dir)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .transcriber import (
+    WordTimestamp,
+    transcribe,
+    transcribe_local,
+    transcribe_api,
+    extract_words,
+    save_whisper_raw,
+    load_whisper_raw,
+)
+from .aligner import (
+    align_scenes_to_timestamps,
+    validate_alignment,
+)
+from .timing_adjuster import adjust_timing
+from .transition_engine import assign_transitions
+from .ken_burns_calculator import assign_ken_burns
+from .render_config_writer import (
+    build_render_config,
+    write_render_config,
+    save_scene_timing,
+)
+from .config import DEFAULT_WHISPER_MODEL
+
+
+class AudioSyncPipeline:
+    """
+    End-to-end orchestrator for the audio-sync pipeline.
+
+    Wraps transcription, alignment, timing adjustment, transition
+    assignment, Ken Burns calculation, and render config generation
+    into a simple procedural API.
+    """
+
+    def __init__(
+        self,
+        *,
+        use_api: bool = False,
+        whisper_model: str = DEFAULT_WHISPER_MODEL,
+    ) -> None:
+        self.use_api = use_api
+        self.whisper_model = whisper_model
+
+    # ------------------------------------------------------------------
+    # Step 1 — Transcribe
+    # ------------------------------------------------------------------
+
+    def transcribe(
+        self,
+        audio_path: str,
+        cache_dir: str | Path | None = None,
+    ) -> list[WordTimestamp]:
+        """Run Whisper on *audio_path* and return word timestamps."""
+        return transcribe(
+            audio_path,
+            use_api=self.use_api,
+            model_size=self.whisper_model,
+            cache_dir=cache_dir,
+        )
+
+    # ------------------------------------------------------------------
+    # Step 2 — Align
+    # ------------------------------------------------------------------
+
+    def align(
+        self,
+        scene_list: list[dict[str, Any]],
+        whisper_words: list[WordTimestamp],
+    ) -> list[dict[str, Any]]:
+        """Match each scene's script_excerpt to word timestamps."""
+        aligned = align_scenes_to_timestamps(scene_list, whisper_words)
+        report = validate_alignment(aligned)
+        self._last_alignment_report = report
+        return aligned
+
+    # ------------------------------------------------------------------
+    # Step 3 — Adjust timing
+    # ------------------------------------------------------------------
+
+    def adjust_timing(
+        self,
+        aligned_scenes: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Apply pre-roll, post-hold, min/max display, transitions, Ken Burns."""
+        scenes = adjust_timing(aligned_scenes)
+        scenes = assign_transitions(scenes)
+        scenes = assign_ken_burns(scenes)
+        return scenes
+
+    # ------------------------------------------------------------------
+    # Step 4 — Generate render config
+    # ------------------------------------------------------------------
+
+    def generate_render_config(
+        self,
+        video_id: str,
+        audio_path: str,
+        scenes: list[dict[str, Any]],
+        image_dir: str,
+        output_dir: str | Path | None = None,
+    ) -> dict[str, Any]:
+        """
+        Build and optionally persist the render config.
+
+        If *output_dir* is provided the following files are written::
+
+            {output_dir}/
+            ├── scene_timing.json     # intermediate debug data
+            └── render_config.json    # final config for Remotion
+        """
+        config = build_render_config(
+            video_id=video_id,
+            audio_path=audio_path,
+            scenes=scenes,
+            image_dir=image_dir,
+        )
+
+        if output_dir is not None:
+            out = Path(output_dir)
+            save_scene_timing(scenes, out / "scene_timing.json")
+            write_render_config(config, out / "render_config.json")
+
+        return config
+
+    # ------------------------------------------------------------------
+    # Convenience — run everything
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        audio_path: str,
+        scene_list: list[dict[str, Any]],
+        video_id: str,
+        image_dir: str,
+        timing_dir: str | Path | None = None,
+    ) -> dict[str, Any]:
+        """
+        Execute the full pipeline: transcribe -> align -> adjust -> config.
+
+        Args:
+            audio_path: Path to the narration audio (.mp3/.wav).
+            scene_list: List of scene dicts (must contain ``script_excerpt``).
+            video_id: Unique video identifier.
+            image_dir: Directory containing generated scene images.
+            timing_dir: Optional directory for caching Whisper output
+                and writing the render config.
+
+        Returns:
+            The render configuration dict.
+        """
+        # Transcribe
+        words = self.transcribe(audio_path, cache_dir=timing_dir)
+
+        # Align
+        aligned = self.align(scene_list, words)
+
+        # Adjust timing + transitions + Ken Burns
+        timed = self.adjust_timing(aligned)
+
+        # Build render config
+        config = self.generate_render_config(
+            video_id=video_id,
+            audio_path=audio_path,
+            scenes=timed,
+            image_dir=image_dir,
+            output_dir=timing_dir,
+        )
+
+        return config
+
+
+__all__ = [
+    "AudioSyncPipeline",
+    "WordTimestamp",
+    "transcribe",
+    "transcribe_local",
+    "transcribe_api",
+    "extract_words",
+    "save_whisper_raw",
+    "load_whisper_raw",
+    "align_scenes_to_timestamps",
+    "validate_alignment",
+    "adjust_timing",
+    "assign_transitions",
+    "assign_ken_burns",
+    "build_render_config",
+    "write_render_config",
+    "save_scene_timing",
+]

--- a/skills/video-pipeline/audio_sync/aligner.py
+++ b/skills/video-pipeline/audio_sync/aligner.py
@@ -1,0 +1,245 @@
+"""
+Scene-to-timestamp alignment.
+
+Matches each scene's ``script_excerpt`` to a span of Whisper word
+timestamps using sequential fuzzy matching.
+"""
+
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+from typing import Any
+
+from .config import MIN_MATCH_RATIO, SEARCH_WINDOW_MULTIPLIER
+from .transcriber import WordTimestamp
+
+
+# ---------------------------------------------------------------------------
+# Text normalisation
+# ---------------------------------------------------------------------------
+
+def normalize_text(text: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace."""
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Core alignment
+# ---------------------------------------------------------------------------
+
+def align_scenes_to_timestamps(
+    scenes: list[dict[str, Any]],
+    whisper_words: list[WordTimestamp],
+    min_match_ratio: float = MIN_MATCH_RATIO,
+) -> list[dict[str, Any]]:
+    """
+    Sequentially align each scene's ``script_excerpt`` to a span of
+    Whisper word timestamps.
+
+    Key insight: scenes are **in order**.  Scene 1's text comes before
+    scene 2's in the audio so we only need to search forward from the
+    last match.
+
+    Returns:
+        Copy of *scenes* with ``start_time``, ``end_time``,
+        ``alignment_score``, ``alignment_method``, ``word_count``,
+        and ``duration`` added.
+    """
+    word_pointer = 0
+    aligned: list[dict[str, Any]] = []
+
+    for scene in scenes:
+        excerpt = scene.get("script_excerpt", "") or ""
+        excerpt_words = normalize_text(excerpt).split()
+        excerpt_len = len(excerpt_words)
+
+        if excerpt_len == 0:
+            aligned.append({
+                **scene,
+                "start_time": None,
+                "end_time": None,
+                "alignment_method": "no_narration",
+            })
+            continue
+
+        # Search forward from current pointer
+        best_start = word_pointer
+        best_score: float = 0.0
+
+        search_limit = min(
+            word_pointer + excerpt_len * SEARCH_WINDOW_MULTIPLIER,
+            len(whisper_words),
+        )
+
+        for i in range(word_pointer, search_limit):
+            span = whisper_words[i: i + excerpt_len]
+            if len(span) < excerpt_len:
+                break
+
+            whisper_text = " ".join(normalize_text(w.word) for w in span)
+            excerpt_text = " ".join(excerpt_words)
+
+            score = SequenceMatcher(None, excerpt_text, whisper_text).ratio()
+
+            if score > best_score:
+                best_score = score
+                best_start = i
+
+        if best_score >= min_match_ratio:
+            match_end = min(best_start + excerpt_len - 1, len(whisper_words) - 1)
+
+            aligned.append({
+                **scene,
+                "start_time": whisper_words[best_start].start,
+                "end_time": whisper_words[match_end].end,
+                "alignment_score": round(best_score, 4),
+                "alignment_method": "fuzzy_match",
+                "word_count": excerpt_len,
+                "duration": round(
+                    whisper_words[match_end].end - whisper_words[best_start].start, 4
+                ),
+            })
+            word_pointer = match_end + 1
+        else:
+            aligned.append({
+                **scene,
+                "start_time": None,
+                "end_time": None,
+                "alignment_score": round(best_score, 4),
+                "alignment_method": "failed",
+            })
+
+    # Fix failed alignments by interpolation
+    aligned = interpolate_failed_alignments(aligned)
+    return aligned
+
+
+# ---------------------------------------------------------------------------
+# Interpolation for failed alignments
+# ---------------------------------------------------------------------------
+
+def interpolate_failed_alignments(
+    scenes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    For scenes that failed to align, estimate timing by interpolating
+    between the nearest successfully aligned neighbours.
+    """
+    for i, scene in enumerate(scenes):
+        if scene.get("start_time") is not None:
+            continue
+        # Don't overwrite intentional no-narration scenes
+        if scene.get("alignment_method") == "no_narration":
+            continue
+
+        # Find previous aligned end
+        prev_end = 0.0
+        for j in range(i - 1, -1, -1):
+            if scenes[j].get("end_time") is not None:
+                prev_end = scenes[j]["end_time"]
+                break
+
+        # Find next aligned start
+        next_start = prev_end + 10.0  # fallback
+        for j in range(i + 1, len(scenes)):
+            if scenes[j].get("start_time") is not None:
+                next_start = scenes[j]["start_time"]
+                break
+
+        # Count consecutive unaligned scenes in this gap
+        gap_count = 0
+        for j in range(i, len(scenes)):
+            if scenes[j].get("start_time") is not None:
+                break
+            gap_count += 1
+
+        gap_duration = next_start - prev_end
+        segment_duration = gap_duration / max(gap_count, 1)
+
+        position_in_gap = 0
+        for j in range(i, i + gap_count):
+            scenes[j]["start_time"] = round(prev_end + position_in_gap * segment_duration, 4)
+            scenes[j]["end_time"] = round(prev_end + (position_in_gap + 1) * segment_duration, 4)
+            scenes[j]["alignment_method"] = "interpolated"
+            scenes[j]["duration"] = round(segment_duration, 4)
+            position_in_gap += 1
+
+    return scenes
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_alignment(scenes: list[dict[str, Any]]) -> dict[str, Any]:
+    """Check alignment quality and flag issues."""
+    issues: list[str] = []
+
+    # 1. No overlapping timestamps
+    for i in range(len(scenes) - 1):
+        cur_end = scenes[i].get("end_time")
+        nxt_start = scenes[i + 1].get("start_time")
+        if cur_end is not None and nxt_start is not None and cur_end > nxt_start + 0.05:
+            issues.append(
+                f"Scene {scenes[i].get('scene_number')} overlaps with "
+                f"scene {scenes[i + 1].get('scene_number')}: "
+                f"{cur_end:.2f} > {nxt_start:.2f}"
+            )
+
+    # 2. No gaps larger than 3 seconds
+    for i in range(len(scenes) - 1):
+        cur_end = scenes[i].get("end_time")
+        nxt_start = scenes[i + 1].get("start_time")
+        if cur_end is not None and nxt_start is not None:
+            gap = nxt_start - cur_end
+            if gap > 3.0:
+                issues.append(
+                    f"Gap of {gap:.1f}s between scene "
+                    f"{scenes[i].get('scene_number')} and "
+                    f"{scenes[i + 1].get('scene_number')}"
+                )
+
+    # 3. Alignment score distribution
+    scores = [
+        s.get("alignment_score", 0)
+        for s in scenes
+        if s.get("alignment_method") == "fuzzy_match"
+    ]
+    avg_score = sum(scores) / len(scores) if scores else 0
+    low_scores = [s for s in scores if s < 0.7]
+
+    # 4. Alignment method counts
+    methods: dict[str, int] = {}
+    for s in scenes:
+        m = s.get("alignment_method", "unknown")
+        methods[m] = methods.get(m, 0) + 1
+
+    # 5. Total duration
+    last_end = 0.0
+    for s in reversed(scenes):
+        if s.get("end_time") is not None:
+            last_end = s["end_time"]
+            break
+
+    quality = "good"
+    if len(issues) > 0 or len(low_scores) >= 5:
+        quality = "acceptable" if len(issues) < 5 else "needs_review"
+
+    return {
+        "total_scenes": len(scenes),
+        "aligned_fuzzy": methods.get("fuzzy_match", 0),
+        "aligned_interpolated": methods.get("interpolated", 0),
+        "failed": methods.get("failed", 0),
+        "no_narration": methods.get("no_narration", 0),
+        "avg_alignment_score": round(avg_score, 3),
+        "low_confidence_count": len(low_scores),
+        "total_duration": round(last_end, 2),
+        "overlaps": sum(1 for i in issues if "overlaps" in i),
+        "large_gaps": sum(1 for i in issues if "Gap" in i),
+        "issues": issues,
+        "quality": quality,
+    }

--- a/skills/video-pipeline/audio_sync/config.py
+++ b/skills/video-pipeline/audio_sync/config.py
@@ -1,0 +1,78 @@
+"""
+Configuration constants for the audio sync pipeline.
+
+Timing rules, thresholds, and Ken Burns defaults used across
+all audio_sync submodules.
+"""
+
+# ---------------------------------------------------------------------------
+# Timing rules (seconds)
+# ---------------------------------------------------------------------------
+MIN_DISPLAY_SECONDS: float = 3.0
+"""No image shown for less than 3 seconds."""
+
+MAX_DISPLAY_SECONDS: float = 18.0
+"""No image shown for more than 18 seconds."""
+
+PRE_ROLL_SECONDS: float = 0.3
+"""Image appears 0.3 s BEFORE its narration starts."""
+
+POST_HOLD_SECONDS: float = 0.5
+"""Image stays 0.5 s AFTER its narration ends."""
+
+CROSSFADE_DURATION: float = 0.4
+"""Default crossfade transition between images (seconds)."""
+
+STYLE_CHANGE_FADE: float = 0.8
+"""Longer fade when visual style changes (e.g. Dossier -> Echo)."""
+
+ACT_TRANSITION_BLACK: float = 1.5
+"""Brief dip-to-black between acts."""
+
+# ---------------------------------------------------------------------------
+# Alignment thresholds
+# ---------------------------------------------------------------------------
+MIN_MATCH_RATIO: float = 0.6
+"""Minimum fuzzy-match similarity to accept an alignment."""
+
+SEARCH_WINDOW_MULTIPLIER: int = 3
+"""When searching for an excerpt in the transcript, search up to
+excerpt_word_count * this multiplier positions ahead."""
+
+# ---------------------------------------------------------------------------
+# Ken Burns defaults
+# ---------------------------------------------------------------------------
+KEN_BURNS_BASE_DURATION: float = 11.0
+"""The "reference" display duration (seconds) for which the base
+zoom speed (1.0x) is calibrated."""
+
+KEN_BURNS_PRESETS: dict[str, dict] = {
+    "slow_zoom_in":   {"start_scale": 1.0,  "end_scale": 1.15},
+    "slow_zoom_out":  {"start_scale": 1.15, "end_scale": 1.0},
+    "slow_pan_right": {"start_x_offset": -40, "end_x_offset": 40},
+    "slow_pan_left":  {"start_x_offset": 40,  "end_x_offset": -40},
+    "slow_tilt_up":   {"start_y_offset": 30,  "end_y_offset": -30},
+}
+
+COMPOSITION_DIRECTION_MAP: dict[str, str] = {
+    "wide":          "slow_zoom_in",
+    "medium":        "slow_pan_right",
+    "closeup":       "slow_zoom_out",
+    "environmental": "slow_pan_left",
+    "portrait":      "slow_zoom_in",
+    "overhead":      "slow_zoom_in",
+    "low_angle":     "slow_tilt_up",
+}
+
+# ---------------------------------------------------------------------------
+# Render defaults
+# ---------------------------------------------------------------------------
+DEFAULT_FPS: int = 30
+DEFAULT_WIDTH: int = 1920
+DEFAULT_HEIGHT: int = 1080
+
+# ---------------------------------------------------------------------------
+# Whisper defaults
+# ---------------------------------------------------------------------------
+DEFAULT_WHISPER_MODEL: str = "medium"
+"""Recommended model for production quality. Use 'small' on CPU-only VPS."""

--- a/skills/video-pipeline/audio_sync/ken_burns_calculator.py
+++ b/skills/video-pipeline/audio_sync/ken_burns_calculator.py
@@ -1,0 +1,82 @@
+"""
+Per-scene Ken Burns effect calculator.
+
+Determines zoom direction, speed multiplier, and scale/offset parameters
+based on each scene's composition type and display duration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .config import (
+    KEN_BURNS_BASE_DURATION,
+    KEN_BURNS_PRESETS,
+    COMPOSITION_DIRECTION_MAP,
+    MIN_DISPLAY_SECONDS,
+)
+
+
+def calculate_ken_burns(
+    composition: str,
+    display_duration: float,
+    scene_index: int,
+) -> dict[str, Any]:
+    """
+    Calculate Ken Burns parameters for a single scene.
+
+    Args:
+        composition: Composition hint (``wide``, ``medium``, ``closeup``,
+            ``environmental``, ``portrait``, ``overhead``, ``low_angle``).
+        display_duration: How long the image will be on screen (seconds).
+        scene_index: Zero-based scene position, used to alternate pan
+            directions for visual variety.
+
+    Returns:
+        Dict with ``direction``, ``speed_multiplier``, and the
+        scale/offset keys from :data:`KEN_BURNS_PRESETS`.
+    """
+    direction = COMPOSITION_DIRECTION_MAP.get(
+        composition.lower() if composition else "",
+        "slow_zoom_in",
+    )
+
+    # Alternate pan direction for variety (every other medium/environmental)
+    if direction in ("slow_pan_right", "slow_pan_left") and scene_index % 2 == 0:
+        direction = (
+            "slow_pan_left" if direction == "slow_pan_right" else "slow_pan_right"
+        )
+
+    # Speed multiplier — slower zoom for longer scenes
+    safe_duration = max(display_duration, MIN_DISPLAY_SECONDS)
+    speed_multiplier = round(KEN_BURNS_BASE_DURATION / safe_duration, 3)
+
+    config = KEN_BURNS_PRESETS.get(direction, KEN_BURNS_PRESETS["slow_zoom_in"]).copy()
+    config["direction"] = direction
+    config["speed_multiplier"] = speed_multiplier
+
+    return config
+
+
+def assign_ken_burns(scenes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Add ``ken_burns`` configuration to every scene.
+
+    Reads ``composition`` (or ``composition_hint``) and
+    ``display_duration`` from each scene dict.
+    """
+    for i, scene in enumerate(scenes):
+        composition = (
+            scene.get("composition")
+            or scene.get("composition_hint")
+            or "wide"
+        )
+        display_duration = scene.get("display_duration", KEN_BURNS_BASE_DURATION)
+
+        scene["ken_burns"] = calculate_ken_burns(
+            composition=composition,
+            display_duration=display_duration,
+            scene_index=i,
+        )
+
+    return scenes

--- a/skills/video-pipeline/audio_sync/render_config_writer.py
+++ b/skills/video-pipeline/audio_sync/render_config_writer.py
@@ -1,0 +1,129 @@
+"""
+Generate the ``render_config.json`` consumed by Remotion.
+
+Assembles all timing, Ken Burns, and transition data into the final
+per-video render configuration.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .config import DEFAULT_FPS, DEFAULT_WIDTH, DEFAULT_HEIGHT
+
+
+def build_render_config(
+    video_id: str,
+    audio_path: str,
+    scenes: list[dict[str, Any]],
+    image_dir: str,
+    *,
+    fps: int = DEFAULT_FPS,
+    width: int = DEFAULT_WIDTH,
+    height: int = DEFAULT_HEIGHT,
+) -> dict[str, Any]:
+    """
+    Build the complete render configuration dict.
+
+    Args:
+        video_id: Unique video identifier.
+        audio_path: Absolute path to the narration audio file.
+        scenes: Fully processed scene list (with timing, Ken Burns,
+            transitions already assigned).
+        image_dir: Directory containing the generated scene images.
+        fps: Frames per second for the output video.
+        width: Output width in pixels.
+        height: Output height in pixels.
+
+    Returns:
+        A dict ready to be serialised as ``render_config.json``.
+    """
+    # Compute total duration from last scene
+    total_duration = 0.0
+    if scenes:
+        last = scenes[-1]
+        total_duration = last.get("display_end", 0.0)
+
+    render_scenes = []
+    for scene in scenes:
+        scene_number = scene.get("scene_number", 0)
+
+        # Build image path — pad scene number to 3 digits
+        image_filename = f"scene_{scene_number:03d}.png"
+        image_path = str(Path(image_dir) / image_filename)
+
+        render_scenes.append({
+            "scene_number": scene_number,
+            "image_path": image_path,
+            "display_start": round(scene.get("display_start", 0.0), 4),
+            "display_end": round(scene.get("display_end", 0.0), 4),
+            "display_duration": round(scene.get("display_duration", 0.0), 4),
+            "narration_start": round(scene.get("start_time", 0.0) or 0.0, 4),
+            "narration_end": round(scene.get("end_time", 0.0) or 0.0, 4),
+            "style": scene.get("style") or scene.get("visual_style") or "",
+            "composition": (
+                scene.get("composition")
+                or scene.get("composition_hint")
+                or ""
+            ),
+            "act": scene.get("act") or scene.get("parent_act") or 0,
+            "ken_burns": scene.get("ken_burns", {}),
+            "transition_in": scene.get("transition_in", {}),
+            "transition_out": scene.get("transition_out", {}),
+        })
+
+    return {
+        "video_id": video_id,
+        "audio_path": audio_path,
+        "total_duration_seconds": round(total_duration, 4),
+        "fps": fps,
+        "resolution": {
+            "width": width,
+            "height": height,
+        },
+        "scenes": render_scenes,
+    }
+
+
+def write_render_config(
+    config: dict[str, Any],
+    output_path: str | Path,
+) -> Path:
+    """Serialise *config* to JSON on disk."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(config, f, indent=2)
+    return output_path
+
+
+def save_scene_timing(
+    scenes: list[dict[str, Any]],
+    output_path: str | Path,
+) -> Path:
+    """
+    Save intermediate scene-level timestamps to
+    ``scene_timing.json`` (useful for debugging).
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    timing_data = []
+    for s in scenes:
+        timing_data.append({
+            "scene_number": s.get("scene_number"),
+            "start_time": s.get("start_time"),
+            "end_time": s.get("end_time"),
+            "display_start": s.get("display_start"),
+            "display_end": s.get("display_end"),
+            "display_duration": s.get("display_duration"),
+            "alignment_method": s.get("alignment_method"),
+            "alignment_score": s.get("alignment_score"),
+        })
+
+    with open(output_path, "w") as f:
+        json.dump(timing_data, f, indent=2)
+
+    return output_path

--- a/skills/video-pipeline/audio_sync/tests/test_aligner.py
+++ b/skills/video-pipeline/audio_sync/tests/test_aligner.py
@@ -1,0 +1,191 @@
+"""Tests for audio_sync.aligner — scene-to-timestamp alignment."""
+
+import pytest
+
+from audio_sync.aligner import (
+    normalize_text,
+    align_scenes_to_timestamps,
+    interpolate_failed_alignments,
+    validate_alignment,
+)
+from audio_sync.transcriber import WordTimestamp
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_words(texts: list[str], start: float = 0.0, gap: float = 0.3) -> list[WordTimestamp]:
+    """Build a list of WordTimestamp objects from plain text tokens."""
+    words = []
+    t = start
+    for text in texts:
+        words.append(WordTimestamp(text, round(t, 2), round(t + gap - 0.02, 2)))
+        t += gap
+    return words
+
+
+# ---------------------------------------------------------------------------
+# normalize_text
+# ---------------------------------------------------------------------------
+
+class TestNormalizeText:
+    def test_lowercase(self):
+        assert normalize_text("Hello World") == "hello world"
+
+    def test_strip_punctuation(self):
+        assert normalize_text("Hello, World!") == "hello world"
+
+    def test_collapse_whitespace(self):
+        assert normalize_text("  hello   world  ") == "hello world"
+
+    def test_numbers_preserved(self):
+        assert normalize_text("$1.25 trillion") == "125 trillion"
+
+    def test_empty_string(self):
+        assert normalize_text("") == ""
+
+
+# ---------------------------------------------------------------------------
+# align_scenes_to_timestamps
+# ---------------------------------------------------------------------------
+
+class TestAlignScenes:
+    def test_exact_match(self):
+        """Scenes whose excerpt exactly matches Whisper output."""
+        words = _make_words(["the", "quick", "brown", "fox", "jumped", "over"])
+        scenes = [
+            {"scene_number": 1, "script_excerpt": "the quick brown"},
+            {"scene_number": 2, "script_excerpt": "fox jumped over"},
+        ]
+        aligned = align_scenes_to_timestamps(scenes, words)
+
+        assert aligned[0]["alignment_method"] == "fuzzy_match"
+        assert aligned[0]["start_time"] == words[0].start
+        assert aligned[0]["end_time"] == words[2].end
+
+        assert aligned[1]["alignment_method"] == "fuzzy_match"
+        assert aligned[1]["start_time"] == words[3].start
+        assert aligned[1]["end_time"] == words[5].end
+
+    def test_fuzzy_match_with_punctuation_differences(self):
+        """Whisper output may differ in punctuation from the script."""
+        words = _make_words(["and", "this", "is", "where", "musk", "made"])
+        scenes = [
+            {"scene_number": 1, "script_excerpt": "And, this is where Musk made"},
+        ]
+        aligned = align_scenes_to_timestamps(scenes, words)
+
+        assert aligned[0]["alignment_method"] == "fuzzy_match"
+        assert aligned[0]["alignment_score"] >= 0.6
+
+    def test_empty_excerpt_treated_as_no_narration(self):
+        words = _make_words(["hello", "world"])
+        scenes = [{"scene_number": 1, "script_excerpt": ""}]
+        aligned = align_scenes_to_timestamps(scenes, words)
+
+        assert aligned[0]["alignment_method"] == "no_narration"
+        assert aligned[0]["start_time"] is None
+
+    def test_sequential_ordering_preserved(self):
+        """Scene 2 can only match words AFTER scene 1's match."""
+        words = _make_words(["a", "b", "c", "d", "e", "f", "g", "h"])
+        scenes = [
+            {"scene_number": 1, "script_excerpt": "a b c"},
+            {"scene_number": 2, "script_excerpt": "e f g"},
+        ]
+        aligned = align_scenes_to_timestamps(scenes, words)
+
+        assert aligned[0]["end_time"] < aligned[1]["start_time"]
+
+    def test_failed_alignment_gets_interpolated(self):
+        """A scene that can't match gets interpolated from neighbours."""
+        words = _make_words(["alpha", "beta", "gamma", "delta", "epsilon"])
+        scenes = [
+            {"scene_number": 1, "script_excerpt": "alpha beta"},
+            {"scene_number": 2, "script_excerpt": "ZZZZZ YYYYY"},  # won't match
+            {"scene_number": 3, "script_excerpt": "delta epsilon"},
+        ]
+        aligned = align_scenes_to_timestamps(scenes, words)
+
+        assert aligned[1]["alignment_method"] == "interpolated"
+        assert aligned[1]["start_time"] is not None
+        assert aligned[1]["end_time"] is not None
+        # Interpolated scene should fall between scene 1 end and scene 3 start
+        assert aligned[1]["start_time"] >= aligned[0]["end_time"]
+        assert aligned[1]["end_time"] <= aligned[2]["start_time"]
+
+
+# ---------------------------------------------------------------------------
+# interpolate_failed_alignments
+# ---------------------------------------------------------------------------
+
+class TestInterpolation:
+    def test_single_gap(self):
+        scenes = [
+            {"scene_number": 1, "start_time": 0.0, "end_time": 5.0},
+            {"scene_number": 2, "start_time": None, "end_time": None},
+            {"scene_number": 3, "start_time": 10.0, "end_time": 15.0},
+        ]
+        result = interpolate_failed_alignments(scenes)
+
+        assert result[1]["start_time"] == 5.0
+        assert result[1]["end_time"] == 10.0
+        assert result[1]["alignment_method"] == "interpolated"
+
+    def test_multiple_gaps(self):
+        scenes = [
+            {"scene_number": 1, "start_time": 0.0, "end_time": 4.0},
+            {"scene_number": 2, "start_time": None, "end_time": None},
+            {"scene_number": 3, "start_time": None, "end_time": None},
+            {"scene_number": 4, "start_time": 10.0, "end_time": 14.0},
+        ]
+        result = interpolate_failed_alignments(scenes)
+
+        # 6 seconds gap split into 2 x 3 seconds
+        assert result[1]["start_time"] == 4.0
+        assert result[1]["end_time"] == 7.0
+        assert result[2]["start_time"] == 7.0
+        assert result[2]["end_time"] == 10.0
+
+
+# ---------------------------------------------------------------------------
+# validate_alignment
+# ---------------------------------------------------------------------------
+
+class TestValidateAlignment:
+    def test_clean_alignment(self):
+        scenes = [
+            {"scene_number": 1, "start_time": 0.0, "end_time": 5.0,
+             "alignment_method": "fuzzy_match", "alignment_score": 0.95},
+            {"scene_number": 2, "start_time": 5.1, "end_time": 10.0,
+             "alignment_method": "fuzzy_match", "alignment_score": 0.88},
+        ]
+        report = validate_alignment(scenes)
+
+        assert report["quality"] == "good"
+        assert report["overlaps"] == 0
+        assert report["large_gaps"] == 0
+        assert report["total_scenes"] == 2
+
+    def test_overlap_detected(self):
+        scenes = [
+            {"scene_number": 1, "start_time": 0.0, "end_time": 6.0,
+             "alignment_method": "fuzzy_match", "alignment_score": 0.9},
+            {"scene_number": 2, "start_time": 5.0, "end_time": 10.0,
+             "alignment_method": "fuzzy_match", "alignment_score": 0.9},
+        ]
+        report = validate_alignment(scenes)
+
+        assert report["overlaps"] == 1
+
+    def test_large_gap_detected(self):
+        scenes = [
+            {"scene_number": 1, "start_time": 0.0, "end_time": 5.0,
+             "alignment_method": "fuzzy_match", "alignment_score": 0.9},
+            {"scene_number": 2, "start_time": 9.0, "end_time": 14.0,
+             "alignment_method": "fuzzy_match", "alignment_score": 0.9},
+        ]
+        report = validate_alignment(scenes)
+
+        assert report["large_gaps"] == 1

--- a/skills/video-pipeline/audio_sync/tests/test_ken_burns.py
+++ b/skills/video-pipeline/audio_sync/tests/test_ken_burns.py
@@ -1,0 +1,70 @@
+"""Tests for audio_sync.ken_burns_calculator — per-scene Ken Burns parameters."""
+
+import pytest
+
+from audio_sync.ken_burns_calculator import (
+    calculate_ken_burns,
+    assign_ken_burns,
+)
+from audio_sync.config import KEN_BURNS_BASE_DURATION
+
+
+class TestCalculateKenBurns:
+    def test_wide_composition_zooms_in(self):
+        kb = calculate_ken_burns("wide", 11.0, scene_index=0)
+        assert kb["direction"] == "slow_zoom_in"
+        assert kb["start_scale"] == 1.0
+        assert kb["end_scale"] == 1.15
+
+    def test_closeup_composition_zooms_out(self):
+        kb = calculate_ken_burns("closeup", 11.0, scene_index=0)
+        assert kb["direction"] == "slow_zoom_out"
+        assert kb["start_scale"] == 1.15
+        assert kb["end_scale"] == 1.0
+
+    def test_medium_alternates_pan_direction(self):
+        kb_even = calculate_ken_burns("medium", 11.0, scene_index=0)
+        kb_odd = calculate_ken_burns("medium", 11.0, scene_index=1)
+        # Even index alternates
+        assert kb_even["direction"] == "slow_pan_left"
+        assert kb_odd["direction"] == "slow_pan_right"
+
+    def test_speed_multiplier_for_long_scene(self):
+        kb = calculate_ken_burns("wide", 16.0, scene_index=0)
+        expected = round(KEN_BURNS_BASE_DURATION / 16.0, 3)
+        assert kb["speed_multiplier"] == expected
+
+    def test_speed_multiplier_for_short_scene(self):
+        """Short scenes (< 3s) are clamped to min_display_seconds."""
+        kb = calculate_ken_burns("wide", 2.0, scene_index=0)
+        expected = round(KEN_BURNS_BASE_DURATION / 3.0, 3)
+        assert kb["speed_multiplier"] == expected
+
+    def test_unknown_composition_defaults_to_zoom_in(self):
+        kb = calculate_ken_burns("unknown_type", 11.0, scene_index=0)
+        assert kb["direction"] == "slow_zoom_in"
+
+    def test_low_angle_tilts_up(self):
+        kb = calculate_ken_burns("low_angle", 11.0, scene_index=0)
+        assert kb["direction"] == "slow_tilt_up"
+
+
+class TestAssignKenBurns:
+    def test_assigns_to_all_scenes(self):
+        scenes = [
+            {"scene_number": 1, "composition": "wide", "display_duration": 8.0},
+            {"scene_number": 2, "composition": "closeup", "display_duration": 12.0},
+        ]
+        result = assign_ken_burns(scenes)
+        for s in result:
+            assert "ken_burns" in s
+            assert "direction" in s["ken_burns"]
+            assert "speed_multiplier" in s["ken_burns"]
+
+    def test_composition_hint_fallback(self):
+        """Should also read 'composition_hint' if 'composition' is missing."""
+        scenes = [
+            {"scene_number": 1, "composition_hint": "environmental", "display_duration": 10.0},
+        ]
+        result = assign_ken_burns(scenes)
+        assert result[0]["ken_burns"]["direction"] in ("slow_pan_left", "slow_pan_right")

--- a/skills/video-pipeline/audio_sync/tests/test_timing.py
+++ b/skills/video-pipeline/audio_sync/tests/test_timing.py
@@ -1,0 +1,163 @@
+"""Tests for audio_sync.timing_adjuster — display time rules."""
+
+import pytest
+
+from audio_sync.timing_adjuster import (
+    apply_pre_roll,
+    apply_post_hold,
+    enforce_minimum_display,
+    enforce_maximum_display,
+    resolve_overlaps,
+    compute_display_durations,
+    adjust_timing,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pre-roll
+# ---------------------------------------------------------------------------
+
+class TestPreRoll:
+    def test_standard_pre_roll(self):
+        scenes = [{"start_time": 5.0, "end_time": 10.0}]
+        result = apply_pre_roll(scenes, pre_roll=0.3)
+        assert result[0]["display_start"] == 4.7
+
+    def test_pre_roll_clamped_to_zero(self):
+        scenes = [{"start_time": 0.1, "end_time": 5.0}]
+        result = apply_pre_roll(scenes, pre_roll=0.3)
+        assert result[0]["display_start"] == 0.0
+
+    def test_none_start_time(self):
+        scenes = [{"start_time": None, "end_time": None}]
+        result = apply_pre_roll(scenes, pre_roll=0.3)
+        assert result[0]["display_start"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Post-hold
+# ---------------------------------------------------------------------------
+
+class TestPostHold:
+    def test_standard_post_hold(self):
+        scenes = [
+            {"start_time": 0.0, "end_time": 5.0, "display_start": 0.0},
+            {"start_time": 6.0, "end_time": 10.0, "display_start": 5.7},
+        ]
+        result = apply_post_hold(scenes, post_hold=0.5)
+        assert result[0]["display_end"] == 5.5
+
+    def test_post_hold_clamped_by_next_scene(self):
+        scenes = [
+            {"start_time": 0.0, "end_time": 5.0, "display_start": 0.0},
+            {"start_time": 5.1, "end_time": 10.0, "display_start": 4.8},
+        ]
+        result = apply_post_hold(scenes, post_hold=0.5)
+        # 5.0 + 0.5 = 5.5 > 4.8 (next display_start), so clamp to 4.8
+        assert result[0]["display_end"] == 4.8
+
+    def test_last_scene_uses_full_post_hold(self):
+        scenes = [
+            {"start_time": 10.0, "end_time": 15.0, "display_start": 9.7},
+        ]
+        result = apply_post_hold(scenes, post_hold=0.5)
+        assert result[0]["display_end"] == 15.5
+
+
+# ---------------------------------------------------------------------------
+# Minimum display
+# ---------------------------------------------------------------------------
+
+class TestMinimumDisplay:
+    def test_short_scene_extended(self):
+        scenes = [
+            {"display_start": 0.0, "display_end": 1.0},
+            {"display_start": 2.0, "display_end": 8.0},
+        ]
+        result = enforce_minimum_display(scenes, min_seconds=3.0)
+        assert result[0]["display_end"] == 3.0
+
+    def test_already_long_enough(self):
+        scenes = [
+            {"display_start": 0.0, "display_end": 5.0},
+        ]
+        result = enforce_minimum_display(scenes, min_seconds=3.0)
+        assert result[0]["display_end"] == 5.0
+
+    def test_extension_shifts_next_scene(self):
+        scenes = [
+            {"display_start": 0.0, "display_end": 1.0},
+            {"display_start": 1.5, "display_end": 8.0},
+        ]
+        result = enforce_minimum_display(scenes, min_seconds=3.0)
+        # Scene 1 extended to 3.0, which pushes scene 2 start to 3.0
+        assert result[0]["display_end"] == 3.0
+        assert result[1]["display_start"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Maximum display
+# ---------------------------------------------------------------------------
+
+class TestMaximumDisplay:
+    def test_long_scene_clamped(self):
+        scenes = [
+            {"display_start": 0.0, "display_end": 25.0},
+        ]
+        result = enforce_maximum_display(scenes, max_seconds=18.0)
+        assert result[0]["display_end"] == 18.0
+
+    def test_normal_scene_unchanged(self):
+        scenes = [
+            {"display_start": 0.0, "display_end": 10.0},
+        ]
+        result = enforce_maximum_display(scenes, max_seconds=18.0)
+        assert result[0]["display_end"] == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Overlap resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveOverlaps:
+    def test_overlapping_scenes_fixed(self):
+        scenes = [
+            {"display_start": 0.0, "display_end": 6.0},
+            {"display_start": 5.0, "display_end": 10.0},
+        ]
+        result = resolve_overlaps(scenes)
+        assert result[1]["display_start"] == 6.0
+
+    def test_no_overlap_unchanged(self):
+        scenes = [
+            {"display_start": 0.0, "display_end": 5.0},
+            {"display_start": 5.0, "display_end": 10.0},
+        ]
+        result = resolve_overlaps(scenes)
+        assert result[1]["display_start"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline
+# ---------------------------------------------------------------------------
+
+class TestAdjustTiming:
+    def test_full_pipeline(self):
+        scenes = [
+            {"scene_number": 1, "start_time": 0.5, "end_time": 5.0},
+            {"scene_number": 2, "start_time": 5.2, "end_time": 12.0},
+            {"scene_number": 3, "start_time": 12.5, "end_time": 14.0},
+        ]
+        result = adjust_timing(scenes)
+
+        # All scenes should have display_start, display_end, display_duration
+        for s in result:
+            assert "display_start" in s
+            assert "display_end" in s
+            assert "display_duration" in s
+            assert s["display_duration"] >= 3.0  # minimum
+            assert s["display_duration"] <= 18.0  # maximum
+
+        # No overlaps
+        for i in range(len(result) - 1):
+            assert result[i]["display_end"] <= result[i + 1]["display_start"] + 0.001

--- a/skills/video-pipeline/audio_sync/tests/test_transitions.py
+++ b/skills/video-pipeline/audio_sync/tests/test_transitions.py
@@ -1,0 +1,74 @@
+"""Tests for audio_sync.transition_engine — transition type selection."""
+
+import pytest
+
+from audio_sync.transition_engine import (
+    determine_transition,
+    assign_transitions,
+)
+from audio_sync.config import CROSSFADE_DURATION, STYLE_CHANGE_FADE, ACT_TRANSITION_BLACK
+
+
+class TestDetermineTransition:
+    def test_same_style_same_act_crossfade(self):
+        cur = {"style": "dossier", "act": 1}
+        nxt = {"style": "dossier", "act": 1}
+        t = determine_transition(cur, nxt)
+        assert t["type"] == "crossfade"
+        assert t["duration"] == CROSSFADE_DURATION
+
+    def test_style_change_longer_crossfade(self):
+        cur = {"style": "dossier", "act": 2}
+        nxt = {"style": "echo", "act": 2}
+        t = determine_transition(cur, nxt)
+        assert t["type"] == "crossfade"
+        assert t["duration"] == STYLE_CHANGE_FADE
+
+    def test_act_change_dip_to_black(self):
+        cur = {"style": "dossier", "act": 1}
+        nxt = {"style": "dossier", "act": 2}
+        t = determine_transition(cur, nxt)
+        assert t["type"] == "dip_to_black"
+        assert t["duration"] == ACT_TRANSITION_BLACK
+
+    def test_last_scene_fade_to_black(self):
+        cur = {"style": "dossier", "act": 6}
+        t = determine_transition(cur, None)
+        assert t["type"] == "fade_to_black"
+
+    def test_visual_style_field_supported(self):
+        """The pipeline may use 'visual_style' instead of 'style'."""
+        cur = {"visual_style": "schema", "parent_act": 3}
+        nxt = {"visual_style": "echo", "parent_act": 3}
+        t = determine_transition(cur, nxt)
+        assert t["type"] == "crossfade"
+        assert t["duration"] == STYLE_CHANGE_FADE
+
+
+class TestAssignTransitions:
+    def test_first_scene_fades_from_black(self):
+        scenes = [
+            {"scene_number": 1, "style": "dossier", "act": 1},
+            {"scene_number": 2, "style": "dossier", "act": 1},
+        ]
+        result = assign_transitions(scenes)
+        assert result[0]["transition_in"]["type"] == "fade_from_black"
+
+    def test_all_scenes_get_both_transitions(self):
+        scenes = [
+            {"scene_number": 1, "style": "dossier", "act": 1},
+            {"scene_number": 2, "style": "dossier", "act": 1},
+            {"scene_number": 3, "style": "echo", "act": 2},
+        ]
+        result = assign_transitions(scenes)
+        for s in result:
+            assert "transition_in" in s
+            assert "transition_out" in s
+
+    def test_transition_in_mirrors_previous_out(self):
+        scenes = [
+            {"scene_number": 1, "style": "dossier", "act": 1},
+            {"scene_number": 2, "style": "dossier", "act": 2},
+        ]
+        result = assign_transitions(scenes)
+        assert result[1]["transition_in"]["type"] == result[0]["transition_out"]["type"]

--- a/skills/video-pipeline/audio_sync/timing_adjuster.py
+++ b/skills/video-pipeline/audio_sync/timing_adjuster.py
@@ -1,0 +1,187 @@
+"""
+Timing adjustment and validation.
+
+Applies pre-roll, post-hold, minimum/maximum display time, and resolves
+overlaps to produce final display_start / display_end per scene.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .config import (
+    MIN_DISPLAY_SECONDS,
+    MAX_DISPLAY_SECONDS,
+    PRE_ROLL_SECONDS,
+    POST_HOLD_SECONDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pre-roll: image appears slightly before narration
+# ---------------------------------------------------------------------------
+
+def apply_pre_roll(
+    scenes: list[dict[str, Any]],
+    pre_roll: float = PRE_ROLL_SECONDS,
+) -> list[dict[str, Any]]:
+    """
+    Set ``display_start`` to ``start_time - pre_roll`` (clamped to 0).
+
+    The viewer needs a fraction of a second to register the new visual
+    before the associated narration begins.
+    """
+    for scene in scenes:
+        start = scene.get("start_time")
+        if start is not None:
+            scene["display_start"] = max(0.0, start - pre_roll)
+        else:
+            scene["display_start"] = 0.0
+    return scenes
+
+
+# ---------------------------------------------------------------------------
+# Post-hold: image lingers briefly after narration
+# ---------------------------------------------------------------------------
+
+def apply_post_hold(
+    scenes: list[dict[str, Any]],
+    post_hold: float = POST_HOLD_SECONDS,
+) -> list[dict[str, Any]]:
+    """
+    Set ``display_end`` to ``end_time + post_hold``, but never extend
+    past the next scene's ``display_start``.
+    """
+    for i, scene in enumerate(scenes):
+        end = scene.get("end_time")
+        if end is None:
+            # Fallback — will be fixed later
+            scene["display_end"] = scene.get("display_start", 0.0) + MIN_DISPLAY_SECONDS
+            continue
+
+        desired_end = end + post_hold
+
+        # Clamp to next scene's display_start if available
+        if i < len(scenes) - 1:
+            next_start = scenes[i + 1].get("display_start")
+            if next_start is not None:
+                desired_end = min(desired_end, next_start)
+
+        scene["display_end"] = desired_end
+
+    return scenes
+
+
+# ---------------------------------------------------------------------------
+# Minimum display time
+# ---------------------------------------------------------------------------
+
+def enforce_minimum_display(
+    scenes: list[dict[str, Any]],
+    min_seconds: float = MIN_DISPLAY_SECONDS,
+) -> list[dict[str, Any]]:
+    """
+    Ensure no image displays for less than *min_seconds*.
+
+    If a scene is too short it is extended; subsequent scenes are shifted
+    forward if this creates an overlap.
+    """
+    for i, scene in enumerate(scenes):
+        duration = scene["display_end"] - scene["display_start"]
+
+        if duration < min_seconds:
+            scene["display_end"] = scene["display_start"] + min_seconds
+
+            # Shift next scene forward if we now overlap
+            if i < len(scenes) - 1:
+                if scene["display_end"] > scenes[i + 1]["display_start"]:
+                    scenes[i + 1]["display_start"] = scene["display_end"]
+
+    return scenes
+
+
+# ---------------------------------------------------------------------------
+# Maximum display time
+# ---------------------------------------------------------------------------
+
+def enforce_maximum_display(
+    scenes: list[dict[str, Any]],
+    max_seconds: float = MAX_DISPLAY_SECONDS,
+) -> list[dict[str, Any]]:
+    """
+    Clamp any scene longer than *max_seconds*.
+
+    The Ken Burns speed multiplier (calculated later) will slow the zoom
+    proportionally for long scenes, so capping here is only a safeguard
+    against extreme outliers.
+    """
+    for scene in scenes:
+        duration = scene["display_end"] - scene["display_start"]
+        if duration > max_seconds:
+            scene["display_end"] = scene["display_start"] + max_seconds
+    return scenes
+
+
+# ---------------------------------------------------------------------------
+# Resolve overlaps
+# ---------------------------------------------------------------------------
+
+def resolve_overlaps(scenes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Ensure no two scenes overlap: each scene's ``display_start`` must be
+    >= the previous scene's ``display_end``.
+    """
+    for i in range(1, len(scenes)):
+        prev_end = scenes[i - 1]["display_end"]
+        if scenes[i]["display_start"] < prev_end:
+            scenes[i]["display_start"] = prev_end
+        # Also make sure display_end >= display_start
+        if scenes[i]["display_end"] < scenes[i]["display_start"]:
+            scenes[i]["display_end"] = scenes[i]["display_start"] + MIN_DISPLAY_SECONDS
+    return scenes
+
+
+# ---------------------------------------------------------------------------
+# Compute display_duration
+# ---------------------------------------------------------------------------
+
+def compute_display_durations(
+    scenes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Add ``display_duration`` = ``display_end`` - ``display_start``."""
+    for scene in scenes:
+        scene["display_duration"] = round(
+            scene["display_end"] - scene["display_start"], 4
+        )
+    return scenes
+
+
+# ---------------------------------------------------------------------------
+# Main entry-point
+# ---------------------------------------------------------------------------
+
+def adjust_timing(
+    scenes: list[dict[str, Any]],
+    *,
+    pre_roll: float = PRE_ROLL_SECONDS,
+    post_hold: float = POST_HOLD_SECONDS,
+    min_display: float = MIN_DISPLAY_SECONDS,
+    max_display: float = MAX_DISPLAY_SECONDS,
+) -> list[dict[str, Any]]:
+    """
+    Full timing-adjustment pipeline.
+
+    1. Pre-roll (image appears before narration)
+    2. Post-hold (image stays after narration)
+    3. Minimum display enforcement
+    4. Maximum display enforcement
+    5. Overlap resolution
+    6. Duration computation
+    """
+    scenes = apply_pre_roll(scenes, pre_roll=pre_roll)
+    scenes = apply_post_hold(scenes, post_hold=post_hold)
+    scenes = enforce_minimum_display(scenes, min_seconds=min_display)
+    scenes = enforce_maximum_display(scenes, max_seconds=max_display)
+    scenes = resolve_overlaps(scenes)
+    scenes = compute_display_durations(scenes)
+    return scenes

--- a/skills/video-pipeline/audio_sync/transcriber.py
+++ b/skills/video-pipeline/audio_sync/transcriber.py
@@ -1,0 +1,209 @@
+"""
+Whisper transcription — local model or OpenAI API.
+
+Produces word-level timestamps for the entire narration audio file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .config import DEFAULT_WHISPER_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+class WordTimestamp:
+    """A single transcribed word with start/end seconds."""
+
+    __slots__ = ("word", "start", "end")
+
+    def __init__(self, word: str, start: float, end: float) -> None:
+        self.word = word
+        self.start = start
+        self.end = end
+
+    def to_dict(self) -> dict:
+        return {"word": self.word, "start": self.start, "end": self.end}
+
+    def __repr__(self) -> str:
+        return f"WordTimestamp({self.word!r}, {self.start:.2f}, {self.end:.2f})"
+
+
+# ---------------------------------------------------------------------------
+# Local Whisper transcription
+# ---------------------------------------------------------------------------
+
+def transcribe_local(
+    audio_path: str,
+    model_size: str = DEFAULT_WHISPER_MODEL,
+) -> dict[str, Any]:
+    """
+    Transcribe audio with the local ``openai-whisper`` package.
+
+    Args:
+        audio_path: Path to .mp3 / .wav narration file.
+        model_size: One of ``tiny``, ``base``, ``small``, ``medium``, ``large``.
+
+    Returns:
+        Raw Whisper result dict (segments + word timestamps).
+    """
+    try:
+        import whisper  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise RuntimeError(
+            "Local whisper not installed. "
+            "Run `pip install openai-whisper` or use transcribe_api()."
+        ) from exc
+
+    model = whisper.load_model(model_size)
+    result = model.transcribe(
+        audio_path,
+        word_timestamps=True,
+        language="en",
+        condition_on_previous_text=True,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Whisper API transcription
+# ---------------------------------------------------------------------------
+
+def transcribe_api(audio_path: str) -> dict[str, Any]:
+    """
+    Transcribe audio via the OpenAI Whisper API (hosted, no GPU needed).
+
+    Cost: ~$0.006/min of audio.  A 25-min video ≈ $0.15.
+
+    Requires ``OPENAI_API_KEY`` env var.
+
+    Returns:
+        Dict with ``words`` list of ``{word, start, end}`` dicts.
+    """
+    try:
+        import openai
+    except ImportError as exc:
+        raise RuntimeError(
+            "openai package not installed. Run `pip install openai`."
+        ) from exc
+
+    client = openai.OpenAI()
+
+    with open(audio_path, "rb") as f:
+        result = client.audio.transcriptions.create(
+            model="whisper-1",
+            file=f,
+            response_format="verbose_json",
+            timestamp_granularities=["word"],
+        )
+
+    return result.model_dump() if hasattr(result, "model_dump") else dict(result)
+
+
+# ---------------------------------------------------------------------------
+# Unified extraction
+# ---------------------------------------------------------------------------
+
+def extract_words(raw_result: dict[str, Any]) -> list[WordTimestamp]:
+    """
+    Normalise Whisper output (local or API) into a flat list of
+    :class:`WordTimestamp` objects.
+
+    Local Whisper nests words inside ``segments[].words[]``.
+    The API returns a flat ``words[]`` list at top level.
+    """
+    words: list[WordTimestamp] = []
+
+    # API format — flat list at top level
+    if "words" in raw_result and isinstance(raw_result["words"], list):
+        for w in raw_result["words"]:
+            words.append(WordTimestamp(
+                word=w.get("word", "").strip(),
+                start=float(w.get("start", 0)),
+                end=float(w.get("end", 0)),
+            ))
+        return words
+
+    # Local whisper format — words nested in segments
+    for segment in raw_result.get("segments", []):
+        for w in segment.get("words", []):
+            words.append(WordTimestamp(
+                word=w.get("word", "").strip(),
+                start=float(w.get("start", 0)),
+                end=float(w.get("end", 0)),
+            ))
+
+    return words
+
+
+# ---------------------------------------------------------------------------
+# Persist / load helpers
+# ---------------------------------------------------------------------------
+
+def save_whisper_raw(raw_result: dict[str, Any], output_path: str | Path) -> Path:
+    """Write the raw Whisper JSON to disk (backup)."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(raw_result, f, indent=2, default=str)
+    return output_path
+
+
+def load_whisper_raw(path: str | Path) -> dict[str, Any]:
+    """Load a previously saved raw Whisper JSON."""
+    with open(path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Convenience entry-point
+# ---------------------------------------------------------------------------
+
+def transcribe(
+    audio_path: str,
+    *,
+    use_api: bool = False,
+    model_size: str = DEFAULT_WHISPER_MODEL,
+    cache_dir: str | Path | None = None,
+) -> list[WordTimestamp]:
+    """
+    High-level entry point: transcribe audio and return word timestamps.
+
+    If *cache_dir* is provided, the raw Whisper JSON is saved there as
+    ``whisper_raw.json`` and subsequent calls with the same *cache_dir*
+    will load from cache instead of re-transcribing.
+
+    Args:
+        audio_path: Path to the narration audio file.
+        use_api: If ``True``, use the OpenAI hosted API instead of a
+            local model.
+        model_size: Local model size (ignored when *use_api* is ``True``).
+        cache_dir: Optional directory for caching Whisper output.
+
+    Returns:
+        Flat list of :class:`WordTimestamp` objects.
+    """
+    # Check cache
+    if cache_dir is not None:
+        cache_file = Path(cache_dir) / "whisper_raw.json"
+        if cache_file.exists():
+            raw = load_whisper_raw(cache_file)
+            return extract_words(raw)
+
+    # Transcribe
+    if use_api:
+        raw = transcribe_api(audio_path)
+    else:
+        raw = transcribe_local(audio_path, model_size=model_size)
+
+    # Cache
+    if cache_dir is not None:
+        save_whisper_raw(raw, Path(cache_dir) / "whisper_raw.json")
+
+    return extract_words(raw)

--- a/skills/video-pipeline/audio_sync/transition_engine.py
+++ b/skills/video-pipeline/audio_sync/transition_engine.py
@@ -1,0 +1,83 @@
+"""
+Transition type selection between scenes.
+
+Determines the transition style and duration based on style changes
+and act boundaries.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .config import CROSSFADE_DURATION, STYLE_CHANGE_FADE, ACT_TRANSITION_BLACK
+
+
+def determine_transition(
+    current_scene: dict[str, Any],
+    next_scene: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """
+    Choose a transition type and duration between *current_scene* and
+    *next_scene*.
+
+    Rules (in priority order):
+    1. Act change -> dip-to-black (1.5 s)
+    2. Style change within same act -> longer crossfade (0.8 s)
+    3. Same style, same act -> quick crossfade (0.4 s)
+    """
+    if next_scene is None:
+        # Last scene — fade to black
+        return {"type": "fade_to_black", "duration": 1.0}
+
+    cur_act = current_scene.get("act") or current_scene.get("parent_act")
+    nxt_act = next_scene.get("act") or next_scene.get("parent_act")
+
+    cur_style = (
+        current_scene.get("style")
+        or current_scene.get("visual_style")
+        or ""
+    )
+    nxt_style = (
+        next_scene.get("style")
+        or next_scene.get("visual_style")
+        or ""
+    )
+
+    # Act change -> dip to black
+    if cur_act is not None and nxt_act is not None and cur_act != nxt_act:
+        return {"type": "dip_to_black", "duration": ACT_TRANSITION_BLACK}
+
+    # Style change within same act -> longer crossfade
+    if cur_style and nxt_style and cur_style != nxt_style:
+        return {"type": "crossfade", "duration": STYLE_CHANGE_FADE}
+
+    # Default — quick crossfade
+    return {"type": "crossfade", "duration": CROSSFADE_DURATION}
+
+
+def assign_transitions(
+    scenes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Assign ``transition_in`` and ``transition_out`` to every scene.
+
+    The first scene always fades from black; each subsequent scene's
+    ``transition_in`` mirrors the previous scene's ``transition_out``.
+    """
+    for i, scene in enumerate(scenes):
+        # transition_in
+        if i == 0:
+            scene["transition_in"] = {"type": "fade_from_black", "duration": 1.0}
+        else:
+            # Mirror the previous scene's transition_out
+            prev_out = scenes[i - 1].get("transition_out", {})
+            scene["transition_in"] = {
+                "type": prev_out.get("type", "crossfade"),
+                "duration": prev_out.get("duration", CROSSFADE_DURATION),
+            }
+
+        # transition_out
+        next_scene = scenes[i + 1] if i < len(scenes) - 1 else None
+        scene["transition_out"] = determine_transition(scene, next_scene)
+
+    return scenes

--- a/skills/video-pipeline/requirements.txt
+++ b/skills/video-pipeline/requirements.txt
@@ -36,6 +36,7 @@ aiofiles>=23.2.0
 
 # Audio Processing
 mutagen>=1.47.0  # Audio duration detection
+openai-whisper>=20231117  # Local Whisper transcription (optional — needs ffmpeg)
 
 # Utilities
 python-dotenv>=1.0.0


### PR DESCRIPTION
Implement the complete audio-sync pipeline that uses Whisper to
transcribe narration audio with word-level timestamps, then aligns
each scene's script_excerpt to the transcript using sequential
fuzzy matching. This produces per-scene timing data (display_start,
display_end) that drives image transitions from the narration itself
rather than fixed intervals.

Module structure:
- config.py: Timing rules, Ken Burns presets, alignment thresholds
- transcriber.py: Local Whisper and OpenAI API transcription with caching
- aligner.py: Sequential fuzzy matching with interpolation fallback
- timing_adjuster.py: Pre-roll, post-hold, min/max display enforcement
- transition_engine.py: Context-aware transition selection (act/style)
- ken_burns_calculator.py: Per-scene zoom direction and speed
- render_config_writer.py: Generates render_config.json for Remotion
- __init__.py: AudioSyncPipeline orchestrator class

Also adds run_audio_sync() method to VideoPipeline for integration
with the existing status-driven workflow, and 46 passing tests.

https://claude.ai/code/session_015Vr89KuKxBTJy8X5A5wcLH