### PR TITLE
Fix scene audio verification and add video file support

### DIFF
--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2474,8 +2474,8 @@ class VideoPipeline:
             if removed:
                 print(f"  🧹 Cleaned {removed} stale assets from public/")
 
-        # CLEAN CAPTION FILES — stale captions from a previous video cause
-        # wrong karaoke text and timing in the rendered video.
+        # CLEAN CAPTION FILES — audio_sync still writes these for legacy
+        # compatibility. Remove stale ones to avoid confusion between renders.
         captions_dir = remotion_dir / "src" / "captions"
         if captions_dir.exists():
             import glob as glob_mod
@@ -2587,10 +2587,11 @@ class VideoPipeline:
                 fname = df["name"]
                 fid = df["id"]
 
-                # Only download Scene audio (.mp3) and image (.png) files
+                # Download Scene audio (.mp3), image (.png), and video (.mp4) files
                 is_audio = fname.startswith("Scene ") and fname.endswith(".mp3")
                 is_image = fname.startswith("Scene_") and fname.endswith(".png")
-                if not is_audio and not is_image:
+                is_video = fname.startswith("Scene_") and fname.endswith(".mp4")
+                if not is_audio and not is_image and not is_video:
                     continue
 
                 dest = public_dir / fname
@@ -2669,12 +2670,14 @@ class VideoPipeline:
             print(f"  🔊 {sfx_count} SFX files ready in public/sfx/")
 
         # Verify every scene has its audio file (Remotion will 404 without it)
-        scene_count = len(props.get("scenes", []))
+        # Use actual scene numbers from props — NOT sequential range(1, N+1)
+        # which breaks when scene numbers have gaps or don't start at 1.
         missing_audio = []
-        for i in range(1, scene_count + 1):
-            audio_path = public_dir / f"Scene {i}.mp3"
+        for scene in props.get("scenes", []):
+            scene_num = scene.get("sceneNumber", 0)
+            audio_path = public_dir / f"Scene {scene_num}.mp3"
             if not audio_path.exists():
-                missing_audio.append(f"Scene {i}.mp3")
+                missing_audio.append(f"Scene {scene_num}.mp3")
 
         if missing_audio:
             missing_list = ", ".join(missing_audio[:10])
@@ -2686,6 +2689,7 @@ class VideoPipeline:
             )
             return {"error": f"Missing audio: {missing_list}", "bot": "Render Bot"}
 
+        scene_count = len(props.get("scenes", []))
         self.slack.notify(
             f"⬇️ *Assets ready:* _{self.video_title}_\n"
             f"{scene_count} scenes, all audio verified. Starting Remotion render now..."


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in scene audio verification that breaks when scene numbers have gaps or don't start at 1, and adds support for downloading video (.mp4) files alongside audio and image assets.

## Key Changes
- **Fixed scene audio verification logic**: Changed from using sequential `range(1, scene_count + 1)` to iterating over actual scene objects and extracting their `sceneNumber` property. This prevents false "missing audio" errors when scene numbers are non-sequential or don't start at 1.
- **Added video file support**: Extended asset download filtering to include `.mp4` video files (in addition to existing `.mp3` audio and `.png` image files) for Scene assets.
- **Updated caption cleanup comment**: Clarified that caption files are written for legacy compatibility by `audio_sync` and should be removed to avoid confusion between renders.
- **Moved scene_count assignment**: Relocated `scene_count` calculation to after audio verification to keep related logic together.

## Implementation Details
- The scene audio verification now safely handles edge cases like non-contiguous scene numbers (e.g., scenes 1, 3, 5) or scenes starting at numbers other than 1.
- Video file detection follows the same naming pattern as images: `Scene_` prefix with `.mp4` extension.
- All three asset types (audio, image, video) are now treated consistently in the download logic.

https://claude.ai/code/session_01KX5NUxjzDvLAoZGPBwDSm9