### PR TITLE
Integrate scene_expander for visual descriptions in image prompts

### DIFF
--- a/skills/video-pipeline/image_prompt_engine/style_config.py
+++ b/skills/video-pipeline/image_prompt_engine/style_config.py
@@ -34,25 +34,26 @@ YOUTUBE_STYLE_PREFIX = (
 # chosen accent color string (e.g. "cold teal").
 
 STYLE_SUFFIXES = {
+    # Dossier IS the base look established by the prefix. The suffix adds only
+    # what differentiates dossier from the generic cinematic base.
     "dossier": (
-        ", cinematic photorealistic, single dramatic light source, Rembrandt lighting, "
-        "deep shadows, desaturated color palette with [ACCENT_COLOR] accent, shallow "
-        "depth of field, subtle film grain, dark moody atmosphere, documentary "
-        "photography style, shot on Arri Alexa, 16:9"
+        ", single dramatic light source, high contrast"
     ),
+    # Schema extends the base with data-overlay aesthetics. Prefix already
+    # covers cinematic/film grain/16:9 so those are not repeated here.
     "schema": (
-        ", cinematic photorealistic background with translucent glowing data overlay, "
+        ", translucent glowing data overlay, "
         "thin luminous [ACCENT_COLOR] connection lines and node points, Bloomberg "
-        "terminal meets surveillance system aesthetic, dark atmosphere, minimal and "
-        "elegant, deep blacks with light-emitting data elements, subtle film grain, "
-        "16:9"
+        "terminal meets surveillance system aesthetic, minimal and "
+        "elegant, deep blacks with light-emitting data elements"
     ),
+    # Echo overrides the base with painterly/historical aesthetics. Only
+    # style-defining elements that DIFFER from the prefix are listed.
     "echo": (
-        ", photorealistic with subtle oil painting texture, dramatic chiaroscuro "
+        ", subtle oil painting texture, dramatic chiaroscuro "
         "candlelight lighting, warm amber tones, period-accurate costume and "
-        "architecture detail, deep shadows, slightly soft focus with painterly grain, "
-        "historical documentary style, heavy film grain, atmospheric and evocative, "
-        "16:9"
+        "architecture detail, slightly soft focus with painterly grain, "
+        "historical documentary style, heavy film grain, atmospheric and evocative"
     ),
 }
 

--- a/skills/video-pipeline/image_prompt_engine/tests/test_prompts.py
+++ b/skills/video-pipeline/image_prompt_engine/tests/test_prompts.py
@@ -56,13 +56,13 @@ def _generate_full_video(seed: int = 42) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 class TestPromptFormat:
-    def test_all_prompts_end_with_16_9(self):
-        """Every prompt ends with '16:9'."""
+    def test_all_prompts_contain_16_9(self):
+        """Every prompt contains '16:9' (from the prefix)."""
         results = _generate_full_video()
         for r in results:
-            assert r["prompt"].rstrip().endswith("16:9"), (
-                f"Prompt at index {r['index']} does not end with '16:9': "
-                f"...{r['prompt'][-30:]}"
+            assert "16:9" in r["prompt"], (
+                f"Prompt at index {r['index']} does not contain '16:9': "
+                f"...{r['prompt'][-60:]}"
             )
 
     def test_dossier_prompts_contain_arri_alexa(self):
@@ -225,7 +225,8 @@ class TestBuildPrompt:
         assert "wide establishing shot" in prompt
         assert "cold teal" in prompt
         assert "shot on Arri Alexa" in prompt
-        assert prompt.endswith("16:9")
+        assert "16:9" in prompt
+        assert "single dramatic light source" in prompt
 
     def test_schema_basic(self):
         prompt = build_prompt(
@@ -239,7 +240,7 @@ class TestBuildPrompt:
         assert "overhead" in prompt.lower() or "surveillance perspective" in prompt
         assert "warm amber" in prompt
         assert "Bloomberg" in prompt
-        assert prompt.endswith("16:9")
+        assert "16:9" in prompt
 
     def test_echo_basic(self):
         prompt = build_prompt(
@@ -253,7 +254,7 @@ class TestBuildPrompt:
         assert "figure from waist up" in prompt
         assert "candlelight" in prompt
         assert "oil painting texture" in prompt
-        assert prompt.endswith("16:9")
+        assert "16:9" in prompt
 
     def test_strips_trailing_comma_from_description(self):
         """Scene descriptions with trailing commas don't create double commas."""
@@ -264,6 +265,24 @@ class TestBuildPrompt:
         """Echo suffix includes 'warm amber tones' regardless of chosen accent."""
         prompt = build_prompt("Historical scene", "echo", "wide", "cold teal")
         assert "warm amber tones" in prompt
+
+    def test_dossier_no_duplicate_rembrandt(self):
+        """Dossier prompts should not duplicate 'Rembrandt lighting' (prefix provides it once)."""
+        prompt = build_prompt("A test scene", "dossier", "wide", "cold teal")
+        count = prompt.lower().count("rembrandt lighting")
+        assert count == 1, f"'Rembrandt lighting' appears {count} times (expected 1)"
+
+    def test_dossier_no_duplicate_film_grain(self):
+        """Dossier prompts should not duplicate 'film grain' (prefix provides it once)."""
+        prompt = build_prompt("A test scene", "dossier", "wide", "cold teal")
+        count = prompt.lower().count("film grain")
+        assert count == 1, f"'film grain' appears {count} times (expected 1)"
+
+    def test_dossier_no_duplicate_arri_alexa(self):
+        """Dossier prompts should not duplicate 'shot on Arri Alexa' (prefix provides it once)."""
+        prompt = build_prompt("A test scene", "dossier", "wide", "cold teal")
+        count = prompt.lower().count("shot on arri alexa")
+        assert count == 1, f"'shot on Arri Alexa' appears {count} times (expected 1)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR refactors the image prompt generation pipeline to use the `scene_expander` utility for converting raw narration scripts into visual scene descriptions. This ensures that image prompts are based on visual descriptions rather than narrator dialogue, improving prompt quality and consistency.

## Key Changes

- **Added `_get_visual_seeds()` method**: Extracts visual seed concepts from the current idea record, checking the Research Payload JSON first, then falling back to the Thumbnail Prompt field.

- **Integrated `scene_expander` for script processing**: Both Airtable Script table records and idea Script fields now use `expand_scenes()` to convert raw narration into visual descriptions with proper act/scene structure, rather than naive paragraph splitting.

- **Separated narration from visual descriptions**: 
  - `scene_description` is now a visual description from `scene_expander` used exclusively for image prompts
  - `narration_text` is used for audio sync and sentence splitting
  - Removed the code that was replacing visual descriptions with narration chunks

- **Cleaned up style suffixes**: Removed duplicate elements from `STYLE_SUFFIXES` that are already provided by the base prefix (e.g., "cinematic photorealistic", "film grain", "16:9", "Rembrandt lighting", "shot on Arri Alexa"). Each style now only specifies what differentiates it from the base.

- **Updated test assertions**: Changed prompt format tests from checking that prompts "end with 16:9" to "contain 16:9" since the aspect ratio is now part of the prefix rather than suffix. Added new tests to verify no duplicate style elements appear in dossier prompts.

## Implementation Details

- Visual seeds are passed to `expand_scenes()` to maintain visual consistency across the video
- Accent color is normalized (spaces replaced with underscores) before passing to `scene_expander`
- The narration sentence map (`_scene_sentence_map`) is still computed and used for Airtable storage and audio sync, but no longer overwrites visual descriptions
- Scene expansion now happens asynchronously via the Anthropic client

https://claude.ai/code/session_019Y8K7ny375jBx3PWQDGbpY