### PR TITLE
Add intelligent scene-level sound curation to Sound Prompt Bot

### DIFF
--- a/skills/video-pipeline/bots/sound_bot.py
+++ b/skills/video-pipeline/bots/sound_bot.py
@@ -60,10 +60,12 @@ class SoundBot:
         if not images:
             return {"error": f"No images found for: {video_title}"}
 
-        # Filter to images with Sound Prompt but no Sound Effect
+        # Filter to images with Sound Prompt (not SKIP) but no Sound Effect
         needs_generation = [
             img for img in images
-            if img.get("Sound Prompt") and not img.get("Sound Effect")
+            if img.get("Sound Prompt")
+            and img.get("Sound Prompt") != "SKIP"
+            and not img.get("Sound Effect")
         ]
 
         if not needs_generation:

--- a/skills/video-pipeline/bots/sound_prompt_bot.py
+++ b/skills/video-pipeline/bots/sound_prompt_bot.py
@@ -1,14 +1,40 @@
-"""Sound Prompt Bot — generates one sound prompt per image row using Claude.
+"""Sound Prompt Bot — intelligently selects which images get sound, then generates prompts.
 
-Reads image rows from the Images table and generates a single ambient sound
-description for each, based on the narration text and visual description.
-This replaces the old scene-level Sound Map approach.
+Two-phase approach:
+1. Curation: Claude sees all images in a scene and picks which ones benefit from sound
+2. Generation: Sound prompts generated only for selected images; skipped images get "SKIP"
+
+Selection bounds are percentage-based (default 25% min, 60% max of images per scene).
 """
 
+import json
+import math
+from collections import defaultdict
 from typing import Optional
 
 from clients.anthropic_client import AnthropicClient
 from clients.airtable_client import AirtableClient
+
+
+SOUND_CURATION_SYSTEM = """\
+You are a cinematic sound designer selecting which moments in a documentary scene deserve ambient sound effects. Not every image needs sound — silence is powerful too.
+
+You will receive all images in a single scene. For each, decide: does this moment benefit from a sound layer, or is it stronger with just narration?
+
+ADD SOUND when:
+- The visual has a distinct environment (city street, factory floor, ocean, forest)
+- There's implied action or motion (crowds moving, machines running, weather)
+- Emotional weight that sound reinforces (tension, revelation, grandeur)
+- Transitional moments that establish a new setting
+
+SKIP SOUND when:
+- Abstract data visualizations or charts with no physical setting
+- Consecutive images showing the same environment (avoid repetitive ambience)
+- Narration alone carries the emotional weight and sound would distract
+- Generic corporate/office visuals with nothing distinctive to hear
+
+Return ONLY a JSON array, one entry per image:
+[{"image_index": 1, "sound": true}, {"image_index": 2, "sound": false}]"""
 
 
 SOUND_PROMPT_SYSTEM = """\
@@ -21,17 +47,193 @@ Rules:
 - Match emotional tone to content
 - Output ONLY the sound description, nothing else."""
 
+# Percentage bounds for sound selection per scene
+MIN_SOUND_PERCENT = 0.25
+MAX_SOUND_PERCENT = 0.60
+
 
 class SoundPromptBot:
-    """Generates one sound prompt per image row in the Images table."""
+    """Selects which images get sound, then generates prompts for those images."""
 
     def __init__(
         self,
         anthropic: Optional[AnthropicClient] = None,
         airtable: Optional[AirtableClient] = None,
+        min_sound_pct: float = MIN_SOUND_PERCENT,
+        max_sound_pct: float = MAX_SOUND_PERCENT,
     ):
         self.anthropic = anthropic or AnthropicClient()
         self.airtable = airtable or AirtableClient()
+        self.min_sound_pct = min_sound_pct
+        self.max_sound_pct = max_sound_pct
+
+    def _compute_bounds(self, image_count: int) -> tuple[int, int]:
+        """Compute min/max sound count for a scene based on percentage bounds.
+
+        Always at least 1 sound per scene.
+        """
+        min_sounds = max(1, math.ceil(image_count * self.min_sound_pct))
+        max_sounds = max(min_sounds, math.floor(image_count * self.max_sound_pct))
+        return min_sounds, max_sounds
+
+    async def curate_scene_sounds(
+        self,
+        scene_images: list[dict],
+    ) -> list[dict]:
+        """Ask Claude which images in a scene should get sound effects.
+
+        Args:
+            scene_images: List of image dicts from Airtable, sorted by index
+
+        Returns:
+            List of dicts with image_index and sound (bool) for each image
+        """
+        image_count = len(scene_images)
+        if image_count == 0:
+            return []
+
+        min_sounds, max_sounds = self._compute_bounds(image_count)
+
+        # Build the scene context for Claude
+        lines = []
+        for img in scene_images:
+            idx = img.get("Image Index", 0)
+            text = img.get("Sentence Text", "").strip()
+            visual = img.get("Image Prompt", "").strip()
+            shot = img.get("Shot Type", "").strip()
+            lines.append(
+                f"Image {idx}:\n"
+                f"  Narration: {text[:200]}\n"
+                f"  Visual: {visual[:200]}\n"
+                f"  Shot: {shot}"
+            )
+
+        user_prompt = (
+            f"Scene with {image_count} images. "
+            f"Select between {min_sounds} and {max_sounds} images for sound effects.\n\n"
+            + "\n\n".join(lines)
+        )
+
+        response = await self.anthropic.generate(
+            prompt=user_prompt,
+            system_prompt=SOUND_CURATION_SYSTEM,
+            model="claude-haiku-4-5-20251001",
+            max_tokens=512,
+            temperature=0.4,
+        )
+
+        if not response:
+            # Fallback: select first min_sounds images
+            return self._fallback_selection(scene_images, min_sounds)
+
+        # Parse JSON response
+        selections = self._parse_curation_response(response, scene_images)
+        if not selections:
+            return self._fallback_selection(scene_images, min_sounds)
+
+        # Enforce bounds
+        selections = self._enforce_bounds(selections, min_sounds, max_sounds)
+        return selections
+
+    def _parse_curation_response(
+        self,
+        response: str,
+        scene_images: list[dict],
+    ) -> list[dict]:
+        """Parse Claude's curation JSON response."""
+        text = response.strip()
+
+        # Strip markdown fences
+        if text.startswith("```"):
+            text = text.split("\n", 1)[-1] if "\n" in text else text[3:]
+            if text.endswith("```"):
+                text = text[:-3]
+            text = text.strip()
+
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            # Try extracting JSON array
+            start = text.find("[")
+            end = text.rfind("]")
+            if start != -1 and end != -1:
+                try:
+                    parsed = json.loads(text[start:end + 1])
+                except json.JSONDecodeError:
+                    return []
+            else:
+                return []
+
+        if not isinstance(parsed, list):
+            return []
+
+        # Build index set from actual images
+        valid_indices = {img.get("Image Index", 0) for img in scene_images}
+
+        results = []
+        for entry in parsed:
+            idx = entry.get("image_index")
+            sound = entry.get("sound", False)
+            if idx in valid_indices:
+                results.append({"image_index": idx, "sound": bool(sound)})
+
+        # Fill in any missing indices as sound=False
+        found_indices = {r["image_index"] for r in results}
+        for idx in valid_indices - found_indices:
+            results.append({"image_index": idx, "sound": False})
+
+        results.sort(key=lambda r: r["image_index"])
+        return results
+
+    def _enforce_bounds(
+        self,
+        selections: list[dict],
+        min_sounds: int,
+        max_sounds: int,
+    ) -> list[dict]:
+        """Enforce min/max sound counts by toggling selections."""
+        selected = [s for s in selections if s["sound"]]
+        not_selected = [s for s in selections if not s["sound"]]
+
+        # Too few: promote unselected images (prefer earlier ones for scene establishment)
+        while len(selected) < min_sounds and not_selected:
+            promoted = not_selected.pop(0)
+            promoted["sound"] = True
+            selected.append(promoted)
+
+        # Too many: demote excess (prefer removing later ones)
+        while len(selected) > max_sounds:
+            demoted = selected.pop()
+            demoted["sound"] = False
+            not_selected.append(demoted)
+
+        all_items = selected + not_selected
+        all_items.sort(key=lambda s: s["image_index"])
+        return all_items
+
+    def _fallback_selection(
+        self,
+        scene_images: list[dict],
+        min_sounds: int,
+    ) -> list[dict]:
+        """Fallback: evenly space sound selections across the scene."""
+        count = len(scene_images)
+        if count == 0:
+            return []
+
+        # Space selections evenly
+        step = max(1, count / min_sounds)
+        selected_positions = set()
+        for i in range(min_sounds):
+            pos = min(int(i * step), count - 1)
+            selected_positions.add(pos)
+
+        results = []
+        for i, img in enumerate(scene_images):
+            idx = img.get("Image Index", 0)
+            results.append({"image_index": idx, "sound": i in selected_positions})
+
+        return results
 
     async def generate_sound_prompt(
         self,
@@ -76,10 +278,10 @@ class SoundPromptBot:
         return prompt
 
     async def process_video(self, video_title: str) -> dict:
-        """Generate sound prompts for all images of a video.
+        """Generate sound prompts for a video using intelligent scene-level curation.
 
-        Reads image rows from the Images table, generates a sound prompt
-        for each one, and writes it back to the "Sound Prompt" field.
+        Phase 1: For each scene, Claude selects which images benefit from sound (25-60%)
+        Phase 2: Generate prompts only for selected images; mark others as SKIP
 
         Args:
             video_title: Title of the video to process
@@ -99,56 +301,101 @@ class SoundPromptBot:
             key=lambda i: (i.get("Scene", 0), i.get("Image Index", 0)),
         )
 
-        total_generated = 0
-        skipped = 0
-
+        # Group images by scene
+        scenes: dict[int, list[dict]] = defaultdict(list)
         for img in images:
-            record_id = img["id"]
-            scene = img.get("Scene", "?")
-            idx = img.get("Image Index", "?")
+            scene_num = img.get("Scene", 0)
+            scenes[scene_num].append(img)
 
-            # Skip if sound prompt already exists
-            existing = img.get("Sound Prompt")
-            if existing:
-                print(f"  Scene {scene} img {idx}: Sound prompt exists, skipping")
-                skipped += 1
-                total_generated += 1
+        total_generated = 0
+        total_skipped_by_curation = 0
+        already_existed = 0
+
+        for scene_num in sorted(scenes.keys()):
+            scene_images = scenes[scene_num]
+
+            # Check if all images in this scene already have prompts
+            needs_processing = [
+                img for img in scene_images if not img.get("Sound Prompt")
+            ]
+            already_done = len(scene_images) - len(needs_processing)
+
+            if not needs_processing:
+                print(f"  Scene {scene_num}: All {len(scene_images)} images already have prompts")
+                already_existed += already_done
+                total_generated += already_done
                 continue
 
-            sentence_text = img.get("Sentence Text", "")
-            image_prompt = img.get("Image Prompt", "")
-            shot_type = img.get("Shot Type", "")
+            if already_done > 0:
+                print(f"  Scene {scene_num}: {already_done}/{len(scene_images)} already done, "
+                      f"processing {len(needs_processing)} remaining")
+                already_existed += already_done
+                total_generated += already_done
 
-            if not sentence_text and not image_prompt:
-                print(f"  Scene {scene} img {idx}: No text or prompt, skipping")
-                continue
+            # Phase 1: Curate — which images get sound?
+            print(f"  Scene {scene_num}: Curating {len(needs_processing)} images...")
+            min_s, max_s = self._compute_bounds(len(needs_processing))
+            selections = await self.curate_scene_sounds(needs_processing)
 
-            print(f"  Scene {scene} img {idx}: Generating sound prompt...")
+            selected_count = sum(1 for s in selections if s["sound"])
+            print(f"    Selected {selected_count}/{len(needs_processing)} for sound "
+                  f"(bounds: {min_s}-{max_s})")
 
-            prompt = await self.generate_sound_prompt(
-                sentence_text=sentence_text,
-                image_prompt=image_prompt,
-                shot_type=shot_type,
-            )
+            # Build lookup: image_index -> should have sound
+            sound_map = {s["image_index"]: s["sound"] for s in selections}
 
-            if prompt:
-                # Write to Airtable
-                try:
-                    self.airtable.update_image_sound_prompt(record_id, prompt)
-                    total_generated += 1
-                    print(f"    ✅ {prompt[:60]}...")
-                except Exception as e:
-                    print(f"    ❌ Failed to write Sound Prompt: {e}")
-            else:
-                print(f"    ❌ Generation failed for scene {scene} img {idx}")
+            # Phase 2: Generate prompts for selected, SKIP for others
+            for img in needs_processing:
+                record_id = img["id"]
+                idx = img.get("Image Index", 0)
+                should_sound = sound_map.get(idx, False)
 
-        print(f"\n  Sound prompts complete: {total_generated}/{len(images)} images "
-              f"({skipped} already existed)")
+                if not should_sound:
+                    # Mark as SKIP
+                    try:
+                        self.airtable.update_image_sound_prompt(record_id, "SKIP")
+                        total_skipped_by_curation += 1
+                        print(f"    Scene {scene_num} img {idx}: SKIP")
+                    except Exception as e:
+                        print(f"    ❌ Failed to write SKIP: {e}")
+                    continue
+
+                sentence_text = img.get("Sentence Text", "")
+                image_prompt = img.get("Image Prompt", "")
+                shot_type = img.get("Shot Type", "")
+
+                if not sentence_text and not image_prompt:
+                    print(f"    Scene {scene_num} img {idx}: No text or prompt, skipping")
+                    continue
+
+                print(f"    Scene {scene_num} img {idx}: Generating sound prompt...")
+
+                prompt = await self.generate_sound_prompt(
+                    sentence_text=sentence_text,
+                    image_prompt=image_prompt,
+                    shot_type=shot_type,
+                )
+
+                if prompt:
+                    try:
+                        self.airtable.update_image_sound_prompt(record_id, prompt)
+                        total_generated += 1
+                        print(f"      ✅ {prompt[:60]}...")
+                    except Exception as e:
+                        print(f"      ❌ Failed to write Sound Prompt: {e}")
+                else:
+                    print(f"      ❌ Generation failed for scene {scene_num} img {idx}")
+
+        total_images = len(images)
+        print(f"\n  Sound prompts complete: {total_generated}/{total_images} generated, "
+              f"{total_skipped_by_curation} skipped by curation "
+              f"({already_existed} already existed)")
 
         return {
             "bot": "Sound Prompt Bot",
             "video_title": video_title,
-            "total_images": len(images),
+            "total_images": total_images,
             "prompts_generated": total_generated,
-            "skipped": skipped,
+            "skipped_by_curation": total_skipped_by_curation,
+            "already_existed": already_existed,
         }

--- a/skills/video-pipeline/tests/test_sound_curation.py
+++ b/skills/video-pipeline/tests/test_sound_curation.py
@@ -1,0 +1,224 @@
+"""Tests for sound prompt bot curation logic.
+
+Tests the pure logic functions (bounds, parsing, enforcement) without
+importing the full client dependency chain.
+"""
+
+import json
+import math
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock heavy client dependencies before importing sound_prompt_bot
+sys.modules.setdefault("clients.anthropic_client", MagicMock())
+sys.modules.setdefault("clients.airtable_client", MagicMock())
+
+from bots.sound_prompt_bot import SoundPromptBot, MIN_SOUND_PERCENT, MAX_SOUND_PERCENT
+
+
+def _make_image(scene: int, index: int, text: str = "narration", prompt: str = "visual") -> dict:
+    return {
+        "id": f"rec_{scene}_{index}",
+        "Scene": scene,
+        "Image Index": index,
+        "Sentence Text": text,
+        "Image Prompt": prompt,
+        "Shot Type": "wide",
+    }
+
+
+def _make_scene_images(scene: int, count: int) -> list[dict]:
+    return [_make_image(scene, i + 1) for i in range(count)]
+
+
+def _bot() -> SoundPromptBot:
+    """Create a SoundPromptBot without triggering client __init__."""
+    bot = SoundPromptBot.__new__(SoundPromptBot)
+    bot.min_sound_pct = MIN_SOUND_PERCENT
+    bot.max_sound_pct = MAX_SOUND_PERCENT
+    return bot
+
+
+class TestComputeBounds:
+    """Test percentage-based min/max sound selection bounds."""
+
+    def test_6_images_scene(self):
+        """Standard scene: 6 images -> min 2, max 3."""
+        bot = _bot()
+        min_s, max_s = bot._compute_bounds(6)
+        assert min_s == 2  # ceil(6 * 0.25) = 2
+        assert max_s == 3  # floor(6 * 0.60) = 3
+
+    def test_4_images_scene(self):
+        """Short scene: 4 images -> min 1, max 2."""
+        bot = _bot()
+        min_s, max_s = bot._compute_bounds(4)
+        assert min_s == 1  # ceil(4 * 0.25) = 1
+        assert max_s == 2  # floor(4 * 0.60) = 2
+
+    def test_10_images_scene(self):
+        """Long scene: 10 images -> min 3, max 6."""
+        bot = _bot()
+        min_s, max_s = bot._compute_bounds(10)
+        assert min_s == 3  # ceil(10 * 0.25) = 3
+        assert max_s == 6  # floor(10 * 0.60) = 6
+
+    def test_1_image_scene(self):
+        """Single image: always at least 1."""
+        bot = _bot()
+        min_s, max_s = bot._compute_bounds(1)
+        assert min_s == 1
+        assert max_s == 1
+
+    def test_2_images_scene(self):
+        """2 images -> min 1, max 1."""
+        bot = _bot()
+        min_s, max_s = bot._compute_bounds(2)
+        assert min_s == 1  # ceil(2 * 0.25) = 1
+        assert max_s == 1  # floor(2 * 0.60) = 1
+
+    def test_min_never_exceeds_max(self):
+        """Min should never exceed max for any count 1-30."""
+        bot = _bot()
+        for count in range(1, 30):
+            min_s, max_s = bot._compute_bounds(count)
+            assert min_s <= max_s, f"min {min_s} > max {max_s} for {count} images"
+            assert min_s >= 1, f"min was 0 for {count} images"
+
+
+class TestParseCurationResponse:
+    """Test parsing Claude's curation JSON response."""
+
+    def setup_method(self):
+        self.bot = _bot()
+        self.images = _make_scene_images(1, 6)
+
+    def test_clean_json(self):
+        response = json.dumps([
+            {"image_index": 1, "sound": True},
+            {"image_index": 2, "sound": False},
+            {"image_index": 3, "sound": True},
+            {"image_index": 4, "sound": False},
+            {"image_index": 5, "sound": True},
+            {"image_index": 6, "sound": False},
+        ])
+        result = self.bot._parse_curation_response(response, self.images)
+        assert len(result) == 6
+        assert result[0] == {"image_index": 1, "sound": True}
+        assert result[1] == {"image_index": 2, "sound": False}
+
+    def test_markdown_fenced_json(self):
+        response = '```json\n[{"image_index": 1, "sound": true}, {"image_index": 2, "sound": false}]\n```'
+        result = self.bot._parse_curation_response(response, self.images)
+        selected = [r for r in result if r["sound"]]
+        assert len(selected) == 1
+
+    def test_json_with_surrounding_text(self):
+        response = 'Here is my selection:\n[{"image_index": 1, "sound": true}]\nDone!'
+        result = self.bot._parse_curation_response(response, self.images)
+        selected = [r for r in result if r["sound"]]
+        assert len(selected) == 1
+
+    def test_missing_indices_filled_as_false(self):
+        """Images not mentioned by Claude default to sound=False."""
+        response = json.dumps([
+            {"image_index": 1, "sound": True},
+            {"image_index": 3, "sound": True},
+        ])
+        result = self.bot._parse_curation_response(response, self.images)
+        assert len(result) == 6
+        for r in result:
+            if r["image_index"] in (2, 4, 5, 6):
+                assert r["sound"] is False
+
+    def test_invalid_json_returns_empty(self):
+        result = self.bot._parse_curation_response("not json at all", self.images)
+        assert result == []
+
+    def test_invalid_indices_ignored(self):
+        response = json.dumps([
+            {"image_index": 1, "sound": True},
+            {"image_index": 99, "sound": True},
+        ])
+        result = self.bot._parse_curation_response(response, self.images)
+        assert len(result) == 6
+        assert sum(1 for r in result if r["sound"]) == 1
+
+
+class TestEnforceBounds:
+    """Test min/max enforcement on curation selections."""
+
+    def setup_method(self):
+        self.bot = _bot()
+
+    def test_too_few_promotes_earlier_images(self):
+        selections = [
+            {"image_index": i, "sound": False} for i in range(1, 7)
+        ]
+        result = self.bot._enforce_bounds(selections, min_sounds=2, max_sounds=4)
+        selected = [r for r in result if r["sound"]]
+        assert len(selected) == 2
+        assert selected[0]["image_index"] == 1
+        assert selected[1]["image_index"] == 2
+
+    def test_too_many_demotes_later_images(self):
+        selections = [
+            {"image_index": i, "sound": True} for i in range(1, 7)
+        ]
+        result = self.bot._enforce_bounds(selections, min_sounds=2, max_sounds=3)
+        selected = [r for r in result if r["sound"]]
+        assert len(selected) == 3
+
+    def test_within_bounds_unchanged(self):
+        selections = [
+            {"image_index": 1, "sound": True},
+            {"image_index": 2, "sound": False},
+            {"image_index": 3, "sound": True},
+            {"image_index": 4, "sound": False},
+            {"image_index": 5, "sound": True},
+            {"image_index": 6, "sound": False},
+        ]
+        result = self.bot._enforce_bounds(selections, min_sounds=2, max_sounds=4)
+        selected = [r for r in result if r["sound"]]
+        assert len(selected) == 3
+
+    def test_result_sorted_by_index(self):
+        selections = [
+            {"image_index": 3, "sound": True},
+            {"image_index": 1, "sound": False},
+            {"image_index": 2, "sound": True},
+        ]
+        result = self.bot._enforce_bounds(selections, min_sounds=1, max_sounds=3)
+        indices = [r["image_index"] for r in result]
+        assert indices == [1, 2, 3]
+
+
+class TestFallbackSelection:
+    """Test fallback when Claude fails to return valid curation."""
+
+    def setup_method(self):
+        self.bot = _bot()
+
+    def test_evenly_spaced_selection(self):
+        images = _make_scene_images(1, 6)
+        result = self.bot._fallback_selection(images, min_sounds=2)
+        selected = [r for r in result if r["sound"]]
+        assert len(selected) == 2
+
+    def test_single_image(self):
+        images = _make_scene_images(1, 1)
+        result = self.bot._fallback_selection(images, min_sounds=1)
+        assert len(result) == 1
+        assert result[0]["sound"] is True
+
+    def test_empty_scene(self):
+        result = self.bot._fallback_selection([], min_sounds=1)
+        assert result == []
+
+    def test_all_images_selected_when_min_equals_count(self):
+        images = _make_scene_images(1, 3)
+        result = self.bot._fallback_selection(images, min_sounds=3)
+        selected = [r for r in result if r["sound"]]
+        assert len(selected) == 3


### PR DESCRIPTION
## Summary
Refactored the Sound Prompt Bot to use a two-phase approach: first intelligently selecting which images in a scene benefit from sound effects, then generating prompts only for those selected images. This replaces the previous one-prompt-per-image approach with a more cinematic, selective strategy.

## Key Changes

- **Two-phase curation system**: 
  - Phase 1: Claude analyzes all images in a scene and selects which ones should have sound (25-60% of images per scene)
  - Phase 2: Generate sound prompts only for selected images; mark others as "SKIP"

- **New curation logic**:
  - `curate_scene_sounds()`: Calls Claude to intelligently select images for sound based on visual distinctiveness, environmental context, and emotional weight
  - `_compute_bounds()`: Calculates min/max sound counts based on configurable percentage bounds (default 25%-60%)
  - `_parse_curation_response()`: Robustly parses Claude's JSON response, handling markdown fences and malformed input
  - `_enforce_bounds()`: Ensures selections stay within min/max bounds by promoting/demoting images as needed
  - `_fallback_selection()`: Provides fallback evenly-spaced selection if Claude fails

- **Updated `process_video()` workflow**:
  - Groups images by scene before processing
  - Calls curation for each scene to determine which images get sound
  - Generates prompts only for curated images; writes "SKIP" for others
  - Improved logging to show curation decisions and statistics

- **New system prompt** (`SOUND_CURATION_SYSTEM`): Instructs Claude on when to add vs. skip sound (environmental distinctiveness, action/motion, emotional weight, etc.)

- **Comprehensive test suite** (`test_sound_curation.py`): 
  - Tests bounds computation for various scene sizes
  - Tests JSON parsing with markdown fences and malformed input
  - Tests min/max enforcement logic
  - Tests fallback selection strategy

- **Updated Sound Bot**: Modified to skip "SKIP" entries when generating sound effects

## Implementation Details

- Percentage-based bounds ensure flexibility across different scene lengths (always at least 1 sound per scene)
- JSON parsing is defensive, extracting arrays from markdown-fenced or text-wrapped responses
- Enforcement prefers promoting earlier images (for scene establishment) and demoting later ones (to preserve key moments)
- Scene-level grouping allows Claude to make contextual decisions about sound distribution across the entire scene

https://claude.ai/code/session_019fCtHPYb3YTwoDvZs7JYKY