### PR TITLE
Remove redundant json imports throughout pipeline.py

### DIFF
--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2371,7 +2371,6 @@ class VideoPipeline:
         props_file = remotion_dir / "props.json"
         public_dir.mkdir(exist_ok=True)
 
-        import json
         with open(props_file, "w") as f:
             json.dump(props, f, indent=2)
         print(f"  📦 Props saved to: {props_file}")
@@ -2818,9 +2817,8 @@ class VideoPipeline:
                 "language": "en",
             }
             try:
-                import json as _json
                 with open(caption_path, "w") as _f:
-                    _json.dump(caption_data, _f, indent=2)
+                    json.dump(caption_data, _f, indent=2)
                 print(f"    Scene {scene_num}: wrote {len(words)} words to {caption_path.name}")
             except Exception as e:
                 print(f"    Scene {scene_num}: ⚠️ caption write failed ({e})")
@@ -3734,7 +3732,6 @@ async def main():
 
     # === MORE IDEAS FROM FORMAT LIBRARY ===
     if len(sys.argv) > 1 and sys.argv[1] == "--more-ideas":
-        import json
         import os as os_mod
         from bots.idea_modeling import generate_modeled_ideas
         
@@ -3969,7 +3966,6 @@ async def main():
         
     if len(sys.argv) > 1 and sys.argv[1] == "--remotion":
         # Export Remotion props for a specific video
-        import json
         from pathlib import Path
 
         # Get title from args or use default


### PR DESCRIPTION
## Summary
Removed redundant local `json` module imports that were declared multiple times within the same file. The `json` module is already imported at the top of the file, making these inline imports unnecessary.

## Key Changes
- Removed `import json` from `run_render_bot()` method (line 2375)
- Removed `import json as _json` from `run_audio_sync()` method and updated the corresponding `json.dump()` call to use the standard `json` reference (line 2820)
- Removed `import json` from `main()` function in the `--more-ideas` conditional block (line 3735)
- Removed `import json` from `run_more_ideas()` function in the `--remotion` conditional block (line 3972)

## Implementation Details
These changes improve code cleanliness by eliminating redundant imports. The `json` module is already imported at the module level, so these local imports were unnecessary. This also makes the code more consistent by using the same `json` reference throughout rather than aliasing it as `_json` in one location.

https://claude.ai/code/session_011LDmVMnZcLj27sUL8B5EJA