### PR TITLE
fix: connect OpenAI API key for Whisper transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ SLACK_BOT_TOKEN=xoxb-xxxxx
 SLACK_CHANNEL_ID=C0A9U1X8NSW
 
 # ============================================
+# OPENAI (Whisper transcription API)
+# ============================================
+OPENAI_API_KEY=sk-xxxxx
+
+# ============================================
 # ELEVENLABS (Voice Synthesis)
 # ============================================
 ELEVENLABS_API_KEY=xxxxx


### PR DESCRIPTION
- Add OPENAI_API_KEY to .env.example template
- Load .env in transcriber.py so API key is available at import time
- Validate API key before creating OpenAI client with clear error message
- Skip placeholder keys (sk-xxxxx) to avoid misleading API calls
- Install openai and python-dotenv packages as dependencies

https://claude.ai/code/session_01Mxbzn4QrWyj8YEU9QqkFLR