### PR TITLE
fix: prefer OpenAI Whisper API and add retry logic for empty responses

### DIFF
--- a/skills/video-pipeline/audio_sync/transcriber.py
+++ b/skills/video-pipeline/audio_sync/transcriber.py
@@ -196,8 +196,8 @@ def transcribe(
             raw = load_whisper_raw(cache_file)
             return extract_words(raw)
 
-    # Transcribe
-    if use_api:
+    # Transcribe — prefer API when OPENAI_API_KEY is available
+    if use_api or os.environ.get("OPENAI_API_KEY"):
         raw = transcribe_api(audio_path)
     else:
         raw = transcribe_local(audio_path, model_size=model_size)

--- a/skills/video-pipeline/pipeline_control.py
+++ b/skills/video-pipeline/pipeline_control.py
@@ -302,7 +302,7 @@ async def handle_prompts(message, say):
     await say(":art: Starting prompts and images generation...")
 
     try:
-        returncode, stdout, stderr = await run_script_async("run_youtube_prompts.py", "prompts", say, timeout=1800)
+        returncode, stdout, stderr = await run_script_async("run_youtube_prompts.py", "prompts", say, timeout=3600)
 
         if returncode == 0:
             output = stdout[-3000:] if len(stdout) > 3000 else stdout
@@ -312,7 +312,7 @@ async def handle_prompts(message, say):
             await say(f":x: Prompts error:\n```{error}```")
 
     except subprocess.TimeoutExpired:
-        await say(":warning: Prompts generation timed out after 30 minutes")
+        await say(":warning: Prompts generation timed out after 60 minutes")
     except asyncio.CancelledError:
         await say(":stop_sign: Prompts generation was stopped")
     except Exception as e:


### PR DESCRIPTION
- transcriber.py: auto-prefer OpenAI Whisper API when OPENAI_API_KEY is
  set, falling back to local model only when no key is available
- scene_expander.py: add retry logic (2 attempts with 2s backoff) to
  _generate_description_for_scene() for empty/failed API responses
- scene_expander.py: wrap regenerate_duplicate_scenes() API call with
  try/except and fallback to prevent crashes on empty responses

https://claude.ai/code/session_01KMyF7eazZd6knLdrgyHJ4x