### PR TITLE
Add chunked resumable upload for large files to Google Drive

### DIFF
--- a/tasks/upload_video_drive.py
+++ b/tasks/upload_video_drive.py
@@ -1,0 +1,53 @@
+"""Upload a rendered video to Google Drive using chunked resumable upload.
+
+Usage:
+    python tasks/upload_video_drive.py <file_path> <folder_id>
+
+Example:
+    python tasks/upload_video_drive.py \
+        /home/clawd/projects/economy-fastforward/remotion-video/out/final.mp4 \
+        1fsFx4mT0JnmFvJcMkMmk69lIopD_voY9
+"""
+
+import os
+import sys
+
+# Add video-pipeline to path for client imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "video-pipeline"))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from clients.google_client import GoogleClient
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python tasks/upload_video_drive.py <file_path> <folder_id>")
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    folder_id = sys.argv[2]
+
+    if not os.path.isfile(file_path):
+        print(f"Error: File not found: {file_path}")
+        sys.exit(1)
+
+    file_name = os.path.basename(file_path)
+    client = GoogleClient()
+    result = client.upload_large_file(
+        file_path=file_path,
+        name=file_name,
+        folder_id=folder_id,
+        mime_type="video/mp4",
+    )
+
+    file_id = result["id"]
+    client.make_file_public(file_id)
+    drive_link = f"https://drive.google.com/file/d/{file_id}/view"
+    print(f"\n    Drive link: {drive_link}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR adds support for uploading large files to Google Drive using chunked resumable uploads, which prevents loading entire files into memory and provides better reliability for large video files.

## Key Changes
- **New `upload_large_file()` method** in `GoogleClient`: Implements chunked resumable upload using `MediaFileUpload` with configurable chunk sizes (default 50 MB). Reads files from disk in chunks rather than loading into memory, making it suitable for files >100 MB.
  - Supports both creating new files and updating existing files (with `check_existing` option)
  - Includes progress reporting during upload
  - Implements retry logic for transient HTTP errors (500, 502, 503, 504)
  
- **Updated imports**: Added `MediaFileUpload` to the Google API client imports alongside existing `MediaIoBaseUpload`

- **New utility script** `tasks/upload_video_drive.py`: Command-line tool for uploading rendered videos to Google Drive
  - Takes file path and folder ID as arguments
  - Automatically makes uploaded files public
  - Outputs shareable Google Drive link upon completion

## Implementation Details
- Chunk size is configurable and defaults to 50 MB (must be a multiple of 256 KB per Google API requirements)
- Uses resumable upload protocol (`resumable=True`) for reliability
- Provides real-time upload progress as percentage
- Gracefully handles transient server errors with exponential backoff
- Checks for existing files to avoid duplicates (can be disabled)

https://claude.ai/code/session_01KdTSg95ErQZ9odu19tAYNp