### PR TITLE
fix: process all 20 scenes by supporting simple [ACT N] markers in extract_acts

### DIFF
--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -1837,6 +1837,7 @@ class VideoPipeline:
 
                 # Reassemble individual script records into a full script
                 total_scripts = len(scripts)
+                print(f"  📋 Total script records from Airtable: {total_scripts}")
                 act_texts: dict[int, list[str]] = {}
                 for script in scripts:
                     scene_text = script.get("Scene text", "") or script.get("Script", "")
@@ -1846,10 +1847,14 @@ class VideoPipeline:
                     act = min(6, (scene_num - 1) * 6 // total_scripts + 1) if total_scripts > 0 else 1
                     act_texts.setdefault(act, []).append(scene_text)
 
+                print(f"  📋 Reassembled into {len(act_texts)} acts: "
+                      + ", ".join(f"Act {k}: {len(v)} scenes" for k, v in sorted(act_texts.items())))
+
                 full_script = "\n\n".join(
                     f"[ACT {act_num}]\n" + "\n\n".join(texts)
                     for act_num, texts in sorted(act_texts.items())
                 )
+                print(f"  📋 Full script: {len(full_script)} chars, {len(full_script.split())} words")
 
                 visual_seeds = self._get_visual_seeds()
                 accent_for_expand = (self.current_idea.get("Accent Color") or "cold_teal").replace(" ", "_")


### PR DESCRIPTION
The scene expansion pipeline stopped at Scene 5 because:
1. Script reassembly from Airtable records creates simple [ACT N] markers
2. extract_acts() only matched the full format [ACT N — Title | 0:00-4:10]
3. With no acts found, the entire script was treated as 1 act
4. _plan_batches() clamped a single act to max 5 scenes

Fixes:
- Add ACT_MARKER_SIMPLE_PATTERN fallback regex in extract_acts()
- Handle single-act edge case in _plan_batches() without 3-5 clamp
- Add diagnostic logging for script reassembly and act extraction

https://claude.ai/code/session_01BjZCTUK3pVjf9Z5r69yoQf