### PR TITLE
fix: Sync images and words to actual audio timing instead of hardcoded 60s

### DIFF
--- a/remotion-video/src/Root.tsx
+++ b/remotion-video/src/Root.tsx
@@ -1,11 +1,34 @@
 import { Composition } from "remotion";
 import { Main } from "./Main";
 import { EconomyVideoAnimated } from "./compositions/EconomyVideoAnimated";
+import { getWordsForScene } from "./transcripts";
 
-// Each scene is approximately 60 seconds of audio
-const SCENE_DURATION_SECONDS = 60;
 const TOTAL_SCENES = 20;
 const FPS = 24;
+// Buffer after last spoken word to let audio trail off naturally
+const SCENE_END_BUFFER_SECONDS = 1;
+// Fallback when transcript data is unavailable
+const FALLBACK_SCENE_DURATION_SECONDS = 60;
+
+/**
+ * Compute actual scene duration from Whisper transcript word timestamps.
+ */
+function getSceneDurationSeconds(sceneNumber: number): number {
+    const words = getWordsForScene(sceneNumber);
+    if (words.length === 0) return FALLBACK_SCENE_DURATION_SECONDS;
+    return words[words.length - 1].end + SCENE_END_BUFFER_SECONDS;
+}
+
+/**
+ * Sum actual durations across all scenes for total video length.
+ */
+function getTotalDurationFrames(sceneCount: number, fps: number): number {
+    let total = 0;
+    for (let i = 1; i <= sceneCount; i++) {
+        total += Math.ceil(getSceneDurationSeconds(i) * fps);
+    }
+    return total;
+}
 
 export const RemotionRoot: React.FC = () => {
     return (
@@ -13,7 +36,7 @@ export const RemotionRoot: React.FC = () => {
             <Composition
                 id="Main"
                 component={Main}
-                durationInFrames={TOTAL_SCENES * SCENE_DURATION_SECONDS * FPS}
+                durationInFrames={getTotalDurationFrames(TOTAL_SCENES, FPS)}
                 fps={FPS}
                 width={1920}
                 height={1080}
@@ -24,7 +47,7 @@ export const RemotionRoot: React.FC = () => {
             <Composition
                 id="Scene1Only"
                 component={Main}
-                durationInFrames={90 * FPS}
+                durationInFrames={Math.ceil(getSceneDurationSeconds(1) * FPS)}
                 fps={FPS}
                 width={1920}
                 height={1080}

--- a/remotion-video/src/renderConfig.ts
+++ b/remotion-video/src/renderConfig.ts
@@ -17,6 +17,8 @@ export interface RenderScene {
     ken_burns: Record<string, unknown>;
     transition_in: Record<string, unknown>;
     transition_out: Record<string, unknown>;
+    sentence_text?: string;
+    image_index?: number;
 }
 
 export interface RenderConfig {


### PR DESCRIPTION
Root cause: Main.tsx and Root.tsx hardcoded every scene to 60 seconds,
but actual scene audio durations range from 65-80 seconds. This clipped
5-20 seconds of narration, images, and captions from every scene,
losing ~4 minutes of content across the full video.

Three interconnected fixes:

1. Dynamic scene durations (Main.tsx, Root.tsx):
   - Compute each scene's duration from its Whisper transcript timestamps
   - Total video duration now sums actual scene lengths instead of 20×60

2. Per-image render_config with sentence_text (pipeline.py, render_config_writer.py):
   - Audio sync now writes per-IMAGE entries (140-180) instead of per-scene (20)
   - Each entry includes sentence_text from Airtable for word-to-image matching
   - render_config.json is auto-copied to remotion-video/public/

3. Fix word-image alignment in Remotion (segments.ts, renderConfig.ts):
   - Pass sentence_text through to buildSegmentsFromPipeline for accurate matching
   - Add duration-based fallback when sentence text unavailable (replaces broken
     empty-text word matching that produced garbage segment boundaries)

https://claude.ai/code/session_01CxjSrWyrrXpdU7N66VQzQQ