### PR TITLE
Add hot-swap image generation model support via Slack commands

### DIFF
--- a/skills/video-pipeline/clients/airtable_client.py
+++ b/skills/video-pipeline/clients/airtable_client.py
@@ -50,6 +50,7 @@ class AirtableClient:
     Style overrides (written via Slack !style commands):
         - Image Style Override    : Long Text — custom instructions for image prompt prefix
         - Thumbnail Style Override: Long Text — custom instructions for thumbnail template
+        - Image Model Override    : Text     — hot-swap scene image model (e.g. "z-image")
 
     Pipeline-only fields (written by later stages, not discovery/research):
         - Script            : Long Text      — written by brief_translator

--- a/skills/video-pipeline/clients/image_client.py
+++ b/skills/video-pipeline/clients/image_client.py
@@ -22,6 +22,15 @@ class ImageClient:
     SCENE_MODEL = "nano-banana-2"  # Nano Banana 2 — scene images (cheaper, reference support)
     THUMBNAIL_MODEL = "nano-banana-pro"  # Nano Banana Pro for thumbnails - text rendering
 
+    # Alternative scene image models (hot-swappable via Slack !model command)
+    ZIMAGE_MODEL = "z-image"  # Z Image — high-quality image generation
+
+    # Valid scene image models for hot-swap validation
+    VALID_SCENE_MODELS = {
+        "nano-banana-2": "Nano Banana 2 (default — reference support, $0.025/img)",
+        "z-image": "Z Image (high-quality, $0.025/img)",
+    }
+
     # Veo 3.1 models
     VEO_MODEL_FAST = "veo3_fast"  # Faster, lower cost
     VEO_MODEL_QUALITY = "veo3"  # Higher quality, slower
@@ -461,6 +470,85 @@ class ImageClient:
         """
         # Delegates to generate_scene_image which uses Nano Banana 2
         return await self.generate_scene_image(prompt, reference_image_url, seed)
+
+    async def generate_scene_image_zimage(
+        self,
+        prompt: str,
+        aspect_ratio: str = "16:9",
+    ) -> Optional[dict]:
+        """Generate a scene image using Z Image model.
+
+        Z Image is a text-to-image model (no reference image support).
+        Uses the same Kie.ai task/poll API pattern.
+
+        Args:
+            prompt: Image generation prompt
+            aspect_ratio: Aspect ratio (16:9, 9:16, 1:1, 4:3, 3:4)
+
+        Returns:
+            Dict with 'url' and 'seed' keys, or None if failed
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        payload = {
+            "model": self.ZIMAGE_MODEL,
+            "input": {
+                "prompt": prompt,
+                "aspect_ratio": aspect_ratio,
+            },
+        }
+
+        prompt_preview = prompt[:100] + "..." if len(prompt) > 100 else prompt
+        print(f"      🎨 Generating scene image with Z Image...")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    self.CREATE_TASK_URL,
+                    headers=headers,
+                    json=payload,
+                    timeout=60.0,
+                )
+                if response.status_code != 200:
+                    print(f"      ❌ Z Image API error: {response.status_code}")
+                    print(f"         Response: {response.text[:500]}")
+                    print(f"         Prompt: {prompt_preview}")
+                    return None
+
+                task_data = response.json()
+                task_id = task_data.get("data", {}).get("taskId")
+
+                if not task_id:
+                    print(f"      ❌ No task ID returned")
+                    print(f"         API response: {task_data}")
+                    print(f"         Prompt: {prompt_preview}")
+                    return None
+
+                print(f"      🎯 Z Image task: {task_id}")
+
+                # Wait and poll — Z Image uses state-based polling (waiting/success/fail)
+                await asyncio.sleep(5)
+                result_urls = await self.poll_for_completion(task_id, max_attempts=60, poll_interval=2.0)
+
+                if result_urls:
+                    return {
+                        "url": result_urls[0],
+                        "seed": None,
+                    }
+
+                print(f"      ❌ Z Image generation failed (task: {task_id})")
+                print(f"         Prompt: {prompt_preview}")
+                return None
+
+        except Exception as e:
+            print(f"      ❌ Z Image error: {e}")
+            print(f"         Prompt: {prompt_preview}")
+            import traceback
+            traceback.print_exc()
+            return None
 
     async def generate_thumbnail(self, prompt: str) -> Optional[list[str]]:
         """Generate a thumbnail using Nano Banana Pro.

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -1415,10 +1415,21 @@ class VideoPipeline:
             self.slack.notify(f"⚠️ Image Bot: 0 pending images found for *{self.video_title}*. Nothing to generate.")
             return {"image_count": 0, "failed_count": 0}
 
+        # Check for image model override (hot-swap via Slack !model command)
+        from clients.image_client import ImageClient
+        model_override = (self.current_idea.get("Image Model Override") or "").strip().lower()
+        if model_override and model_override not in ImageClient.VALID_SCENE_MODELS:
+            print(f"     ⚠️ Invalid model override '{model_override}', falling back to default")
+            model_override = ""
+        if model_override:
+            print(f"     🔄 Model override active: {model_override} ({ImageClient.VALID_SCENE_MODELS[model_override]})")
+
         # YouTube pipeline: Core Image is optional (uses text-to-image without reference)
         # Animation pipeline: Core Image is required (uses Seed Dream 4.5 Edit with reference)
-        use_reference = bool(self.core_image_url)
-        if use_reference:
+        use_reference = bool(self.core_image_url) and model_override != "z-image"
+        if model_override == "z-image":
+            print(f"     🎨 Using Z Image model (text-to-image, no reference)")
+        elif use_reference:
             print(f"     🖼️ Using Core Image reference (Seed Dream 4.5 Edit)")
         else:
             print(f"     📸 Using text-to-image generation (no Core Image reference)")
@@ -1453,9 +1464,10 @@ class VideoPipeline:
                     prompt_preview = prompt[:120] + "..." if len(prompt) > 120 else prompt
 
                     try:
-                        # Generate image: use Core Image reference if available,
-                        # otherwise use text-to-image (YouTube pipeline path)
-                        if use_reference:
+                        # Generate image: route based on model override, then reference availability
+                        if model_override == "z-image":
+                            result = await self.image_client.generate_scene_image_zimage(prompt, aspect_ratio="16:9")
+                        elif use_reference:
                             result = await self.image_client.generate_scene_image(prompt, self.core_image_url)
                         else:
                             result_urls = await self.image_client.generate_and_wait(prompt, aspect_ratio="16:9")
@@ -1556,7 +1568,9 @@ class VideoPipeline:
                     
                     prompt_preview = prompt[:120] + "..." if len(prompt) > 120 else prompt
                     try:
-                        if use_reference:
+                        if model_override == "z-image":
+                            result = await self.image_client.generate_scene_image_zimage(prompt, aspect_ratio="16:9")
+                        elif use_reference:
                             result = await self.image_client.generate_scene_image(prompt, self.core_image_url)
                         else:
                             result_urls = await self.image_client.generate_and_wait(prompt, aspect_ratio="16:9")

--- a/skills/video-pipeline/pipeline_control.py
+++ b/skills/video-pipeline/pipeline_control.py
@@ -173,6 +173,11 @@ async def handle_help(message, say):
 - `style color <title>: <color>` - Set accent color (cold teal, muted crimson, warm amber, muted green)
 - `style reset <title>` - Clear all style overrides and accent color for a video
 
+*Image Model*
+- `model <title>: <model>` - Switch image generation model for a video (e.g. `model My Video: z-image`)
+- `model reset <title>` - Revert to default model (nano-banana-2)
+- `models` - List all available image generation models
+
 *System & DevOps*
 - `stop` / `kill` - Stop the currently running pipeline
 - `status` / `check` - Check current project status (both pipelines)
@@ -1950,11 +1955,86 @@ async def handle_style_reset(message, say):
             "Image Style Override": "",
             "Thumbnail Style Override": "",
             "Accent Color": "",
+            "Image Model Override": "",
         })
         video_title = idea.get("Video Title", title)
         await say(f":white_check_mark: Style overrides cleared for *{video_title}*")
     except Exception as e:
         await say(f":x: Error resetting style overrides: {e}")
+
+
+# ---------------------------------------------------------------------------
+# !model — hot-swap image generation model for a video
+# ---------------------------------------------------------------------------
+
+@app.message(re.compile(r"^!?model\s+(.+?):\s*(.+)", re.IGNORECASE))
+async def handle_model_set(message, say):
+    """Set the image generation model override for a specific video."""
+    match = re.search(r"^!?model\s+(.+?):\s*(.+)", message["text"], re.IGNORECASE)
+    if not match:
+        await say(":x: Usage: `model <video_title>: <model_name>`")
+        return
+
+    title = match.group(1).strip()
+    model_name = match.group(2).strip().lower()
+
+    from clients.image_client import ImageClient
+    if model_name not in ImageClient.VALID_SCENE_MODELS:
+        valid = "\n".join(f"  • `{k}` — {v}" for k, v in ImageClient.VALID_SCENE_MODELS.items())
+        await say(f":x: Invalid model *{model_name}*. Available models:\n{valid}")
+        return
+
+    try:
+        from clients.airtable_client import AirtableClient
+        airtable = AirtableClient()
+        idea = airtable.find_idea_by_title(title)
+        if not idea:
+            await say(f":x: No video found matching *{title}*")
+            return
+
+        airtable.update_idea_fields(idea["id"], {"Image Model Override": model_name})
+        video_title = idea.get("Video Title", title)
+        desc = ImageClient.VALID_SCENE_MODELS[model_name]
+        await say(f":arrows_counterclockwise: Image model set for *{video_title}*: `{model_name}` ({desc})")
+    except Exception as e:
+        await say(f":x: Error setting image model: {e}")
+
+
+@app.message(re.compile(r"^!?model\s+reset\s+(.+)", re.IGNORECASE))
+async def handle_model_reset(message, say):
+    """Clear the image model override for a specific video (revert to default)."""
+    match = re.search(r"^!?model\s+reset\s+(.+)", message["text"], re.IGNORECASE)
+    if not match:
+        await say(":x: Usage: `model reset <video_title>`")
+        return
+
+    title = match.group(1).strip()
+
+    try:
+        from clients.airtable_client import AirtableClient
+        airtable = AirtableClient()
+        idea = airtable.find_idea_by_title(title)
+        if not idea:
+            await say(f":x: No video found matching *{title}*")
+            return
+
+        airtable.update_idea_fields(idea["id"], {"Image Model Override": ""})
+        video_title = idea.get("Video Title", title)
+        await say(f":white_check_mark: Image model reset to default (nano-banana-2) for *{video_title}*")
+    except Exception as e:
+        await say(f":x: Error resetting image model: {e}")
+
+
+@app.message(re.compile(r"^!?models$", re.IGNORECASE))
+async def handle_model_list(message, say):
+    """List all available image generation models."""
+    from clients.image_client import ImageClient
+    lines = [":camera: *Available Image Generation Models:*\n"]
+    for model_id, desc in ImageClient.VALID_SCENE_MODELS.items():
+        default = " _(default)_" if model_id == ImageClient.SCENE_MODEL else ""
+        lines.append(f"  • `{model_id}` — {desc}{default}")
+    lines.append("\n_Use `model <title>: <model>` to set, `model reset <title>` to revert._")
+    await say("\n".join(lines))
 
 
 # ---------------------------------------------------------------------------
@@ -2006,6 +2086,9 @@ Available commands (return one of these EXACTLY):
 - "style thumbnail TITLE: INSTRUCTIONS" — set thumbnail style override for a video (keep TITLE and INSTRUCTIONS)
 - "style color TITLE: COLOR" — set accent color for a video (valid colors: cold teal, muted crimson, warm amber, muted green). Keep TITLE and COLOR from user message.
 - "style reset TITLE" — clear style overrides for a video (keep TITLE from user message)
+- "model TITLE: MODEL" — set image generation model for a video (valid models: nano-banana-2, z-image). Keep TITLE and MODEL from user message.
+- "model reset TITLE" — reset image model to default for a video (keep TITLE from user message)
+- "models" — list available image generation models
 - "help" — show available commands
 - "unknown" — message is not a bot command (casual chat, question, etc.)
 
@@ -2039,7 +2122,13 @@ Rules:
 "use teal for VIDEO" → style color VIDEO: cold teal, \
 "make VIDEO amber" → style color VIDEO: warm amber, \
 "green accent for VIDEO" → style color VIDEO: muted green, \
-"reset the style for VIDEO" → style reset VIDEO
+"reset the style for VIDEO" → style reset VIDEO, \
+"switch VIDEO to z-image" → model VIDEO: z-image, \
+"use z image for VIDEO" → model VIDEO: z-image, \
+"change model for VIDEO to z-image" → model VIDEO: z-image, \
+"reset model for VIDEO" → model reset VIDEO, \
+"what models are available" → models, \
+"list models" → models
 4. If they mention an API key or secret key, return: set key KEY
 5. If truly ambiguous, return: unknown"""
 
@@ -2107,6 +2196,7 @@ async def handle_fallback(event, say):
         "restart": handle_restart,
         "update": handle_update,
         "help": handle_help,
+        "models": handle_model_list,
         "cron on": handle_cron,
         "cron off": handle_cron,
         "cron status": handle_cron,
@@ -2162,6 +2252,20 @@ async def handle_fallback(event, say):
         await handle_style_reset(fake_message, say)
         return
 
+    # Check for "model" commands (hot-swap image generation model)
+    if command.startswith("model reset "):
+        fake_message = {"text": command, "user": event.get("user", "")}
+        await handle_model_reset(fake_message, say)
+        return
+    if command.startswith("model ") and ":" in command:
+        fake_message = {"text": command, "user": event.get("user", "")}
+        await handle_model_set(fake_message, say)
+        return
+    if command == "models":
+        fake_message = {"text": command, "user": event.get("user", "")}
+        await handle_model_list(fake_message, say)
+        return
+
     # Check for "discover" with focus keyword
     if command.startswith("discover"):
         fake_message = {"text": command, "user": event.get("user", ""),
@@ -2212,6 +2316,7 @@ async def main():
     print("  animate / discover / research")
     print("  queue / skip / retry    - Pipeline management")
     print("  style image/thumbnail/color/reset - Per-video style overrides")
+    print("  model <title>: <model> / models   - Hot-swap image generation model")
     print("  stop / status / logs / disk / show env / restart / update")
     print("  set env KEY=VALUE       - Set any env var in .env")
     print("  cron on/off/status      - Manage scheduled cron jobs")


### PR DESCRIPTION
## Summary
This PR adds the ability to dynamically switch between image generation models on a per-video basis through Slack commands, without restarting the pipeline. Users can now override the default Nano Banana 2 model with Z Image for specific videos.

## Key Changes

- **New Slack Commands**:
  - `!model <title>: <model>` — Set image generation model for a specific video
  - `!model reset <title>` — Revert to default model (nano-banana-2)
  - `!models` — List all available image generation models with descriptions

- **Image Client Enhancement**:
  - Added `VALID_SCENE_MODELS` dictionary defining available models (nano-banana-2, z-image)
  - Implemented `generate_scene_image_zimage()` method for Z Image model support
  - Z Image uses text-to-image generation (no reference image support) with same Kie.ai task/poll API pattern

- **Pipeline Integration**:
  - Added "Image Model Override" field to Airtable schema
  - Pipeline now checks for model override before generating images
  - Routes image generation to appropriate model based on override:
    - Z Image: text-to-image only
    - Nano Banana 2: supports reference images when available
  - Validates model override against `VALID_SCENE_MODELS` to prevent invalid selections

- **Help & Documentation**:
  - Updated help text with new model commands
  - Added model examples to AI fallback handler for natural language command parsing
  - Updated startup console output to mention model hot-swap capability

## Implementation Details

- Model override is stored in Airtable's "Image Model Override" field and persists across pipeline runs
- Z Image model is validated and logged when active, with fallback to default if invalid
- Both image generation paths (with/without reference) respect the model override
- Error handling includes validation of model names against the allowed list before API calls

https://claude.ai/code/session_013qCZxzYkyaJgG49SnNsYc7