### PR TITLE
Fix recurring audio contamination: remove hardcoded video titles, add cache invalidation

### DIFF
--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2304,7 +2304,7 @@ class VideoPipeline:
 
         # CLEAN PUBLIC/ DIR — prevents asset contamination between renders
         # Each video needs its own Scene_XX_XX.png files; stale files from
-        # a previous render would produce wrong visuals.
+        # a previous render would produce wrong visuals or WRONG AUDIO.
         remotion_dir = Path(__file__).parent.parent.parent / "remotion-video"
         public_dir = remotion_dir / "public"
         if public_dir.exists():
@@ -2312,12 +2312,24 @@ class VideoPipeline:
             stale_audio = glob_mod.glob(str(public_dir / "Scene *.mp3"))
             stale_images = glob_mod.glob(str(public_dir / "Scene_*.png"))
             stale_videos = glob_mod.glob(str(public_dir / "Scene_*.mp4"))
+            stale_config = glob_mod.glob(str(public_dir / "render_config.json"))
             removed = 0
-            for f in stale_audio + stale_images + stale_videos:
+            for f in stale_audio + stale_images + stale_videos + stale_config:
                 os.remove(f)
                 removed += 1
             if removed:
                 print(f"  🧹 Cleaned {removed} stale assets from public/")
+
+        # CLEAN CAPTION FILES — stale captions from a previous video cause
+        # wrong karaoke text and timing in the rendered video.
+        captions_dir = remotion_dir / "src" / "captions"
+        if captions_dir.exists():
+            import glob as glob_mod
+            stale_captions = glob_mod.glob(str(captions_dir / "Scene *.json"))
+            for f in stale_captions:
+                os.remove(f)
+            if stale_captions:
+                print(f"  🧹 Cleaned {len(stale_captions)} stale caption files")
 
         # PRE-FLIGHT CHECK: Regenerate any missing/pending images before render
         # This prevents render failures due to missing image files

--- a/skills/video-pipeline/reset_visuals.py
+++ b/skills/video-pipeline/reset_visuals.py
@@ -48,5 +48,9 @@ def reset_visuals(video_title: str):
 
 
 if __name__ == "__main__":
-    title = "The Robot TRAP Nobody Sees Coming (A 4-Stage Monopoly)"
+    if len(sys.argv) > 1:
+        title = " ".join(sys.argv[1:])
+    else:
+        print("Usage: python3 reset_visuals.py \"Video Title\"")
+        sys.exit(1)
     reset_visuals(title)

--- a/skills/video-pipeline/run_audio_sync.py
+++ b/skills/video-pipeline/run_audio_sync.py
@@ -38,7 +38,30 @@ from audio_sync.ken_burns_calculator import assign_ken_burns
 from audio_sync.render_config_writer import build_render_config, write_render_config
 
 
-VIDEO_TITLE = "The Robot TRAP Nobody Sees Coming (A 4-Stage Monopoly)"
+def _get_video_title() -> str:
+    """Get video title from CLI args or prompt interactively."""
+    if len(sys.argv) > 1:
+        return " ".join(sys.argv[1:])
+
+    # No hardcoded default — force explicit selection to prevent
+    # audio contamination between videos (the #1 recurring bug).
+    print("Usage: python3 run_audio_sync.py \"Video Title\"")
+    print("\nAvailable videos (from Airtable):")
+    try:
+        api = get_airtable_api()
+        table = api.table(AIRTABLE_BASE_ID, AIRTABLE_IDEAS_TABLE_ID)
+        records = table.all(sort=["Video Title"])
+        for r in records:
+            status = r["fields"].get("Status", "")
+            title = r["fields"].get("Video Title", "")
+            if title and status in ("Ready To Render", "Done", "Rendered"):
+                print(f"  • [{status}] {title}")
+    except Exception:
+        pass
+    sys.exit(1)
+
+
+VIDEO_TITLE = _get_video_title()
 DESKTOP_SRC = Path.home() / "Desktop" / VIDEO_TITLE
 
 # Hardcoded Airtable IDs (must match clients/airtable_client.py)

--- a/skills/video-pipeline/run_remaining_pipeline.py
+++ b/skills/video-pipeline/run_remaining_pipeline.py
@@ -22,9 +22,18 @@ async def main():
     
     pipeline = VideoPipeline()
     
-    # Set the folder ID from the previous script bot run
-    pipeline.project_folder_id = "1dF0p5iMgUa04oArBvAnHswHJKSckacmS"
-    pipeline.video_title = "Why AI's \"Fake Bubble\" Will Make You RICH"
+    # Load from Airtable via CLI argument — no hardcoded titles/IDs
+    if len(sys.argv) < 2:
+        print("Usage: python3 run_remaining_pipeline.py \"Video Title\"")
+        sys.exit(1)
+    video_title = " ".join(sys.argv[1:])
+
+    ideas = pipeline.airtable.get_all_ideas()
+    idea = next((i for i in ideas if i.get("Video Title") == video_title), None)
+    if not idea:
+        print(f"❌ No idea found with title: {video_title}")
+        sys.exit(1)
+    pipeline._load_idea(idea)
     
     try:
         # Step 1: Voice Bot

--- a/skills/video-pipeline/upload_images_to_drive.py
+++ b/skills/video-pipeline/upload_images_to_drive.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Download images from Airtable and upload to Google Drive.
 
-Reads all image records for the Robot video, downloads each attachment,
+Reads all image records for a video, downloads each attachment,
 and uploads to the matching Google Drive folder with Scene_XX_YY.png naming.
 
-Usage (on VPS):
-    python3 upload_images_to_drive.py
+Usage:
+    python3 upload_images_to_drive.py "Video Title"
 """
 import os
 import sys
@@ -23,7 +23,15 @@ import httpx
 from clients.airtable_client import AirtableClient
 from clients.google_client import GoogleClient
 
-VIDEO_TITLE = "The Robot TRAP Nobody Sees Coming (A 4-Stage Monopoly)"
+def _get_video_title() -> str:
+    """Get video title from CLI args — no hardcoded default."""
+    if len(sys.argv) > 1:
+        return " ".join(sys.argv[1:])
+    print("Usage: python3 upload_images_to_drive.py \"Video Title\"")
+    sys.exit(1)
+
+
+VIDEO_TITLE = _get_video_title()
 
 
 def main():


### PR DESCRIPTION
Root cause of the repeated "wrong audio in Remotion render" bug:

1. run_audio_sync.py had VIDEO_TITLE hardcoded to "The Robot TRAP..." —
   every manual run synced the wrong video's data, overwriting
   render_config.json and caption files in public/

2. Whisper transcriber cached results indefinitely with no invalidation —
   when audio files changed (regenerated voices), stale transcriptions
   were silently reused

3. Render bot cleaned Scene*.mp3 and Scene*.png but NOT render_config.json
   or caption files — stale timing/karaoke data from previous videos
   persisted across renders

Fixes:
- run_audio_sync.py, upload_images_to_drive.py, reset_visuals.py,
  run_remaining_pipeline.py: require video title as CLI argument,
  no more hardcoded defaults
- transcriber.py: cache now tracks audio file size/mtime/path and
  invalidates when the source audio changes
- pipeline.py render bot: clean render_config.json and all caption
  files alongside audio/image cleanup

https://claude.ai/code/session_01J6TYAtm24VFCDdMnruLSx3