### PR TITLE
Add entity consistency checking to catch hallucinated proper nouns

### DIFF
--- a/skills/video-pipeline/brief_translator/__init__.py
+++ b/skills/video-pipeline/brief_translator/__init__.py
@@ -29,7 +29,7 @@ from .supplementer import (
 )
 from .script_generator import generate_script
 from .scene_expander import expand_scene_concepts
-from .scene_validator import validate_scene_list, auto_fix_minor_issues
+from .scene_validator import validate_scene_list, auto_fix_minor_issues, check_entity_consistency
 from .pipeline_writer import graduate_to_pipeline
 from .psych_angle_assigner import (
     assign_angles_to_scenes,
@@ -162,23 +162,38 @@ class BriefTranslator:
 
             # === STEP 2a: Extract and persist framework ===
             selected_framework = extract_framework_from_script(script)
+            if not selected_framework:
+                # Fallback: use the framework_angle from the research brief
+                selected_framework = brief.get("framework_angle", "")
             if selected_framework:
                 logger.info(f"Selected framework: {selected_framework}")
                 brief["_selected_framework"] = selected_framework
-                # Write to Airtable "Framework" field (graceful degradation)
+                # Write to Airtable "Framework Angle" field (graceful degradation)
                 try:
                     self.airtable.update_idea_fields(
-                        idea_record_id, {"Framework": selected_framework}
+                        idea_record_id, {"Framework Angle": selected_framework}
                     )
                 except Exception as fw_err:
                     logger.warning(
-                        f"Could not write Framework field to Airtable "
-                        f"(field may not exist yet): {fw_err}"
+                        f"Could not write Framework Angle to Airtable: {fw_err}"
                     )
             else:
-                logger.info("No PRIMARY FRAMEWORK line found in script output")
+                logger.info("No framework found in script output or research brief")
 
-            # === STEP 2b: Assign Psychological Angles ===
+            # === STEP 2b: Entity consistency check ===
+            entity_warnings = check_entity_consistency(
+                script=script,
+                brief=brief,
+                slack_client=self.slack,
+                video_title=brief.get("headline", ""),
+            )
+            if entity_warnings:
+                logger.warning(
+                    f"Entity consistency: {len(entity_warnings)} potential "
+                    f"hallucination(s) detected"
+                )
+
+            # === STEP 2c: Assign Psychological Angles ===
             from .script_generator import extract_acts
             acts = extract_acts(script)
             if not acts:

--- a/skills/video-pipeline/brief_translator/scene_validator.py
+++ b/skills/video-pipeline/brief_translator/scene_validator.py
@@ -5,7 +5,11 @@ it enters the pipeline. Supports both the unified scene format (20-30 scenes)
 and the legacy flat format (~136 scenes).
 """
 
+import logging
+import re
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 # Required fields for each scene (unified format with backward-compat aliases)
@@ -265,3 +269,172 @@ def auto_fix_minor_issues(scenes: list[dict]) -> list[dict]:
                 fixed[mid][style_field] = "schema"
 
     return fixed
+
+
+# ---------------------------------------------------------------------------
+# Entity consistency checking — catches hallucinated proper nouns
+# ---------------------------------------------------------------------------
+
+# Well-known framework authors / historical figures that are always allowed
+# because the script engine references them as part of analytical frameworks.
+_FRAMEWORK_ENTITIES = {
+    "machiavelli", "greene", "robert greene", "sun tzu", "thucydides",
+    "taleb", "nassim taleb", "brzezinski", "mackinder", "spykman",
+    "kindleberger", "schelling", "olson", "mancur olson", "nye",
+    "joseph nye", "jung", "kahneman", "tversky", "thaler", "gramsci",
+    "bernays", "chomsky", "marcus aurelius", "seneca", "graham allison",
+    "athens", "sparta", "rome", "ottoman", "british empire",
+}
+
+# Multiple regex patterns to catch different proper noun styles:
+# 1. Multi-word proper nouns: "Sam Altman", "Goldman Sachs"
+_MULTI_WORD_PN_RE = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b")
+# 2. CamelCase / mixed-case: "DeepSeek", "OpenAI", "iPhone"
+_CAMEL_CASE_RE = re.compile(r"\b([A-Z][a-z]+[A-Z][A-Za-z]*)\b")
+# 3. Single capitalized words (4+ chars to skip "The", "And", etc.)
+_SINGLE_CAP_RE = re.compile(r"\b([A-Z][a-z]{3,})\b")
+# 4. All-caps acronyms (2+ chars): "IBM", "NATO", "OPEC"
+_ACRONYM_RE = re.compile(r"\b([A-Z]{2,})\b")
+
+# Common English words that start with a capital letter at sentence starts.
+# We skip these to reduce false positives.
+_COMMON_WORDS = {
+    "this", "that", "these", "those", "there", "their", "they",
+    "what", "when", "where", "which", "while", "with", "will",
+    "from", "have", "here", "been", "being", "before", "after",
+    "about", "above", "also", "always", "another", "because",
+    "between", "both", "could", "does", "done", "during", "each",
+    "either", "enough", "even", "every", "first", "found", "gave",
+    "give", "goes", "going", "gone", "good", "great", "just",
+    "keep", "know", "last", "like", "long", "look", "made", "make",
+    "many", "might", "more", "most", "much", "must", "never", "next",
+    "once", "only", "other", "over", "part", "past", "same", "should",
+    "show", "since", "some", "still", "such", "take", "tell", "than",
+    "then", "them", "think", "thought", "through", "time", "turn",
+    "under", "used", "very", "want", "well", "were", "would", "your",
+    "into", "back", "came", "come", "down", "face", "fact", "five",
+    "four", "hand", "head", "high", "home", "kind", "left", "life",
+    "line", "move", "name", "need", "news", "note", "number", "open",
+    "play", "point", "power", "real", "right", "room", "rule", "seem",
+    "side", "small", "stand", "start", "state", "story", "sure",
+    "thing", "three", "today", "true", "until", "upon", "watch",
+    "week", "work", "world", "year", "years",
+    # Script-specific common words that often get capitalized
+    "hook", "build", "payoff", "bridge", "lesson", "stakes",
+    "framework", "mechanism", "mirror", "foundation", "history",
+    "dark", "revelation", "pattern", "system", "empire", "stage",
+}
+
+
+def _extract_entities_from_text(text: str) -> set[str]:
+    """Extract likely proper nouns from a block of text.
+
+    Returns a set of lowercased entity strings for easy comparison.
+    """
+    entities: set[str] = set()
+
+    for pattern in (_MULTI_WORD_PN_RE, _CAMEL_CASE_RE, _SINGLE_CAP_RE, _ACRONYM_RE):
+        for m in pattern.findall(text):
+            lowered = m.lower()
+            # Skip very short matches and common English words
+            if len(m) <= 2 or lowered in _COMMON_WORDS:
+                continue
+            entities.add(lowered)
+
+    return entities
+
+
+def _extract_research_entities(brief: dict) -> set[str]:
+    """Extract all proper nouns / entity names from the research payload.
+
+    Combines entities from headline, thesis, fact_sheet, character_dossier,
+    historical_parallels, and other research fields.
+    """
+    research_fields = [
+        "headline", "thesis", "executive_hook", "fact_sheet",
+        "historical_parallels", "framework_analysis", "character_dossier",
+        "narrative_arc", "counter_arguments", "visual_seeds",
+        "source_bibliography", "source_urls",
+    ]
+    all_text = " ".join(str(brief.get(f, "")) for f in research_fields)
+    return _extract_entities_from_text(all_text)
+
+
+# Regex to strip act marker lines before entity extraction
+_ACT_MARKER_LINE_RE = re.compile(
+    r"\[ACT\s+\d+\s*[—–\-].*?\]", re.IGNORECASE
+)
+
+
+def check_entity_consistency(
+    script: str,
+    brief: dict,
+    slack_client=None,
+    video_title: str = "",
+) -> list[str]:
+    """Check that entities in the script are grounded in the research payload.
+
+    This is a WARNING-level check, not a blocker. It extracts proper nouns
+    from both the research payload and the script, then flags any script
+    entities that don't appear in the research.
+
+    Args:
+        script: The full generated script text.
+        brief: The research brief dict.
+        slack_client: Optional SlackClient for sending warnings.
+        video_title: Video title for Slack messages.
+
+    Returns:
+        List of warning strings for any ungrounded entities found.
+    """
+    research_entities = _extract_research_entities(brief)
+
+    # Strip act marker lines so their titles don't generate false positives
+    cleaned_script = _ACT_MARKER_LINE_RE.sub("", script)
+    script_entities = _extract_entities_from_text(cleaned_script)
+
+    # Also add the headline words as allowed (the title itself is fair game)
+    headline = brief.get("headline", "")
+    research_entities |= _extract_entities_from_text(headline)
+
+    # Framework entities are always allowed
+    allowed = research_entities | _FRAMEWORK_ENTITIES
+
+    # Find entities in script that are NOT in the research
+    ungrounded = script_entities - allowed
+
+    warnings = []
+    if ungrounded:
+        # Try to locate which scene/act each ungrounded entity appears in
+        # by scanning the script with act markers
+        from .script_generator import extract_acts
+        acts = extract_acts(script)
+
+        for entity in sorted(ungrounded):
+            # Find which act(s) reference this entity
+            locations = []
+            for act_num, act_text in acts.items():
+                if entity in act_text.lower():
+                    locations.append(f"Act {act_num}")
+
+            location_str = ", ".join(locations) if locations else "unknown location"
+            warning = (
+                f"WARNING: '{entity}' found in script ({location_str}) "
+                f"but not in research payload. Possible hallucination."
+            )
+            warnings.append(warning)
+            logger.warning(warning)
+
+        # Send summary to Slack if available
+        if slack_client and warnings:
+            title_label = video_title or brief.get("headline", "Untitled")
+            slack_msg = (
+                f"⚠️ Entity consistency check for '{title_label}':\n"
+                + "\n".join(warnings[:10])  # Cap at 10 to avoid spam
+            )
+            try:
+                slack_client.send_message(slack_msg)
+            except Exception:
+                pass
+
+    return warnings

--- a/skills/video-pipeline/brief_translator/script_generator.py
+++ b/skills/video-pipeline/brief_translator/script_generator.py
@@ -224,6 +224,31 @@ lens. Act 1 reveals the framework through shock. Act 4 proves the framework \
 through historical dread. Act 6 delivers the framework as empowerment.
 """
 
+_STRICT_GROUNDING_RULE = """\
+=== STRICT FACTUAL GROUNDING RULE — NON-NEGOTIABLE ===
+
+Every factual claim, entity name, company name, person name, event, date, \
+and dollar amount in the script MUST come directly from the research payload \
+provided. You may NOT introduce:
+- Companies, people, or events not mentioned in the research
+- Dollar amounts or statistics not in the fact sheet
+- Historical events not in the historical parallels section
+- Dates or timelines not supported by the source material
+
+If you need a transition, analogy, or rhetorical device, use only the \
+entities and events from the research payload. Do NOT substitute \
+similar-sounding companies (e.g. DeepSeek for Anthropic) or similar topics \
+(e.g. tariffs for Pentagon contracts).
+
+Before finalizing each act, verify: is every proper noun, date, statistic, \
+and event traceable to the research payload? If not, remove it or replace \
+it with something from the research.
+
+The ONLY exception is well-known historical figures or events used in \
+framework references (e.g. Machiavelli, Sun Tzu, Athens vs Sparta) that \
+are part of the analytical framework, NOT part of the factual narrative.
+"""
+
 _ACT_SPECIFIC_RULES = """\
 === ACT-SPECIFIC RULES (UPDATED) ===
 
@@ -256,8 +281,27 @@ they can't unsee.
 
 Act 6 (The Lesson):
 The prediction must be specific and falsifiable — not 'things will change' \
-but 'watch for X within Y months.' The final payoff should feel like a \
-permanent upgrade to how the viewer sees power. Last line should linger.
+but 'watch for X within Y months.'
+
+The final scene MUST end on EMPOWERMENT, not fear or cynicism. The viewer \
+just spent 15-20 minutes learning frameworks. The close should:
+1. Name the specific frameworks taught in the video (e.g. 'regulatory \
+capture, sovereign exception, the panopticon effect')
+2. Give the viewer a concrete detection tool: 'When you see X, ask Y. \
+When you see A, look for B.'
+3. Frame knowledge as power: the viewer now has X-ray vision that most \
+people lack
+4. End with agency: 'Now that you see the pattern, you can't unsee it. \
+And that's the first step to changing it.'
+
+BAD close: 'The cage is closing and you're trapped.' (leaves viewer \
+feeling helpless)
+GOOD close: 'Now you see it. Regulatory capture. Sovereign exception. \
+The panopticon effect. Three frameworks that explain how power really \
+moves. When a company gets designated, ask who benefits within 48 hours. \
+When you see all lawful purposes in any contract, find the loopholes. \
+When one player gets punished, watch who self-censors. You just learned \
+to read the game. Most people never will.'
 """
 
 
@@ -580,6 +624,7 @@ def build_script_prompt(brief: dict) -> str:
     rendered += "\n\n" + _FRAMEWORK_REVELATION_ENGINE
     rendered += "\n\n" + _FRAMEWORK_PSYCH_SEPARATION
     rendered += "\n\n" + _ACT_SPECIFIC_RULES
+    rendered += "\n\n" + _STRICT_GROUNDING_RULE
 
     return rendered
 


### PR DESCRIPTION
## Summary
This PR adds a new entity consistency validation layer to the video pipeline that detects when the generated script introduces proper nouns (people, companies, events) that aren't grounded in the research payload. This helps catch AI hallucinations before they reach production.

## Key Changes

- **New entity consistency checker** (`check_entity_consistency()` in `scene_validator.py`):
  - Extracts proper nouns from both the research brief and generated script using regex patterns for multi-word names, CamelCase, capitalized words, and acronyms
  - Compares script entities against research entities to identify ungrounded references
  - Maintains a whitelist of well-known framework authors (Machiavelli, Sun Tzu, etc.) that are always allowed
  - Filters out common English words to reduce false positives
  - Returns warnings with act/scene locations for any suspicious entities
  - Optionally sends summary warnings to Slack

- **Enhanced script generation prompts** (`script_generator.py`):
  - Added `_STRICT_GROUNDING_RULE` that explicitly forbids introducing entities, dates, statistics, or events not in the research payload
  - Expanded Act 6 (The Lesson) guidance to emphasize empowerment framing and concrete detection tools
  - Clarifies the only exception: well-known historical figures used in analytical frameworks

- **Pipeline integration** (`__init__.py`):
  - Integrated entity consistency check as Step 2b in the translation pipeline (non-blocking warning)
  - Added fallback logic for framework extraction (uses `framework_angle` from brief if script extraction fails)
  - Fixed Airtable field name from "Framework" to "Framework Angle"
  - Improved logging for framework detection and entity warnings

## Implementation Details

- Entity extraction uses four regex patterns to catch different proper noun styles (multi-word, CamelCase, single capitalized, acronyms)
- Act marker lines are stripped before entity extraction to avoid false positives from scene titles
- Ungrounded entities are located within specific acts for easier debugging
- The check is a WARNING-level validation, not a blocker, allowing scripts to proceed while flagging concerns
- Common English words and script-specific terms are maintained in a curated exclusion list

https://claude.ai/code/session_016axya14cWTJYvr1M4aEPQ2