### PR TITLE
fix: add web search to discovery scanner and research agent

### DIFF
--- a/skills/video-pipeline/pipeline_control.py
+++ b/skills/video-pipeline/pipeline_control.py
@@ -856,6 +856,8 @@ async def handle_discover(message, say, client):
     # Extract optional focus keyword from message text
     text = message.get("text", "").strip()
     focus = re.sub(r"^(run\s+)?(?:discover|scan)\s*", "", text, flags=re.IGNORECASE).strip()
+    # Strip brackets — users type "Discover [topic]" but brackets aren't part of the topic
+    focus = focus.strip("[]")
     channel = message.get("channel", "")
 
     focus_msg = f" (focus: {focus})" if focus else ""

--- a/skills/video-pipeline/research_agent.py
+++ b/skills/video-pipeline/research_agent.py
@@ -38,7 +38,14 @@ research brief that will be used to write a 25-minute narration script with
 The research must be DEEP — not surface-level summaries. You are producing the
 intellectual foundation for a video that will be watched by hundreds of thousands
 of people. Every fact must be specific, every parallel must be illuminating,
-every angle must hook the viewer."""
+every angle must hook the viewer.
+
+You have web search available. USE IT to verify facts before including them.
+- Search for every key claim, statistic, and date
+- Include only facts you can verify via web search
+- Cite real sources for key claims
+- If you cannot verify a fact, mark it as unverified
+- For niche topics, search multiple query variations"""
 
 RESEARCH_PROMPT_TEMPLATE = """\
 Research the following topic in depth:
@@ -198,6 +205,8 @@ class ResearchAgent:
                 - title_options (str)
                 - thumbnail_concepts (str)
         """
+        from clients.anthropic_client import WEB_SEARCH_TOOL
+
         logger.info(f"Starting deep research on: {topic}")
 
         prompt = _build_research_prompt(topic, seed_urls, context)
@@ -208,6 +217,7 @@ class ResearchAgent:
             model=self.model,
             max_tokens=8000,
             temperature=0.7,
+            tools=[WEB_SEARCH_TOOL],
         )
 
         payload = _parse_research_payload(response)


### PR DESCRIPTION
The discovery scanner and research agent were calling Claude with no
web search tool — all headlines were hallucinated from training data
and all research facts were unverified. This caused focused queries
like "Discover [el mencho CJNG]" to return unrelated China/Taiwan
headlines because Claude had no internet access to search for the
actual topic.

Changes:
- anthropic_client.py: Add optional `tools` param to generate(),
  add _extract_text() to handle mixed content blocks from web
  search responses, define WEB_SEARCH_TOOL constant
- discovery_scanner.py: Pass WEB_SEARCH_TOOL to _gather_headlines(),
  rewrite prompts to instruct Claude to search the web for real
  headlines, make focus a hard constraint ("ALL ideas MUST be about
  this topic") instead of soft suggestion, remove unused
  _build_scan_query()
- research_agent.py: Pass WEB_SEARCH_TOOL to research(), add
  instructions to verify facts via web search
- pipeline_control.py: Strip brackets from focus keyword so
  "Discover [el mencho CJNG]" passes "el mencho CJNG" not
  "[el mencho CJNG]"

https://claude.ai/code/session_01Sx9mBzSBce8gNfurWmteoL