### PR TITLE
Enhance thumbnails: stronger archetypes, precise text placement, expanded power triggers, Machiavellian visual vocabulary

### DIFF
--- a/skills/video-pipeline/thumbnail_title/selector.py
+++ b/skills/video-pipeline/thumbnail_title/selector.py
@@ -10,13 +10,18 @@ POWER_KEYWORDS = [
     "robot", "ai replace", "monopoly", "inequality",
     "corporate", "billionaire", "oligarch", "who owns",
     "who controls", "who profits",
+    "ban", "blacklist", "purge", "weapon", "sanctions",
+    "trap", "control", "dominance", "leverage", "coercion",
+    "force", "punish", "puppet", "chess", "weaponize",
+    "crush", "destroy", "eliminate", "betray", "backstab",
+    "exploit",
 ]
 
 # Keywords that trigger Template B: Mindplicit Banner
 STRATEGY_KEYWORDS = [
     "machiavelli", "strategy", "hidden", "secret",
     "never do", "warning", "dark", "manipulation",
-    "power play", "puppet",
+    "power play",
 ]
 
 

--- a/skills/video-pipeline/thumbnail_title/templates.py
+++ b/skills/video-pipeline/thumbnail_title/templates.py
@@ -1,9 +1,9 @@
 """Thumbnail prompt templates for Economy FastForward.
 
 Three templates, each producing a distinct visual layout:
-  - Template A: CFH Split (default, ~70% usage)
-  - Template B: Mindplicit Banner (~20% usage)
-  - Template C: Power Dynamic (~10% usage, EFF exclusive)
+  - Template A: CFH Split (default, ~60% usage)
+  - Template B: Mindplicit Banner (~10% usage)
+  - Template C: Power Dynamic (~30% usage, EFF exclusive)
 
 All templates produce 1280x720 (16:9) editorial comic illustrations
 via Nano Banana Pro with text baked directly into the image.
@@ -13,20 +13,29 @@ via Nano Banana Pro with text baked directly into the image.
 # ---------------------------------------------------------------------------
 # Template A: CFH Split
 # ---------------------------------------------------------------------------
+# character_archetype should be a RECOGNIZABLE STEREOTYPE, not a generic person.
+# Examples: "panicked Wall Street trader in rumpled suit with loosened tie",
+# "smug Uncle Sam with top hat and pointing finger",
+# "sweating Pentagon general covered in medals",
+# "terrified tech CEO gripping cracked laptop",
+# "furious Chinese official slamming table"
 TEMPLATE_A_CFH_SPLIT = (
     "Editorial comic illustration, bold graphic novel style, dark navy background "
     "with dramatic amber side lighting, 16:9 landscape aspect ratio,\n\n"
-    "Left 60% of frame: {nationality} {worker_type} with {emotion} facial expression, "
-    "wearing {cultural_signifier}, mouth {mouth_expression}, waist-up framing, "
+    "Left 60% of frame: {character_archetype} with {emotion} facial expression, "
+    "mouth {mouth_expression}, waist-up framing, "
     "face is large and clearly readable, bold black outlines, high color saturation, "
     "sweat drops or motion lines reinforcing the emotion,\n\n"
     "Right side: {secondary_element}, this element tells the second half of the story "
     "and contrasts with the figure's emotion,\n\n"
-    'Bold text in upper right area reading "{line_1}" in large white bold condensed '
-    'all-caps font with heavy black outline stroke, the word "{red_word}" is bright red, '
-    'below it smaller white bold text "{line_2}" with black outline,\n\n'
-    "Dark navy gradient background, simple composition, thick confident black linework, "
-    "bold saturated colors, magazine cover composition"
+    "Bold text block anchored to upper-right 35% of frame, text must not overlap "
+    "the character's face. Line_1 reading \"{line_1}\" in large white bold condensed "
+    "all-caps font with heavy black outline stroke, the word \"{red_word}\" is bright "
+    "red and is the LARGEST text element. Directly below with no gap, smaller white "
+    "bold text \"{line_2}\" with black outline. Line_1 font size is approximately 3x "
+    "larger than line_2.\n\n"
+    "Simple composition, thick confident black linework, bold saturated colors, "
+    "magazine cover composition, high contrast, readable at small mobile thumbnail size"
 )
 
 
@@ -36,13 +45,15 @@ TEMPLATE_A_CFH_SPLIT = (
 TEMPLATE_B_MINDPLICIT_BANNER = (
     "Editorial comic illustration, dark dramatic scene, deep navy black background "
     "with warm amber lighting from below, 16:9 landscape aspect ratio,\n\n"
-    'Bold text banner across top of frame reading "{line_1}" in large white bold '
-    'condensed all-caps font with heavy black outline stroke, the word "{red_word}" '
-    'is bright red, below it smaller white text "{line_2}" with black outline,\n\n'
+    "Text banner spans full width across top 20% of frame. \"{line_1}\" in large "
+    "white bold condensed all-caps font with heavy black outline stroke, the word "
+    "\"{red_word}\" is bright red and LARGEST. \"{line_2}\" directly below, smaller "
+    "white text with black outline. Text must be fully contained in top 20% of frame.\n\n"
     "Center and lower frame: {power_scene}, dramatic shadows with warm amber accent "
     "lighting on key focal points,\n\n"
-    "{ground_detail}, editorial illustration with noir influence, bold blacks, "
-    "dramatic contrast, thick black linework"
+    "{ground_detail},\n\n"
+    "Simple composition, thick confident black linework, bold saturated colors, "
+    "magazine cover composition, high contrast, readable at small mobile thumbnail size"
 )
 
 
@@ -52,6 +63,10 @@ TEMPLATE_B_MINDPLICIT_BANNER = (
 TEMPLATE_C_POWER_DYNAMIC = (
     "Editorial comic illustration, bold graphic novel style, dark navy background "
     "with dramatic golden amber lighting, 16:9 landscape aspect ratio,\n\n"
+    "Bold text reading \"{line_1}\" anchored to top-center of frame, spanning full "
+    "width. \"{red_word}\" is bright red and LARGEST text element. \"{line_2}\" "
+    "directly below, smaller white text with black outline. All text contained in "
+    "top 15% of frame, above both figures.\n\n"
     "Left side: {victim_type} stumbling backward in {emotion}, {cultural_signifier} "
     "flying off, mouth open, eyes wide, bold black outlines, high color saturation, "
     "waist-up framing with large readable facial expression, cold blue lighting on "
@@ -61,11 +76,8 @@ TEMPLATE_C_POWER_DYNAMIC = (
     "in the golden glow,\n\n"
     "A large bold red arrow pointing from the victim toward the instrument suggesting "
     "{relationship},\n\n"
-    'Bold text reading "{line_1}" in large white bold condensed all-caps font with '
-    'heavy black outline stroke at top of frame, the word "{red_word}" is bright red, '
-    'below it smaller white text "{line_2}" with black outline,\n\n'
-    "Simple composition, thick confident black linework, magazine cover style, "
-    "dramatic contrast between cold blue victim side and warm golden power side"
+    "Simple composition, thick confident black linework, bold saturated colors, "
+    "magazine cover composition, high contrast, readable at small mobile thumbnail size"
 )
 
 
@@ -76,17 +88,16 @@ TEMPLATES = {
     "template_a": {
         "name": "CFH Split",
         "prompt": TEMPLATE_A_CFH_SPLIT,
-        "usage_weight": 0.70,
+        "usage_weight": 0.60,
         "variables": [
-            "nationality", "worker_type", "emotion", "cultural_signifier",
-            "mouth_expression", "secondary_element", "line_1", "red_word",
-            "line_2",
+            "character_archetype", "emotion", "mouth_expression",
+            "secondary_element", "line_1", "red_word", "line_2",
         ],
     },
     "template_b": {
         "name": "Mindplicit Banner",
         "prompt": TEMPLATE_B_MINDPLICIT_BANNER,
-        "usage_weight": 0.20,
+        "usage_weight": 0.10,
         "variables": [
             "line_1", "red_word", "line_2", "power_scene", "ground_detail",
         ],
@@ -94,7 +105,7 @@ TEMPLATES = {
     "template_c": {
         "name": "Power Dynamic",
         "prompt": TEMPLATE_C_POWER_DYNAMIC,
-        "usage_weight": 0.10,
+        "usage_weight": 0.30,
         "variables": [
             "victim_type", "emotion", "cultural_signifier", "power_figure",
             "instrument", "relationship", "line_1", "red_word", "line_2",

--- a/skills/video-pipeline/thumbnail_title/title_generator.py
+++ b/skills/video-pipeline/thumbnail_title/title_generator.py
@@ -85,8 +85,12 @@ Your job: Generate a click-worthy title that follows one of the proven formula p
 
 RULES:
 1. The title MUST contain exactly ONE word in ALL CAPS — this is the curiosity trigger.
-2. The CAPS word becomes the red highlight in the thumbnail. Pick a word with emotional weight:
-   TRAP, DEATH, COLLAPSE, WEAPON, CRISIS, LIES, DYING, SWALLOWED, MISTAKE, STRONGER, WEAKER, RICHER, etc.
+2. The CAPS word becomes the red highlight in the thumbnail. It must trigger a visceral
+   emotional reaction — a gut punch, not a label.
+   BEST caps_words (prefer these): PURGE, TRAP, KILLED, CRUSHED, WEAPONIZED, BLACKLISTED,
+   BANNED, BETRAYED, RIGGED, DOOMED, BROKE, DEAD, SWALLOWED, COLLAPSE, DEATH, DYING
+   AVOID generic structural words: STAGE, STEP, PHASE, PATTERN, LAWS, RULES, SYSTEM, PLAN
+   The caps_word should make a viewer feel something, not describe a format.
 3. The main hook (before the parenthetical) should be 6-8 words.
 4. The parenthetical reveal should create a curiosity gap.
 5. Total title length should be under 70 characters for the main hook.


### PR DESCRIPTION
- templates.py: Replace nationality/worker_type with character_archetype for
  recognizable stereotypes, tighten text placement with explicit anchoring and
  size ratios, unify all 3 templates with consistent style footer
- selector.py: Expand Template C triggers with 21 new power/conflict keywords
  (ban, blacklist, purge, weapon, trap, etc.), shift expected usage from ~10%
  to ~30%, remove puppet from Template B (now in Template C)
- title_generator.py: Add visceral caps_word guidance (PURGE, KILLED, CRUSHED,
  WEAPONIZED, BLACKLISTED, etc.) and explicitly ban generic structural words
  (STAGE, STEP, PHASE, PATTERN, etc.)
- prompt_builder.py: Add Machiavellian visual element injection (~50% probability)
  from pool of 6 thematic elements (puppet strings, chess pieces, shadowy hand,
  falling crown, cracked scales, dagger in map), update variable descriptions
  for character_archetype and richer Template C guidance

https://claude.ai/code/session_01EC9HEUn2Pqyd5iF6JZoNrY