### PR TITLE
Add independent thumbnail text overlay (yin-yang mode)

### DIFF
--- a/skills/video-pipeline/clients/airtable_client.py
+++ b/skills/video-pipeline/clients/airtable_client.py
@@ -203,7 +203,7 @@ class AirtableClient:
             "Framework Angle", "Headline", "Timeliness Score",
             "Audience Fit Score", "Content Gap Score", "Monetization Risk",
             "Source URLs", "Executive Hook", "Thesis", "Date Surfaced",
-            "Research Payload", "Thematic Framework",
+            "Research Payload", "Thematic Framework", "Thumbnail Text",
         ]
         for key in rich_field_keys:
             if key in idea_data and idea_data[key]:

--- a/skills/video-pipeline/discovery_scanner.py
+++ b/skills/video-pipeline/discovery_scanner.py
@@ -529,6 +529,7 @@ def build_option_map(ideas: list[dict]) -> list[dict]:
                 "idea": idea,
                 "title": title_opt.get("title", "Untitled"),
                 "formula_id": title_opt.get("formula_id", ""),
+                "thumbnail_text": title_opt.get("thumbnail_text", ""),
             })
     return options
 
@@ -628,6 +629,11 @@ def build_idea_record_from_discovery(idea: dict, idea_number: int = 1) -> dict:
     headline_source = idea.get("headline_source", "")
     source_urls = headline_source  # includes source publication and URL if available
 
+    # Extract thumbnail text from the selected title option
+    thumbnail_text = ""
+    if title_options:
+        thumbnail_text = title_options[0].get("thumbnail_text", "")
+
     record = {
         "viral_title": best_title or f"Discovery Idea {idea_number}",
         "hook_script": idea.get("hook", ""),
@@ -647,6 +653,8 @@ def build_idea_record_from_discovery(idea: dict, idea_number: int = 1) -> dict:
         "Executive Hook": idea.get("hook", ""),
         "Thesis": idea.get("our_angle", ""),
         "Date Surfaced": date.today().isoformat(),
+        # Thumbnail text for yin-yang overlay (independent from title)
+        "Thumbnail Text": thumbnail_text,
         # Store full discovery data as Original DNA for downstream use
         "original_dna": json.dumps({
             "source": "discovery_scanner",

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2322,6 +2322,13 @@ class VideoPipeline:
         if thumbnail_style_override:
             print(f"  🎨 Thumbnail style override active: {thumbnail_style_override[:80]}...")
 
+        # Read independent thumbnail text (yin-yang: different from title)
+        thumbnail_text = (self.current_idea.get("Thumbnail Text") or "").strip()
+        if thumbnail_text:
+            print(f"  📝 Thumbnail Text from Airtable: {thumbnail_text}")
+        else:
+            print(f"  📝 No Thumbnail Text set — will extract from title (legacy behavior)")
+
         # Build metadata for template selection
         video_metadata = {
             "Video Title": video_title,
@@ -2342,6 +2349,7 @@ class VideoPipeline:
             result = await engine.generate(
                 video_metadata,
                 thumbnail_style_override=thumbnail_style_override or None,
+                thumbnail_text=thumbnail_text or None,
             )
         except Exception as e:
             error_msg = f"Thumbnail/title generation failed for '{self.video_title}': {e}"

--- a/skills/video-pipeline/pipeline_control.py
+++ b/skills/video-pipeline/pipeline_control.py
@@ -1235,6 +1235,7 @@ async def handle_reaction_added(event, client):
             selected["idea_index"],
             selected_title=selected["title"],
             selected_formula_id=selected.get("formula_id", ""),
+            selected_thumbnail_text=selected.get("thumbnail_text", ""),
         )
         return
 
@@ -1258,6 +1259,7 @@ async def handle_reaction_added(event, client):
             selected["idea_index"], ideas, airtable_ids,
             selected_title=selected["title"],
             selected_formula_id=selected.get("formula_id", ""),
+            selected_thumbnail_text=selected.get("thumbnail_text", ""),
         )
         remove_discovery_message(item_ts)
         return
@@ -1267,6 +1269,7 @@ async def _handle_discovery_approval(
     client, channel: str, ts: str, idea_index: int,
     selected_title: str = None,
     selected_formula_id: str = "",
+    selected_thumbnail_text: str = "",
 ):
     """Approve a discovery idea and auto-trigger deep research.
 
@@ -1316,6 +1319,7 @@ async def _handle_discovery_approval(
                 "future_prediction": "",
             },
             "writer_guidance": idea.get("our_angle", ""),
+            "Thumbnail Text": selected_thumbnail_text,
             "original_dna": json.dumps({
                 "source": "discovery_scanner",
                 "headline_source": idea.get("headline_source", ""),
@@ -1393,6 +1397,7 @@ async def _handle_cron_discovery_approval(
     ideas: list[dict], airtable_record_ids: list,
     selected_title: str = None,
     selected_formula_id: str = "",
+    selected_thumbnail_text: str = "",
 ):
     """Approve a discovery idea from the cron job's tracked messages.
 
@@ -1453,6 +1458,12 @@ async def _handle_cron_discovery_approval(
                     airtable.update_idea_field(record_id, "Title Formula", selected_formula_id)
                 except Exception as e:
                     log.warning(f"Could not write Title Formula: {e}")
+            # Save thumbnail text for yin-yang overlay
+            if selected_thumbnail_text:
+                try:
+                    airtable.update_idea_field(record_id, "Thumbnail Text", selected_thumbnail_text)
+                except Exception as e:
+                    log.warning(f"Could not write Thumbnail Text: {e}")
             log.info(f"Updated existing Airtable record: {record_id} — {title} (formula: {selected_formula_id})")
         else:
             # Fallback: create a new record (shouldn't normally happen)
@@ -1465,6 +1476,7 @@ async def _handle_cron_discovery_approval(
                     "future_prediction": "",
                 },
                 "writer_guidance": idea.get("our_angle", ""),
+                "Thumbnail Text": selected_thumbnail_text,
                 "original_dna": json.dumps({
                     "source": "discovery_scanner",
                     "headline_source": idea.get("headline_source", ""),

--- a/skills/video-pipeline/thumbnail_title/engine.py
+++ b/skills/video-pipeline/thumbnail_title/engine.py
@@ -3,14 +3,19 @@
 This is the main entry point for the thumbnail/title system. It:
 1. Selects the appropriate template based on video metadata
 2. Generates a title using proven formula patterns
-3. Builds a thumbnail prompt with the title's CAPS word as the red highlight
+3. Builds a thumbnail prompt with text overlay (either independent thumbnail_text
+   or the title's CAPS word as fallback)
 4. Generates the thumbnail image via Nano Banana Pro
 5. Validates the result
 6. Returns a complete package ready for pipeline integration
 
+The yin-yang system: when thumbnail_text is provided, the thumbnail overlay is
+INDEPENDENT from the title — they complement each other without repeating.
+When thumbnail_text is absent, falls back to extracting the CAPS word from the title.
+
 Usage from pipeline.py:
     engine = ThumbnailTitleEngine(anthropic_client, image_client)
-    result = await engine.generate(video_metadata)
+    result = await engine.generate(video_metadata, thumbnail_text="KILLED IN 4 HOURS")
 """
 
 from typing import Optional
@@ -24,12 +29,29 @@ from thumbnail_title.validator import validate_thumbnail, validate_title_thumbna
 # Maximum generation attempts before flagging for manual review
 MAX_GENERATION_ATTEMPTS = 3
 
+# Words that trigger visceral emotional reactions — used to pick the red_word
+# when parsing independent thumbnail text. Ordered roughly by impact.
+EMOTIONALLY_CHARGED_WORDS = {
+    "KILLED", "DEAD", "DEATH", "DYING", "DIE", "MURDER", "PURGE", "PURGED",
+    "TRAP", "TRAPPED", "CRUSHED", "WEAPONIZED", "BLACKLISTED", "BANNED",
+    "BETRAYED", "RIGGED", "DOOMED", "BROKE", "BROKEN", "SWALLOWED",
+    "COLLAPSE", "COLLAPSED", "DESTROYED", "STOLEN", "TOXIC", "FATAL",
+    "EXPOSED", "ERASED", "SILENCED", "ENSLAVED", "OWNED", "DEVOURED",
+    "CONQUERED", "RUINED", "LOST", "BURNED", "FALLEN", "FAILED",
+    "CRASHED", "WIPED", "GUTTED", "BLEEDING", "WAR", "CRISIS",
+    "CHAOS", "LIED", "FRAUD", "SCAM", "LIES", "VICTIM", "BURIED",
+    "STRANGLED", "LOOTED", "HIJACKED", "BANKRUPT", "WRECKED",
+}
+
 
 class ThumbnailTitleEngine:
     """Orchestrates matched title + thumbnail generation.
 
-    Produces title/thumbnail pairs where the CAPS word in the title
-    matches the red_word in the thumbnail, creating a unified visual hook.
+    Supports two modes:
+    - Yin-yang mode (preferred): thumbnail_text is provided independently,
+      creating a complementary but different overlay from the title.
+    - Legacy mode: extracts the CAPS word from the title as the red_word
+      in the thumbnail.
     """
 
     def __init__(self, anthropic_client, image_client):
@@ -42,6 +64,46 @@ class ThumbnailTitleEngine:
         self.title_gen = TitleGenerator(anthropic_client)
         self.prompt_builder = ThumbnailPromptBuilder(anthropic_client)
         self.image_client = image_client
+
+    @staticmethod
+    def _parse_thumbnail_text(thumbnail_text: str) -> dict:
+        """Parse independent thumbnail text into line_1, line_2, and red_word.
+
+        Splits 2-5 word ALL CAPS text into two display lines and picks the
+        most emotionally charged word as the red highlight.
+
+        Args:
+            thumbnail_text: 2-5 word ALL CAPS overlay text, e.g. "KILLED IN 4 HOURS"
+
+        Returns:
+            Dict with line_1, line_2, caps_word (red_word).
+        """
+        text = thumbnail_text.strip().upper()
+        words = text.split()
+
+        # Pick the red word: first emotionally charged word, or first word
+        red_word = words[0]  # default fallback
+        for word in words:
+            if word in EMOTIONALLY_CHARGED_WORDS:
+                red_word = word
+                break
+
+        # Split into line_1 / line_2 based on word count
+        if len(words) <= 3:
+            line_1 = text
+            line_2 = ""
+        elif len(words) == 4:
+            line_1 = " ".join(words[:2])
+            line_2 = " ".join(words[2:])
+        else:  # 5 words
+            line_1 = " ".join(words[:3])
+            line_2 = " ".join(words[3:])
+
+        return {
+            "line_1": line_1,
+            "line_2": line_2,
+            "caps_word": red_word,
+        }
 
     @staticmethod
     def _apply_thumbnail_override(
@@ -114,6 +176,7 @@ class ThumbnailTitleEngine:
         preferred_formula: Optional[str] = None,
         preferred_template: Optional[str] = None,
         thumbnail_style_override: Optional[str] = None,
+        thumbnail_text: Optional[str] = None,
     ) -> dict:
         """Generate a matched title + thumbnail pair.
 
@@ -132,6 +195,10 @@ class ThumbnailTitleEngine:
                   placeholders still substituted).
                 - "APPEND: ..." — append to selected template.
                 - Otherwise — append to selected template.
+            thumbnail_text: Independent thumbnail overlay text (2-5 words, ALL CAPS).
+                When provided, used as the thumbnail text instead of extracting
+                the CAPS word from the title (yin-yang mode). Falls back to
+                title-based extraction when None or empty.
 
         Returns:
             Dict with:
@@ -167,8 +234,20 @@ class ThumbnailTitleEngine:
             preferred_formula=preferred_formula,
         )
         print(f"  Title: {title_data['title']}")
-        print(f"  CAPS word: {title_data['caps_word']}")
-        print(f"  Thumbnail text: {title_data['line_1']} / {title_data['line_2']}")
+        print(f"  CAPS word (from title): {title_data['caps_word']}")
+
+        # Step 2b: Override thumbnail overlay with independent text (yin-yang mode)
+        if thumbnail_text:
+            parsed = self._parse_thumbnail_text(thumbnail_text)
+            title_data["line_1"] = parsed["line_1"]
+            title_data["line_2"] = parsed["line_2"]
+            title_data["caps_word"] = parsed["caps_word"]
+            print(f"  Yin-yang mode: using independent thumbnail text")
+            print(f"  Thumbnail text: {parsed['line_1']}" + (f" / {parsed['line_2']}" if parsed['line_2'] else ""))
+            print(f"  Red word: {parsed['caps_word']}")
+        else:
+            print(f"  Legacy mode: thumbnail text derived from title")
+            print(f"  Thumbnail text: {title_data['line_1']} / {title_data['line_2']}")
 
         # Step 3: Validate title-thumbnail pairing
         pair_valid, pair_issues = validate_title_thumbnail_pair(title_data, template_key)


### PR DESCRIPTION
## Summary
Introduces a "yin-yang mode" for thumbnail generation that allows independent thumbnail overlay text separate from the video title. When thumbnail text is provided, it's used directly for the overlay; otherwise, the system falls back to extracting the CAPS word from the title (legacy behavior).

## Key Changes

- **Thumbnail Engine**: Added `_parse_thumbnail_text()` method to parse independent 2-5 word ALL CAPS text into display lines and extract the most emotionally charged word as the red highlight
- **Emotionally Charged Words**: Introduced `EMOTIONALLY_CHARGED_WORDS` set to intelligently select the red word from thumbnail text based on impact (KILLED, DEAD, BETRAYED, etc.)
- **Generate Method**: Extended `engine.generate()` to accept optional `thumbnail_text` parameter; when provided, overrides title-based extraction with independent overlay text
- **Pipeline Integration**: Updated `pipeline.py` to read "Thumbnail Text" field from Airtable and pass it to the thumbnail engine
- **Discovery Scanner**: Modified to extract and propagate `thumbnail_text` from title options through the idea record building process
- **Pipeline Control**: Updated approval handlers to capture and store `selected_thumbnail_text` in Airtable's "Thumbnail Text" field for both manual and cron-triggered approvals
- **Airtable Client**: Added "Thumbnail Text" to the rich field keys list for proper field handling

## Implementation Details

- The system intelligently selects the red word by scanning for emotionally charged terms first, falling back to the first word if none match
- Text splitting logic handles 2-5 word inputs: ≤3 words on line_1, 4 words split 2-2, 5 words split 3-2
- Maintains backward compatibility: when `thumbnail_text` is None/empty, uses the original title-based CAPS word extraction
- Logging distinguishes between "yin-yang mode" (independent text) and "legacy mode" (title-derived text)

https://claude.ai/code/session_01YYPDcAEfcqGe1T8ikpA5T7