### PR TITLE
Switch scene image generation from Seed Dream 4.5 to Nano Banana 2

### DIFF
--- a/animation/config.py
+++ b/animation/config.py
@@ -23,7 +23,7 @@ SCENE_PLANNER_MODEL = "claude-sonnet-4-5-20250929"
 QC_MODEL = "claude-haiku-4-5-20241022"
 
 # ==================== IMAGE GENERATION ====================
-SCENE_IMAGE_MODEL = "seedream/4.5-edit"  # Seed Dream 4.5 Edit — reference-based generation
+SCENE_IMAGE_MODEL = "nano-banana-2"  # Nano Banana 2 — reference-based generation (cheaper)
 THUMBNAIL_IMAGE_MODEL = "nano-banana-pro"
 
 # ==================== VIDEO GENERATION ====================

--- a/storyengine/backend/src/clients/image.ts
+++ b/storyengine/backend/src/clients/image.ts
@@ -2,14 +2,14 @@
  * Image Generation Client via Kie.ai API
  *
  * Ported from: skills/video-pipeline/clients/image_client.py
- * Supports Seed Dream 4.0 (scene images) and Nano Banana Pro (thumbnails).
+ * Supports Nano Banana 2 (scene images) and Nano Banana Pro (thumbnails).
  */
 
 const CREATE_TASK_URL = "https://api.kie.ai/api/v1/jobs/createTask";
 const RECORD_INFO_URL = "https://api.kie.ai/api/v1/jobs/recordInfo";
 
 // Model routing
-const SCENE_MODEL = "seedream/4.5-edit";
+const SCENE_MODEL = "nano-banana-2";
 const THUMBNAIL_MODEL = "nano-banana-pro";
 
 export class ImageClient {
@@ -111,7 +111,7 @@ export class ImageClient {
   }
 
   /**
-   * Generate a scene image using Seed Dream 4.5 Edit with reference.
+   * Generate a scene image using Nano Banana 2 with reference.
    */
   async generateSceneImage(
     prompt: string,
@@ -122,10 +122,10 @@ export class ImageClient {
       model: SCENE_MODEL,
       input: {
         prompt,
-        image_urls: [referenceImageUrl],
+        image_input: [referenceImageUrl],
         aspect_ratio: "16:9",
-        quality: "basic",
-        ...(seed !== undefined ? { seed } : {}),
+        resolution: "1K",
+        output_format: "png",
       },
     };
 
@@ -151,7 +151,7 @@ export class ImageClient {
       if (urls?.length) {
         return {
           url: urls[0],
-          seed: taskData?.data?.seed ?? seed,
+          seed: undefined,
         };
       }
       return null;


### PR DESCRIPTION
## Summary
Migrate scene image generation across the codebase from Seed Dream 4.5 Edit to Nano Banana 2 model, which provides cost savings while maintaining reference image support for character and scene consistency.

## Key Changes
- **Model Update**: Changed `SCENE_MODEL` from `"seedream/4.5-edit"` to `"nano-banana-2"` in:
  - `skills/video-pipeline/clients/image_client.py`
  - `storyengine/backend/src/clients/image.ts`
  - `animation/config.py`

- **API Parameter Changes**: Updated payload structure for Nano Banana 2 compatibility:
  - Renamed `image_urls` → `image_input` (reference image parameter)
  - Replaced `quality: "basic"` with `resolution: "1K"` and `output_format: "png"`
  - Removed seed parameter handling (Nano Banana 2 does not support seeds)

- **Return Value Updates**: Changed seed return value from `task_data.get("data", {}).get("seed", seed)` to `None` since the new model doesn't support seed-based reproducibility

- **Documentation**: Updated docstrings and comments to reflect the model change and clarify that the `seed` parameter is kept for API compatibility but unused

## Implementation Details
- The `generate_scene_image_with_reference()` method continues to delegate to `generate_scene_image()`, maintaining the same interface
- All reference image functionality is preserved—the Core Image is still passed as a reference for consistency in character/scene generation
- Changes are synchronized across both Python (video pipeline) and TypeScript (backend) implementations

https://claude.ai/code/session_01SfRapXzCkm9JskvajNnsF8