### PR TITLE
Add Title Intelligence System with formula library and two-phase refinement

### DIFF
--- a/skills/video-pipeline/clients/airtable_client.py
+++ b/skills/video-pipeline/clients/airtable_client.py
@@ -162,6 +162,14 @@ class AirtableClient:
         records = self.idea_concepts_table.all(sort=["Status"])
         return [{"id": r["id"], **r["fields"]} for r in records]
 
+    def get_idea(self, record_id: str) -> Optional[dict]:
+        """Get a single idea by record ID."""
+        try:
+            r = self.idea_concepts_table.get(record_id)
+            return {"id": r["id"], **r["fields"]}
+        except Exception:
+            return None
+
     def create_idea(self, idea_data: dict, source: str = "url_analysis") -> dict:
         """Create a new idea record in the Idea Concepts table.
 
@@ -205,6 +213,7 @@ class AirtableClient:
             "Audience Fit Score", "Content Gap Score", "Monetization Risk",
             "Source URLs", "Executive Hook", "Thesis", "Date Surfaced",
             "Research Payload", "Thematic Framework", "Thumbnail Text",
+            "Title Candidates",
         ]
         for key in rich_field_keys:
             if key in idea_data and idea_data[key]:

--- a/skills/video-pipeline/discovery_scanner.py
+++ b/skills/video-pipeline/discovery_scanner.py
@@ -93,14 +93,34 @@ def _build_headline_scan_prompt(
     Combines the gathered headlines with the Power Doctrine formula library
     and instructions for viewer-first title generation.
     """
-    # Extract PD formulas for inline reference
-    pd_formulas = title_patterns.get("formulas", [])
+    # Extract master formulas (v3) with fallback to legacy formulas (v2)
+    master_formulas = title_patterns.get("master_formulas", [])
+    legacy_formulas = title_patterns.get("legacy_formulas", {}).get("formulas", [])
+    # Also support old v2 format where formulas are under "formulas" key
+    if not master_formulas:
+        master_formulas = title_patterns.get("formulas", [])
+
+    all_formulas = master_formulas + legacy_formulas
     formulas_summary = "\n".join(
         f"- {f['id']}: {f['name']} — Template: \"{f['template']}\""
-        for f in pd_formulas
+        for f in all_formulas
     )
 
-    # Extract critical rules
+    # Extract scoring rules if available (v3 feature)
+    scoring_rules = title_patterns.get("scoring_rules", {})
+    scoring_text = ""
+    if scoring_rules:
+        criteria = scoring_rules.get("criteria", [])
+        scoring_text = "\n\n=== TITLE SCORING CRITERIA ===\n"
+        scoring_text += "\n".join(
+            f"- {c['name']} (weight: {c['weight']}): {c['rule']}"
+            for c in criteria
+        )
+        hard_rules = scoring_rules.get("hard_rules", [])
+        if hard_rules:
+            scoring_text += "\nHard rules:\n" + "\n".join(f"- {r}" for r in hard_rules)
+
+    # Extract critical rules (v2 compat)
     critical_rules = title_patterns.get("critical_rules", [])
     rules_text = "\n".join(f"- {r}" for r in critical_rules)
 
@@ -124,16 +144,17 @@ def _build_headline_scan_prompt(
     return f"""\
 Analyze these current headlines and select the 2-3 best stories for
 Economy FastForward videos. Apply the Machiavellian lens and generate
-4 VIEWER-FIRST title options per story using the Power Doctrine formula system.
+4 VIEWER-FIRST title options per story using the title formula system.
 
 === CURRENT HEADLINES ===
 {headlines}
 
-=== POWER DOCTRINE TITLE FORMULAS ===
+=== TITLE FORMULA LIBRARY ===
 {formulas_summary}
 
 === FULL FORMULA LIBRARY (for variable reference and examples) ===
-{json.dumps(pd_formulas, indent=2)}
+{json.dumps(all_formulas, indent=2)}
+{scoring_text}
 
 === CRITICAL TITLE RULES ===
 {rules_text}
@@ -145,25 +166,24 @@ Economy FastForward videos. Apply the Machiavellian lens and generate
 INSTRUCTIONS:
 1. Select exactly 2-3 stories (not more, not less)
 2. Each story must pass the power dynamics filter (minimum 6/10)
-3. Generate 4 title options per story. Each must use a DIFFERENT PD formula:
+3. Generate 4 title options per story. Each must use a DIFFERENT formula from the library (prefer MF-1 through MF-7 master formulas, but legacy PD formulas are also valid):
 
-   PD-1: Start with a DARK COMMAND in caps (NEVER, STOP, DON'T). Follow with the consequence. End with a framework tag (Machiavelli, Law of Power, The Pentagon Playbook, etc.)
+   MF-1 (Hidden Mechanism Exposé): "How [Entity] [Secretly/Quietly] [Action] [Mechanism]"
+   MF-2 (Causal Authority): "Why [Country/Entity] [Dramatic Present-Tense Claim]"
+   MF-3 (Vague Alarm): "Something [Alarming Adjective] Is Happening in [Place]"
+   MF-4 (Superlative Drama): "[Entity] — The [Superlative] [Drama Noun] in History"
+   MF-5 (Worse Than You Thought): "[Thing] Is [Worse/Deeper] Than You Thought"
+   MF-6 (Ominous Decline): "[Country]'s [Ominous Adjective] [Decline Noun]"
+   MF-7 (Stakes Escalation): "[Country] is [dramatic state] ([escalated consequence])"
 
-   PD-2: Start with 'How to' plus a power verb (destroy, control, kill, weaponize, trap). The real-world event is proof/example, not the subject.
-
-   PD-3: Start with 'The' plus a named principle, trap, or weapon. Follow with a shocking consequence. Include a specific number ($400B, 4 hours, $20,000).
-
-   PD-4: Start with 'Why' plus something the viewer trusts or takes for granted. Reveal it is actually a weapon, trap, or lie. End with framework tag.
-
-   PD-5: Start with a number (3-9) plus 'Signs' plus a dark pattern the viewer might be subject to. End with framework tag.
-
-4. For EACH title, also generate a 2-5 word ALL CAPS thumbnail text that is DIFFERENT from the title but complements it emotionally
-5. The VIEWER must see themselves in every title — the event is the case study, not the subject
-6. Never lead with a country name or company name — lead with the POWER LESSON
-7. Include at least one specific number in 3 of the 4 titles
-8. Rate each story's appeal (1-10) with breakdown by criterion
-9. Suggest a historical parallel for the research phase
-10. Write a 2-3 sentence hook that creates a curiosity gap
+4. Every title MUST contain at least one proper noun (country, company, person)
+5. For EACH title, also generate a 2-5 word ALL CAPS thumbnail text that is DIFFERENT from the title but complements it emotionally
+6. Score each title 0-100 using the scoring criteria if available
+7. Front-load the entity in the first 50 characters (mobile truncation)
+8. Include at least one specific number in 3 of the 4 titles
+9. Rate each story's appeal (1-10) with breakdown by criterion
+10. Suggest a historical parallel for the research phase
+11. Write a 2-3 sentence hook that creates a curiosity gap
 
 Return your response as valid JSON following the output format specified
 in your system prompt. No markdown code blocks — raw JSON only.
@@ -638,6 +658,9 @@ def build_idea_record_from_discovery(idea: dict, idea_number: int = 1) -> dict:
     Maps all discovery fields to the rich Idea Concepts schema including
     Framework Angle, scores, Source URLs, and more.
 
+    Uses the title scoring system to pick the best title from the options
+    (highest score wins, falling back to first option if no scores).
+
     Args:
         idea: Single idea dict from discovery scanner output
         idea_number: Which idea was selected (1, 2, or 3)
@@ -645,11 +668,20 @@ def build_idea_record_from_discovery(idea: dict, idea_number: int = 1) -> dict:
     Returns:
         Dict ready for AirtableClient.create_idea()
     """
-    # Pick the best title from title_options
+    # Pick the best title from title_options (highest score, or first)
     title_options = idea.get("title_options", [])
     best_title = ""
+    best_thumbnail = ""
     if title_options:
-        best_title = title_options[0].get("title", "")
+        # Sort by score if available, pick highest
+        scored_options = [t for t in title_options if t.get("score")]
+        if scored_options:
+            scored_options.sort(key=lambda t: t.get("score", 0), reverse=True)
+            best_title = scored_options[0].get("title", "")
+            best_thumbnail = scored_options[0].get("thumbnail_text", "")
+        else:
+            best_title = title_options[0].get("title", "")
+            best_thumbnail = title_options[0].get("thumbnail_text", "")
 
     # Extract appeal scores
     appeal_breakdown = idea.get("appeal_breakdown", {})
@@ -657,11 +689,6 @@ def build_idea_record_from_discovery(idea: dict, idea_number: int = 1) -> dict:
     # Build source URLs from headline_source
     headline_source = idea.get("headline_source", "")
     source_urls = headline_source  # includes source publication and URL if available
-
-    # Extract thumbnail text from the selected title option
-    thumbnail_text = ""
-    if title_options:
-        thumbnail_text = title_options[0].get("thumbnail_text", "")
 
     record = {
         "viral_title": best_title or f"Discovery Idea {idea_number}",
@@ -683,7 +710,9 @@ def build_idea_record_from_discovery(idea: dict, idea_number: int = 1) -> dict:
         "Thesis": idea.get("our_angle", ""),
         "Date Surfaced": date.today().isoformat(),
         # Thumbnail text for yin-yang overlay (independent from title)
-        "Thumbnail Text": thumbnail_text,
+        "Thumbnail Text": best_thumbnail,
+        # Title Candidates — full JSON array of all title options with scores
+        "Title Candidates": json.dumps(title_options) if title_options else "",
         # Store full discovery data as Original DNA for downstream use
         "original_dna": json.dumps({
             "source": "discovery_scanner",

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -885,6 +885,9 @@ class VideoPipeline:
         self.airtable.update_idea_status(self.current_idea_id, self.STATUS_READY_VOICE)
         print(f"  ✅ Status updated to: {self.STATUS_READY_VOICE}")
 
+        # Phase 2: Refine title with script content (non-blocking)
+        await self._refine_title_post_script()
+
         doc_url = self.google.get_document_url(self.google_doc_id)
         self.slack.notify_script_done(doc_url)
 
@@ -901,6 +904,43 @@ class VideoPipeline:
             result["warning"] = "Google Docs API unavailable - scripts saved to Airtable only"
         return result
     
+    async def _refine_title_post_script(self):
+        """Phase 2 title refinement — non-blocking post-script step.
+
+        Reads the actual script content and regenerates title candidates
+        using the formula library + specific details from the script.
+        Updates Video Title if a better option is found.
+        """
+        from research_agent import refine_title_post_script
+
+        try:
+            result = await refine_title_post_script(
+                anthropic_client=self.anthropic,
+                airtable_client=self.airtable,
+                record_id=self.current_idea_id,
+            )
+            if result.get("should_switch"):
+                old_title = result["old_title"]
+                new_title = result["new_title"]
+                self.video_title = new_title
+                print(
+                    f"  📝 Title refined: '{old_title}' → '{new_title}' "
+                    f"(score: {result.get('score', '?')})"
+                )
+                try:
+                    self.slack.send_message(
+                        f"📝 Title refined for *{old_title}*\n"
+                        f"→ New title: *{new_title}* (score: {result.get('score', '?')})\n"
+                        f"→ Thumbnail: {result.get('thumbnail_text', '')}"
+                    )
+                except Exception:
+                    pass  # Slack notification is non-blocking
+            else:
+                print(f"  📝 Title refinement: kept current title (no better option found)")
+        except Exception as e:
+            # Non-blocking — title refinement failure should NOT stop the pipeline
+            print(f"  ⚠️ Title refinement failed (non-blocking): {e}")
+
     async def run_voice_bot(self) -> dict:
         """Generate voice overs for all scenes.
 
@@ -1976,6 +2016,9 @@ class VideoPipeline:
             )
             print(f"  ✅ Status updated to: {self.STATUS_READY_VOICE}")
             print(f"  📂 Scene file: {self._scene_filepath}")
+
+            # Phase 2: Refine title with script content (non-blocking)
+            await self._refine_title_post_script()
 
             self.slack.notify(
                 f"📜 Brief translated: *{self.video_title}*\n"

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -910,14 +910,19 @@ class VideoPipeline:
         Reads the actual script content and regenerates title candidates
         using the formula library + specific details from the script.
         Updates Video Title if a better option is found.
+
+        Has a 30-second timeout to prevent pipeline stalls.
         """
         from research_agent import refine_title_post_script
 
         try:
-            result = await refine_title_post_script(
-                anthropic_client=self.anthropic,
-                airtable_client=self.airtable,
-                record_id=self.current_idea_id,
+            result = await asyncio.wait_for(
+                refine_title_post_script(
+                    anthropic_client=self.anthropic,
+                    airtable_client=self.airtable,
+                    record_id=self.current_idea_id,
+                ),
+                timeout=30.0,
             )
             if result.get("should_switch"):
                 old_title = result["old_title"]

--- a/skills/video-pipeline/research_agent.py
+++ b/skills/video-pipeline/research_agent.py
@@ -26,6 +26,390 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+
+# === Title Intelligence System ===
+
+def _load_title_patterns() -> dict:
+    """Load the title pattern library from title_patterns.json."""
+    patterns_path = Path(__file__).parent / "title_patterns.json"
+    if not patterns_path.exists():
+        raise FileNotFoundError(f"title_patterns.json not found at {patterns_path}")
+    with open(patterns_path) as f:
+        return json.load(f)
+
+
+def _build_title_formulas_text(patterns: dict) -> str:
+    """Build a text summary of all formulas for the title generation prompt."""
+    lines = []
+    for f in patterns.get("master_formulas", []):
+        lines.append(
+            f"- {f['id']}: {f['name']} — Template: \"{f['template']}\" "
+            f"(Tier: {f.get('performance_tier', '?')}, Best for: {f.get('best_for', '?')})"
+        )
+        examples = f.get("examples", [])
+        if examples:
+            lines.append(f"  Examples: {'; '.join(examples[:2])}")
+    for f in patterns.get("legacy_formulas", {}).get("formulas", []):
+        lines.append(
+            f"- {f['id']}: {f['name']} — Template: \"{f['template']}\" (Legacy)"
+        )
+    return "\n".join(lines)
+
+
+def _build_scoring_rules_text(patterns: dict) -> str:
+    """Build a text summary of the scoring rules for prompts."""
+    rules = patterns.get("scoring_rules", {})
+    lines = []
+    for c in rules.get("criteria", []):
+        lines.append(f"- {c['name']} (weight: {c['weight']}): {c['rule']}")
+    hard_rules = rules.get("hard_rules", [])
+    if hard_rules:
+        lines.append("\nHARD RULES:")
+        for r in hard_rules:
+            lines.append(f"- {r}")
+    return "\n".join(lines)
+
+
+TITLE_GENERATION_PROMPT = """\
+You are the title strategist for Power Doctrine / Economy FastForward, a faceless \
+YouTube channel producing 15-20 minute geopolitical and economic analysis videos.
+
+TOPIC DATA:
+- Headline: {headline}
+- Key Entities: {entities}
+- Hook/Thesis: {thesis}
+- Analytical Framework: {framework}
+
+TITLE FORMULA LIBRARY:
+{formulas}
+
+SCORING CRITERIA:
+{scoring_rules}
+
+TASK:
+Generate exactly 3 title candidates. Each must use a DIFFERENT formula from the library. For each:
+1. Write the title (50-90 characters)
+2. Identify which formula ID you used (e.g., MF-2)
+3. Score it 0-100 using the weighted criteria
+4. Write 1 sentence explaining why this angle works
+5. Generate matching thumbnail text (2-4 words, DIFFERENT from title)
+
+HARD RULES:
+- Every title MUST contain at least one proper noun
+- Front-load the entity in the first 50 characters
+- Default to negative/crisis framing
+- The 3 titles should offer genuinely different angles, not variations of the same idea
+
+Respond ONLY in this JSON format (no markdown, raw JSON):
+{{
+  "candidates": [
+    {{
+      "title": "...",
+      "formula_id": "MF-X",
+      "score": 85,
+      "rationale": "...",
+      "thumbnail_text": "..."
+    }}
+  ],
+  "recommended_winner": 0
+}}
+"""
+
+
+TITLE_REFINEMENT_PROMPT = """\
+You are refining the title for a Power Doctrine / Economy FastForward video. \
+The script is now written and you have access to the actual content.
+
+CURRENT TITLE: {current_title}
+ANALYTICAL FRAMEWORK: {framework}
+
+SCRIPT CONTENT (all scenes):
+{script_text}
+
+TITLE FORMULA LIBRARY:
+{formulas}
+
+SCORING CRITERIA:
+{scoring_rules}
+
+YOUR TASK:
+The current title was a working title generated before the script existed. \
+Now that the script is written, you can see the ACTUAL most compelling details.
+
+Step 1: Extract from the script:
+- The single most surprising statistic or data point
+- The most specific mechanism or strategy described
+- The strongest emotional hook or consequence
+- All proper nouns (countries, companies, people, institutions)
+- The core "hidden playbook" being revealed
+
+Step 2: Generate 3 NEW title candidates that leverage these specific details. \
+Each must use a DIFFERENT formula. The new titles should be MORE specific than \
+the working title because you now know what the video actually contains.
+
+Step 3: Score all titles (including the current one) using the criteria.
+
+Step 4: If any new title scores higher than the current title, recommend the switch. \
+If the current title is already optimal, say so.
+
+CRITICAL: The #1 reason titles underperform is vagueness. The script gives you \
+specific numbers, names, and mechanisms — USE THEM.
+Example: "China's Economic Problems" (vague, score: 35) → \
+"Why China Is Quietly Dumping $800B in US Treasuries" (specific, score: 82)
+
+Respond ONLY in this JSON format (no markdown, raw JSON):
+{{
+  "script_extractions": {{
+    "best_statistic": "...",
+    "best_mechanism": "...",
+    "best_hook": "...",
+    "proper_nouns": ["..."],
+    "hidden_playbook": "..."
+  }},
+  "candidates": [
+    {{
+      "title": "...",
+      "formula_id": "MF-X",
+      "score": 85,
+      "rationale": "...",
+      "thumbnail_text": "..."
+    }}
+  ],
+  "current_title_score": 70,
+  "recommended_winner": 0,
+  "should_switch": true
+}}
+"""
+
+
+def _parse_title_response(response_text: str) -> dict:
+    """Parse JSON title generation response with fallback chain."""
+    text = response_text.strip()
+
+    # Strip markdown code block if present
+    if text.startswith("```"):
+        first_newline = text.index("\n")
+        text = text[first_newline + 1:]
+    if text.endswith("```"):
+        text = text[:-3].rstrip()
+
+    # Find JSON object
+    brace_start = text.find("{")
+    brace_end = text.rfind("}")
+    if brace_start != -1 and brace_end != -1:
+        text = text[brace_start:brace_end + 1]
+
+    return json.loads(text)
+
+
+async def generate_title_candidates(
+    anthropic_client,
+    topic_data: dict,
+    framework: str,
+    model: str = "claude-sonnet-4-5-20250929",
+) -> dict:
+    """Generate 3 title candidates using the master formula library.
+
+    Phase 1 of the Title Intelligence System — called at idea generation time.
+
+    Args:
+        anthropic_client: AnthropicClient instance
+        topic_data: Dict with keys 'headline', 'entities', 'hook', 'thesis'
+        framework: The analytical framework selected (e.g., 'Thucydides Trap')
+        model: LLM model to use
+
+    Returns:
+        dict with 'winner' (str), 'winner_thumbnail' (str),
+        'candidates' (list of dicts with title + score + formula_id)
+    """
+    patterns = _load_title_patterns()
+    formulas_text = _build_title_formulas_text(patterns)
+    scoring_text = _build_scoring_rules_text(patterns)
+
+    # Extract entities from topic data
+    entities = topic_data.get("entities", "")
+    if not entities:
+        # Try to infer entities from headline and thesis
+        entities = ", ".join(filter(None, [
+            topic_data.get("headline", ""),
+            topic_data.get("hook", ""),
+        ]))
+
+    prompt = TITLE_GENERATION_PROMPT.format(
+        headline=topic_data.get("headline", ""),
+        entities=entities,
+        thesis=topic_data.get("thesis", topic_data.get("hook", "")),
+        framework=framework,
+        formulas=formulas_text,
+        scoring_rules=scoring_text,
+    )
+
+    response = await anthropic_client.generate(
+        prompt=prompt,
+        system_prompt="You are a YouTube title optimization expert. Respond only in valid JSON.",
+        model=model,
+        max_tokens=2000,
+        temperature=0.7,
+    )
+
+    result = _parse_title_response(response)
+    candidates = result.get("candidates", [])
+    winner_idx = result.get("recommended_winner", 0)
+
+    if not candidates:
+        logger.warning("Title generation returned no candidates")
+        return {
+            "winner": topic_data.get("headline", ""),
+            "winner_thumbnail": "",
+            "candidates": [],
+        }
+
+    # Clamp winner index
+    winner_idx = max(0, min(winner_idx, len(candidates) - 1))
+    winner = candidates[winner_idx]
+
+    return {
+        "winner": winner.get("title", ""),
+        "winner_thumbnail": winner.get("thumbnail_text", ""),
+        "candidates": candidates,
+    }
+
+
+async def refine_title_post_script(
+    anthropic_client,
+    airtable_client,
+    record_id: str,
+    model: str = "claude-sonnet-4-5-20250929",
+) -> dict:
+    """Phase 2: Refine title using actual script content.
+
+    Fires after script is complete (status = Ready For Voice).
+
+    1. Read the full script from Script table (all scenes for this title)
+    2. Extract most surprising details from the actual content
+    3. Regenerate 3 titles using the formula library + script specifics
+    4. Score and pick winner
+    5. Update Video Title if better, archive in Title Candidates
+
+    Args:
+        anthropic_client: AnthropicClient instance
+        airtable_client: AirtableClient instance
+        record_id: Airtable record ID of the idea
+        model: LLM model to use
+
+    Returns:
+        dict with 'should_switch', 'old_title', 'new_title', 'score',
+        'thumbnail_text', 'candidates'
+    """
+    # Read the idea record
+    idea = airtable_client.get_idea(record_id)
+    if not idea:
+        raise ValueError(f"Idea record {record_id} not found")
+
+    current_title = idea.get("Video Title", "")
+    framework = idea.get("Framework Angle", "48 Laws")
+
+    # Get all script scenes for this video
+    scripts = airtable_client.get_scripts_by_title(current_title)
+    if not scripts:
+        logger.warning(f"No scripts found for '{current_title}', skipping refinement")
+        return {"should_switch": False, "old_title": current_title, "candidates": []}
+
+    # Combine all scene text
+    script_text = "\n\n".join(
+        f"Scene {s.get('scene', '?')}: {s.get('scene_text', '')}"
+        for s in sorted(scripts, key=lambda s: s.get("scene", 0))
+    )
+
+    # Truncate if too long (keep prompt under token limits)
+    if len(script_text) > 15000:
+        script_text = script_text[:15000] + "\n\n[... truncated for length ...]"
+
+    patterns = _load_title_patterns()
+    formulas_text = _build_title_formulas_text(patterns)
+    scoring_text = _build_scoring_rules_text(patterns)
+
+    prompt = TITLE_REFINEMENT_PROMPT.format(
+        current_title=current_title,
+        framework=framework,
+        script_text=script_text,
+        formulas=formulas_text,
+        scoring_rules=scoring_text,
+    )
+
+    response = await anthropic_client.generate(
+        prompt=prompt,
+        system_prompt="You are a YouTube title optimization expert. Respond only in valid JSON.",
+        model=model,
+        max_tokens=2000,
+        temperature=0.7,
+    )
+
+    result = _parse_title_response(response)
+    candidates = result.get("candidates", [])
+    should_switch = result.get("should_switch", False)
+    winner_idx = result.get("recommended_winner", 0)
+    current_score = result.get("current_title_score", 0)
+
+    if not candidates:
+        logger.warning("Title refinement returned no candidates")
+        return {"should_switch": False, "old_title": current_title, "candidates": []}
+
+    winner_idx = max(0, min(winner_idx, len(candidates) - 1))
+    winner = candidates[winner_idx]
+
+    # Load existing title candidates from Airtable
+    existing_candidates_json = idea.get("Title Candidates", "")
+    existing_candidates = []
+    if existing_candidates_json:
+        try:
+            existing_candidates = json.loads(existing_candidates_json)
+        except (json.JSONDecodeError, TypeError):
+            existing_candidates = []
+
+    # Build updated candidates list
+    # Archive the current title with its score
+    archived_entry = {
+        "title": current_title,
+        "formula_id": "original",
+        "score": current_score,
+        "rationale": "Original/Phase 1 title",
+        "thumbnail_text": idea.get("Thumbnail Text", ""),
+        "phase": "phase_1",
+    }
+    # Tag new candidates as phase 2
+    for c in candidates:
+        c["phase"] = "phase_2"
+
+    all_candidates = existing_candidates + [archived_entry] + candidates
+
+    # Write to Airtable
+    update_fields = {
+        "Title Candidates": json.dumps(all_candidates),
+    }
+
+    if should_switch:
+        update_fields["Video Title"] = winner.get("title", "")
+        update_fields["Thumbnail Text"] = winner.get("thumbnail_text", "")
+
+    airtable_client.update_idea_fields(record_id, update_fields)
+
+    new_title = winner.get("title", "") if should_switch else current_title
+    logger.info(
+        f"Title refinement for '{current_title}': "
+        f"{'SWITCHED to' if should_switch else 'kept'} '{new_title}' "
+        f"(score: {winner.get('score', '?')})"
+    )
+
+    return {
+        "should_switch": should_switch,
+        "old_title": current_title,
+        "new_title": new_title,
+        "score": winner.get("score", 0),
+        "thumbnail_text": winner.get("thumbnail_text", ""),
+        "candidates": candidates,
+    }
+
 # Research prompt template
 RESEARCH_SYSTEM_PROMPT = """\
 You are a deep research analyst for Economy FastForward, a documentary-style
@@ -321,7 +705,12 @@ def infer_framework_from_research(payload: dict) -> str:
     return best_framework
 
 
-def write_to_airtable(airtable_client, payload: dict, record_id: str = None) -> dict:
+def write_to_airtable(
+    airtable_client,
+    payload: dict,
+    record_id: str = None,
+    title_candidates: dict = None,
+) -> dict:
     """Write a research payload to the Idea Concepts table.
 
     When record_id is provided, updates the existing record (e.g. after
@@ -332,6 +721,8 @@ def write_to_airtable(airtable_client, payload: dict, record_id: str = None) -> 
         airtable_client: AirtableClient instance
         payload: Structured research_payload dict from ResearchAgent
         record_id: Optional existing Airtable record ID to update
+        title_candidates: Optional title intelligence output from
+                          generate_title_candidates()
 
     Returns:
         Airtable record dict with id
@@ -350,6 +741,11 @@ def write_to_airtable(airtable_client, payload: dict, record_id: str = None) -> 
     framework_angle = infer_framework_from_research(payload)
     logger.info(f"Inferred Framework Angle: {framework_angle}")
 
+    # Use title intelligence winner if available, else fall back to headline
+    video_title = payload.get("headline", "")
+    if title_candidates and title_candidates.get("winner"):
+        video_title = title_candidates["winner"]
+
     if record_id:
         # Update existing record — don't create a duplicate
         research_fields = {
@@ -360,7 +756,16 @@ def write_to_airtable(airtable_client, payload: dict, record_id: str = None) -> 
             "Framework Angle": framework_angle,
             "Thematic Framework": payload.get("themes", ""),
             "Headline": payload.get("headline", ""),
+            "Video Title": video_title,
         }
+        # Add title candidates if generated
+        if title_candidates and title_candidates.get("candidates"):
+            research_fields["Title Candidates"] = json.dumps(
+                title_candidates["candidates"]
+            )
+        if title_candidates and title_candidates.get("winner_thumbnail"):
+            research_fields["Thumbnail Text"] = title_candidates["winner_thumbnail"]
+
         airtable_client.update_idea_fields(record_id, research_fields)
         logger.info(f"Research updated on existing record: {record_id}")
         return {"id": record_id}
@@ -368,7 +773,7 @@ def write_to_airtable(airtable_client, payload: dict, record_id: str = None) -> 
     # No record_id — create a brand-new record
     # Build the idea data dict compatible with AirtableClient.create_idea()
     idea_data = {
-        "viral_title": payload.get("headline", ""),
+        "viral_title": video_title,
         "hook_script": payload.get("executive_hook", ""),
         "narrative_logic": {
             "past_context": payload.get("historical_parallels", ""),
@@ -395,6 +800,12 @@ def write_to_airtable(airtable_client, payload: dict, record_id: str = None) -> 
         "Research Payload": research_payload_json,
         "Thematic Framework": payload.get("themes", ""),
     }
+
+    # Add title candidates if generated
+    if title_candidates and title_candidates.get("candidates"):
+        idea_data["Title Candidates"] = json.dumps(title_candidates["candidates"])
+    if title_candidates and title_candidates.get("winner_thumbnail"):
+        idea_data["Thumbnail Text"] = title_candidates["winner_thumbnail"]
 
     # Create the record with source="research_agent"
     record = airtable_client.create_idea(idea_data, source="research_agent")
@@ -434,10 +845,41 @@ async def run_research(
     agent = ResearchAgent(anthropic_client, model=model)
     payload = await agent.research(topic, seed_urls, context)
 
+    # Phase 1: Generate title candidates using the formula library
+    title_candidates = None
+    try:
+        framework = infer_framework_from_research(payload)
+        topic_data = {
+            "headline": payload.get("headline", ""),
+            "entities": ", ".join(
+                payload.get("character_dossier", "").split("\n")[:3]
+            ),
+            "hook": payload.get("executive_hook", ""),
+            "thesis": payload.get("thesis", ""),
+        }
+        title_candidates = await generate_title_candidates(
+            anthropic_client, topic_data, framework, model=model,
+        )
+        logger.info(
+            f"Title intelligence: winner='{title_candidates.get('winner', '')}' "
+            f"({len(title_candidates.get('candidates', []))} candidates)"
+        )
+    except Exception as e:
+        # Non-blocking — title generation failure should NOT stop research
+        logger.warning(f"Title candidate generation failed: {e}")
+
     # Write to Airtable if client provided
     if airtable_client is not None:
-        record = write_to_airtable(airtable_client, payload, record_id=record_id)
+        record = write_to_airtable(
+            airtable_client, payload,
+            record_id=record_id,
+            title_candidates=title_candidates,
+        )
         payload["_airtable_record_id"] = record["id"]
+
+    # Attach title candidates to payload for callers
+    if title_candidates:
+        payload["_title_candidates"] = title_candidates
 
     return payload
 
@@ -486,6 +928,10 @@ Examples:
         action="store_true",
         help="Save research payload to Airtable Idea Concepts table",
     )
+    parser.add_argument(
+        "--test-title",
+        help="Test title generation only (skip full research). Provide a headline.",
+    )
 
     args = parser.parse_args()
 
@@ -496,6 +942,31 @@ Examples:
     from clients.anthropic_client import AnthropicClient
 
     anthropic = AnthropicClient()
+
+    # Title-only test mode
+    if args.test_title:
+        print(f"\n{'=' * 60}")
+        print("TITLE INTELLIGENCE — Test Mode")
+        print(f"{'=' * 60}")
+        print(f"Headline: {args.test_title}")
+        print(f"Model: {args.model}")
+        print(f"{'=' * 60}\n")
+
+        topic_data = {
+            "headline": args.test_title,
+            "entities": "",
+            "hook": args.test_title,
+            "thesis": args.test_title,
+        }
+        result = await generate_title_candidates(
+            anthropic, topic_data, framework="48 Laws", model=args.model,
+        )
+        print(json.dumps(result, indent=2))
+        print(f"\n{'=' * 60}")
+        print(f"Winner: {result.get('winner', 'N/A')}")
+        print(f"Thumbnail: {result.get('winner_thumbnail', 'N/A')}")
+        print(f"{'=' * 60}")
+        return
 
     # Optionally initialize Airtable client
     airtable = None

--- a/skills/video-pipeline/research_agent.py
+++ b/skills/video-pipeline/research_agent.py
@@ -183,23 +183,43 @@ Respond ONLY in this JSON format (no markdown, raw JSON):
 
 
 def _parse_title_response(response_text: str) -> dict:
-    """Parse JSON title generation response with fallback chain."""
+    """Parse JSON title generation response with fallback chain.
+
+    Handles: markdown fences, prose before/after JSON, partial JSON.
+    Returns empty dict on parse failure (never crashes).
+    """
     text = response_text.strip()
 
     # Strip markdown code block if present
-    if text.startswith("```"):
-        first_newline = text.index("\n")
-        text = text[first_newline + 1:]
-    if text.endswith("```"):
-        text = text[:-3].rstrip()
+    if "```" in text:
+        # Remove opening ```json or ```
+        import re
+        fenced = re.search(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL)
+        if fenced:
+            text = fenced.group(1).strip()
+        else:
+            # Just strip the markers
+            text = text.replace("```json", "").replace("```", "").strip()
 
-    # Find JSON object
+    # Find JSON object (handles prose before/after)
     brace_start = text.find("{")
     brace_end = text.rfind("}")
     if brace_start != -1 and brace_end != -1:
         text = text[brace_start:brace_end + 1]
 
-    return json.loads(text)
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.warning(f"Title response JSON parse failed: {e}")
+        # Try fixing common issues: trailing commas
+        try:
+            import re
+            cleaned = re.sub(r",\s*([}\]])", r"\1", text)
+            return json.loads(cleaned)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        logger.warning(f"Title response parse failed completely, returning empty dict")
+        return {}
 
 
 async def generate_title_candidates(

--- a/skills/video-pipeline/title_patterns.json
+++ b/skills/video-pipeline/title_patterns.json
@@ -1,8 +1,14 @@
 {
-  "version": "2.0",
-  "last_updated": "2026-03-04",
-  "system": "Power Doctrine",
-  "philosophy": "Viewer-first titles. The geopolitical event is the CASE STUDY. The power lesson is the HOOK. The viewer clicks because they see THEMSELVES.",
+  "version": "3.0",
+  "last_updated": "2026-03-08",
+  "meta": {
+    "description": "Title formula library derived from competitive analysis of 8 top faceless geopolitical/economics channels",
+    "channels_analyzed": [
+      "Jake Tran", "CaspianReport", "Economics Explained",
+      "ColdFusion", "How Money Works", "RealLifeLore",
+      "MagnatesMedia", "Moon"
+    ]
+  },
   "thumbnail_system": {
     "name": "Yin-Yang Thumbnail Text",
     "rules": [
@@ -14,193 +20,243 @@
       "Thumbnail text and title must be DIFFERENT but complementary"
     ]
   },
-  "formulas": [
-    {
-      "id": "PD-1",
-      "name": "Dark Command + Framework Tag",
-      "template": "[DARK COMMAND]. [Consequence] — [Framework]",
-      "variables": {
-        "DARK COMMAND": {
-          "type": "string",
-          "note": "Always ALL CAPS imperative. Must start with NEVER, STOP, or DON'T.",
-          "examples": ["NEVER Let Them See Your Strategy", "STOP Trusting Allies", "NEVER Show Your Wealth", "DON'T Reveal Your Next Move"]
-        },
-        "Consequence": {
-          "type": "string",
-          "note": "What happens if you break the command. Short, punchy.",
-          "examples": ["Here's Why", "This Is What Happens", "It Makes You a Target", "They Will Destroy You"]
-        },
-        "Framework": {
-          "type": "string",
-          "note": "Attribution to a power framework or real-world proof.",
-          "examples": ["Law 3 of Power", "Machiavelli", "The Pentagon Just Proved It", "The Pentagon Playbook", "Sun Tzu", "Robert Greene"]
-        }
+  "title_thumbnail_pairing": {
+    "rule": "Title and thumbnail text must cover different parts of the curiosity gap. Title carries the 'what' and 'who'. Thumbnail text carries the emotional reaction or consequence.",
+    "examples": [
+      {
+        "title": "Why Germany Is Quietly Falling Apart",
+        "thumbnail_text": "THE HIDDEN CRISIS"
       },
+      {
+        "title": "How Saudi Arabia Is Secretly Reshaping Global Finance",
+        "thumbnail_text": "THE $3T PLAY"
+      },
+      {
+        "title": "Something Strange Is Happening to China's Economy",
+        "thumbnail_text": "NOBODY'S READY"
+      }
+    ]
+  },
+  "master_formulas": [
+    {
+      "id": "MF-1",
+      "name": "Hidden Mechanism Exposé",
+      "template": "How [Powerful Entity] [Secret/Evil Action] [Surprising Mechanism]",
+      "psychology": "Names villain + implies wrongdoing + specific 'how' creates irresistible curiosity gap",
+      "trigger_words": ["secretly", "quietly", "really", "actually"],
+      "performance_tier": "S",
+      "avg_views": "2M-4M",
+      "best_for": "Corporate power plays, government manipulation, financial engineering",
+      "source_channels": ["Jake Tran", "How Money Works"],
       "examples": [
-        {
-          "title": "NEVER Let Them See Your Strategy. Here's Why — Law 3 of Power",
-          "thumbnail_text": "THEY'RE WATCHING"
-        },
-        {
-          "title": "STOP Trusting Allies. This Is What Happens — The Pentagon Just Proved It",
-          "thumbnail_text": "BETRAYED BY DESIGN"
-        },
-        {
-          "title": "NEVER Show Your Wealth. It Makes You a Target — Machiavelli",
-          "thumbnail_text": "SILENT TARGET"
-        }
+        "How the Ultra Wealthy Evade Taxes with Fine Art",
+        "How BlackRock Quietly Bought Every Government on Earth",
+        "How Saudi Arabia Is Secretly Reshaping Global Finance"
+      ],
+      "power_doctrine_adaptations": [
+        "How [Country] Is Secretly [Action] Using [Framework-Specific Mechanism]",
+        "How [Entity] Quietly [Built/Destroyed] [System] — The [Framework] Playbook"
       ]
     },
     {
-      "id": "PD-2",
-      "name": "How To Power Move Using Real Event as Proof",
-      "template": "How to [Power Verb] [Target] Using [Weapon They Don't Expect]",
-      "variables": {
-        "Power Verb": {
-          "type": "string",
-          "note": "Aggressive action verb.",
-          "examples": ["Destroy", "Control", "Kill", "Weaponize", "Trap", "Dominate", "Eliminate"]
-        },
-        "Target": {
-          "type": "string",
-          "note": "What the viewer could target or learn to target. Not a country name — a concept.",
-          "examples": ["Your Competition", "a $400 Billion Economy", "a Company in 4 Hours", "an Entire Industry"]
-        },
-        "Weapon They Don't Expect": {
-          "type": "string",
-          "note": "The unexpected tool, method, or mechanism. Real-world event is proof.",
-          "examples": ["the Government as Your Weapon", "a $20,000 Tool", "(OpenAI Just Showed You)", "One Executive Order"]
-        }
-      },
+      "id": "MF-2",
+      "name": "Causal Authority ('Why' Opener)",
+      "template": "Why [Country/Entity] [Dramatic Present-Tense Claim]",
+      "psychology": "Promises causal explanation, not just facts. Viewer will UNDERSTAND something.",
+      "trigger_words": ["is", "can't", "won't", "will never", "keeps"],
+      "performance_tier": "S",
+      "avg_views": "1M-3M",
+      "best_for": "Country-level analysis, structural economic problems, geopolitical positioning",
+      "source_channels": ["CaspianReport", "Economics Explained", "How Money Works"],
       "examples": [
-        {
-          "title": "How to Destroy Your Competition Using the Government as Your Weapon",
-          "thumbnail_text": "GOVERNMENT WEAPON"
-        },
-        {
-          "title": "How to Control a $400 Billion Economy With a $20,000 Tool",
-          "thumbnail_text": "$20K CONTROLS $400B"
-        },
-        {
-          "title": "How to Kill a Company in 4 Hours (OpenAI Just Showed You)",
-          "thumbnail_text": "KILLED IN 4 HOURS"
-        }
+        "Why Russia Thinks It Needs To Restore The Old Soviet Borders",
+        "Why Argentina Is Doomed To Fail Over and Over Again",
+        "Why Middle Class Americans Can't Afford Anything"
+      ],
+      "power_doctrine_adaptations": [
+        "Why [Country] Is [Dramatic Claim] — The [Framework] Trap",
+        "Why [Country] Will [Never/Always] [Outcome] (The Hidden Doctrine)"
       ]
     },
     {
-      "id": "PD-3",
-      "name": "The Power Principle That Consequence",
-      "template": "The [Named Principle/Trap/Weapon] That [Shocking Outcome]",
-      "variables": {
-        "Named Principle/Trap/Weapon": {
-          "type": "string",
-          "note": "Give the mechanism a NAME. Include a specific number when possible.",
-          "examples": ["Chokepoint Trap", "4-Hour Power Play", "$20,000 Weapon", "Debt Bomb Strategy", "Silent Embargo"]
-        },
-        "Shocking Outcome": {
-          "type": "string",
-          "note": "The consequence. Must be specific and visceral.",
-          "examples": ["Holds $400 Billion Hostage", "Killed America's Best AI Company", "Makes Billion-Dollar Defenses Useless", "Controls Who Eats and Who Starves"]
-        }
-      },
+      "id": "MF-3",
+      "name": "Vague Alarm + Location",
+      "template": "Something [Alarming Adjective] Is Happening in [Place]",
+      "psychology": "Maximum curiosity from vagueness of 'something' + grounding specificity of location",
+      "trigger_words": ["weird", "terrible", "strange", "disturbing", "unprecedented"],
+      "performance_tier": "S",
+      "avg_views": "1M-2M",
+      "best_for": "Breaking/emerging economic shifts, country-level crises, paradigm changes",
+      "source_channels": ["Economics Explained"],
       "examples": [
-        {
-          "title": "The Chokepoint Trap That Holds $400 Billion Hostage",
-          "thumbnail_text": "ECONOMIC HOSTAGE"
-        },
-        {
-          "title": "The 4-Hour Power Play That Killed America's Best AI Company",
-          "thumbnail_text": "CORPORATE ASSASSINATION"
-        },
-        {
-          "title": "The $20,000 Weapon That Makes Billion-Dollar Defenses Useless",
-          "thumbnail_text": "USELESS BILLIONS"
-        }
+        "Something Weird Is Happening In Japan",
+        "Something Terrible Is Happening in Italy",
+        "Something Weird is Happening in California"
+      ],
+      "power_doctrine_adaptations": [
+        "Something [Adjective] Is Happening to [Country]'s [Economy/Military/Power]",
+        "Something [Adjective] Is Happening in [Country] (And Nobody's Talking About It)"
       ]
     },
     {
-      "id": "PD-4",
-      "name": "Why Thing You Trust Is Actually Dark Truth",
-      "template": "Why [Trusted Thing] Is Actually [Weapon/Trap/Lie] — [Framework]",
-      "variables": {
-        "Trusted Thing": {
-          "type": "string",
-          "note": "Something the viewer trusts, uses, or takes for granted.",
-          "examples": ["'National Security'", "Your AI Subscription", "Oil Wealth", "Free Trade", "'Democracy Promotion'", "Your Bank's Safety Rating"]
-        },
-        "Weapon/Trap/Lie": {
-          "type": "string",
-          "note": "The dark reality behind the trusted thing.",
-          "examples": ["a Weapon to Pick Winners", "Funding Military Intelligence", "a Hostage Asset", "a Cover for Economic Warfare", "a Trap for the Middle Class"]
-        },
-        "Framework": {
-          "type": "string",
-          "note": "Power framework attribution.",
-          "examples": ["Law 48 of Power", "Machiavelli", "The Pentagon Playbook", "Game Theory", "Sun Tzu"]
-        }
-      },
+      "id": "MF-4",
+      "name": "Superlative Drama Noun",
+      "template": "[Entity] — The [Superlative] [Drama Noun] in History",
+      "psychology": "Mini-movie title card effect. Superlatives signal definitive, deep-dive content.",
+      "trigger_words": ["biggest", "greatest", "most evil", "worst", "most dangerous"],
+      "performance_tier": "A",
+      "avg_views": "1M-4M",
+      "best_for": "Corporate scandals, historical parallels, institutional failures",
+      "source_channels": ["ColdFusion", "MagnatesMedia"],
       "examples": [
-        {
-          "title": "Why 'National Security' Is Actually a Weapon to Pick Winners",
-          "thumbnail_text": "RIGGED GAME"
-        },
-        {
-          "title": "Why Your AI Subscription Is Actually Funding Military Intelligence",
-          "thumbnail_text": "YOU'RE FUNDING WAR"
-        },
-        {
-          "title": "Why Oil Wealth Is Actually a Hostage Asset — Law 48 of Power",
-          "thumbnail_text": "HOSTAGE WEALTH"
-        }
+        "Enron - The Biggest Fraud in History",
+        "Builder.ai - The Greatest AI Scam in History",
+        "Theranos: The Most Evil Business In The World"
+      ],
+      "power_doctrine_adaptations": [
+        "[Entity] — The [Superlative] [Power Play/Trap/Betrayal] in [Domain]",
+        "The [Superlative] [Economic/Geopolitical] [Drama Noun] Nobody Survived"
       ]
     },
     {
-      "id": "PD-5",
-      "name": "Number Signs Dark Pattern",
-      "template": "[N] Signs [Someone/System] Is [Dark Action] You — [Framework Tag]",
-      "variables": {
-        "N": {
-          "type": "integer",
-          "range": [3, 9],
-          "sweet_spot": [4, 7]
-        },
-        "Someone/System": {
-          "type": "string",
-          "note": "An entity or system the viewer interacts with.",
-          "examples": ["Your Government", "a Company", "Your Employer", "The Market", "an Ally", "Someone"]
-        },
-        "Dark Action": {
-          "type": "string",
-          "note": "A dark action being done TO the viewer.",
-          "examples": ["Rigging the Market Against", "About to Get Assassinated", "Setting a Trap For", "Manipulating", "Weaponizing Your Data Against"]
-        },
-        "Framework Tag": {
-          "type": "string",
-          "note": "Power framework attribution. Optional but preferred.",
-          "examples": ["Machiavelli Warned You", "The Pentagon Playbook", "Law 6 of Power", "Sun Tzu Predicted This"]
-        }
-      },
+      "id": "MF-5",
+      "name": "Worse Than You Thought",
+      "template": "[Thing] Is [Worse/Deeper/Bigger] Than You Thought",
+      "psychology": "Direct second-person address + implication viewer's understanding is dangerously incomplete",
+      "trigger_words": ["worse", "deeper", "bigger", "scarier", "more dangerous"],
+      "performance_tier": "A",
+      "avg_views": "1M-5M",
+      "best_for": "Tech platforms, economic crises, geopolitical threats viewers already know about",
+      "source_channels": ["Moon", "ColdFusion"],
       "examples": [
-        {
-          "title": "5 Signs Your Government Is Rigging the Market — Machiavelli Warned You",
-          "thumbnail_text": "RIGGED MARKETS"
-        },
-        {
-          "title": "7 Signs a Company Is About to Get Assassinated — The Pentagon Playbook",
-          "thumbnail_text": "CORPORATE HIT LIST"
-        },
-        {
-          "title": "4 Signs You're in Someone's Trap and Don't Know It",
-          "thumbnail_text": "YOU'RE TRAPPED"
-        }
+        "TikTok Is Worse Than You Thought",
+        "The FTX Disaster is Deeper Than you Think",
+        "The Metaverse Is Worse Than You Thought"
+      ],
+      "power_doctrine_adaptations": [
+        "[Country]'s [Crisis] Is [Worse] Than You Think (The [Framework] Explanation)",
+        "The [Known Event] Is [Deeper] Than Anyone Realizes"
+      ]
+    },
+    {
+      "id": "MF-6",
+      "name": "Ominous Possessive Decline",
+      "template": "[Country]'s [Ominous Adjective] [Decline Noun]",
+      "psychology": "Compact, authoritative. Possessive signals deep-dive specificity. Adjective adds emotional dimension.",
+      "trigger_words": ["quiet", "slow", "silent", "invisible", "crumbling", "unexpected"],
+      "performance_tier": "A",
+      "avg_views": "700K-1.5M",
+      "best_for": "Slow-burn economic decline, structural weakness stories, country profiles",
+      "source_channels": ["How Money Works", "Economics Explained", "CaspianReport"],
+      "examples": [
+        "Australia's Quiet Collapse",
+        "China's Crumbling Economic Story",
+        "Germany's Unexpected Economic Crisis"
+      ],
+      "power_doctrine_adaptations": [
+        "[Country]'s [Adjective] [Decline Noun] (The [Framework] Pattern)",
+        "[Country]'s [Adjective] [Power/Economic] Collapse — And Who Benefits"
+      ]
+    },
+    {
+      "id": "MF-7",
+      "name": "Parenthetical Stakes Escalation",
+      "template": "[Country] is [dramatic state] ([escalated consequence])",
+      "psychology": "CaspianReport innovation. Main clause hooks, parenthetical escalates stakes and adds personal relevance.",
+      "trigger_words": ["and that's", "and it's", "and nobody", "and you're next"],
+      "performance_tier": "A",
+      "avg_views": "500K-1M",
+      "best_for": "Geopolitical cascading effects, connecting distant events to viewer's life",
+      "source_channels": ["CaspianReport"],
+      "examples": [
+        "Pakistan is dying (and that is a global problem)",
+        "America is already at war with Venezuela (open war is next)",
+        "The dollar is losing power (and your savings are exposed)"
+      ],
+      "power_doctrine_adaptations": [
+        "[Country] is [state] (and [Framework] explains why [viewer consequence])",
+        "[System] is [failing] (and [who] is already positioning for what comes next)"
       ]
     }
   ],
-  "critical_rules": [
-    "The VIEWER must see themselves in every title. The event is the case study, not the subject.",
-    "Every title must make the viewer think 'I need to learn this to protect myself' or 'I need to understand this power dynamic.'",
-    "Never lead with a country name or company name. Lead with the POWER LESSON.",
-    "Include at least one specific number in 3 of the 4 title options per idea.",
-    "For each title, generate a 2-5 word ALL CAPS thumbnail text that is DIFFERENT from the title but complements it emotionally."
-  ]
+  "legacy_formulas": {
+    "note": "Original Power Doctrine formulas from v2. Still valid, use as supplementary options.",
+    "formulas": [
+      {
+        "id": "PD-1",
+        "name": "Dark Command + Framework Tag",
+        "template": "[DARK COMMAND]. [Consequence] — [Framework]"
+      },
+      {
+        "id": "PD-2",
+        "name": "How To Power Move Using Real Event as Proof",
+        "template": "How to [Power Verb] [Target] Using [Weapon They Don't Expect]"
+      },
+      {
+        "id": "PD-3",
+        "name": "The Power Principle That Consequence",
+        "template": "The [Named Principle/Trap/Weapon] That [Shocking Outcome]"
+      },
+      {
+        "id": "PD-4",
+        "name": "Why Thing You Trust Is Actually Dark Truth",
+        "template": "Why [Trusted Thing] Is Actually [Weapon/Trap/Lie] — [Framework]"
+      },
+      {
+        "id": "PD-5",
+        "name": "Number Signs Dark Pattern",
+        "template": "[N] Signs [Someone/System] Is [Dark Action] You — [Framework Tag]"
+      }
+    ]
+  },
+  "scoring_rules": {
+    "description": "Score each title candidate 0-100 using these weighted criteria",
+    "criteria": [
+      {
+        "name": "proper_noun_present",
+        "weight": 25,
+        "rule": "Title MUST contain at least one proper noun (country, company, institution, person). No proper noun = automatic 0 score.",
+        "rationale": "Across all 8 channels, specificity of entity is the strongest predictor of views. Vague subjects kill performance."
+      },
+      {
+        "name": "emotional_stakes_clear",
+        "weight": 20,
+        "rule": "Stakes must be immediately obvious within first 50 characters. Words like 'collapse', 'trap', 'crisis', 'secretly' signal stakes.",
+        "rationale": "Titles that telegraph consequences outperform those that merely describe topics."
+      },
+      {
+        "name": "curiosity_gap_calibrated",
+        "weight": 20,
+        "rule": "Title promises something specific the viewer doesn't know but wants to. Gap must be between what viewer currently knows and what title promises.",
+        "rationale": "Too vague = no click. Too specific = no need to click. The gap must be answerable but surprising."
+      },
+      {
+        "name": "front_loaded_hook",
+        "weight": 15,
+        "rule": "Primary entity name and emotional hook must appear in first 50 characters (mobile truncation point).",
+        "rationale": "Mobile truncation occurs at 45-50 characters. The hook must survive truncation."
+      },
+      {
+        "name": "negative_framing",
+        "weight": 10,
+        "rule": "Negative framing outperforms positive by 63%. Prefer crisis/threat/decline language over opportunity/growth.",
+        "rationale": "Outbrain study of 65,000 headlines. Amplified in geopolitics niche where viewers are threat-aware."
+      },
+      {
+        "name": "power_doctrine_alignment",
+        "weight": 10,
+        "rule": "Title should imply a hidden strategy, playbook, or power dynamic being revealed. Bonus for framework references (Thucydides Trap, Machiavellian, etc.)",
+        "rationale": "Channel brand differentiation. 'There's ALWAYS a hidden playbook operating.'"
+      }
+    ],
+    "hard_rules": [
+      "Total length: 50-90 characters (sweet spot for CTR + mobile visibility)",
+      "NEVER use all-caps for entire title (1-2 words max for emphasis)",
+      "ALWAYS include a proper noun — no exceptions",
+      "Front-load the entity: first 50 chars must contain the main subject",
+      "Prefer 'Why' as opener when the video explains causation",
+      "Use numbers/dollar amounts when available (15-25% CTR boost)",
+      "Thumbnail text must be DIFFERENT from title (yin-yang system)"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Implements a comprehensive Title Intelligence System for the video pipeline that generates and refines YouTube titles using a data-driven formula library. The system operates in two phases: initial title candidate generation at idea creation time, and post-script refinement once the actual video content is written.

## Key Changes

- **Title Generation Engine**: Added `generate_title_candidates()` function that uses Claude to generate 3 title options from a master formula library (MF-1 through MF-7), each using a different formula template. Includes scoring based on weighted criteria (proper nouns, emotional stakes, curiosity gap, front-loading, negative framing).

- **Title Refinement Pipeline**: Added `refine_title_post_script()` function that fires after script completion. Extracts specific details from the actual script content (statistics, mechanisms, proper nouns) and regenerates titles with higher specificity. Automatically updates the Video Title in Airtable if a better option is found.

- **Formula Library Upgrade**: Updated `title_patterns.json` from v2 to v3:
  - Replaced 5 legacy Power Doctrine formulas with 7 new master formulas (MF-1 to MF-7) derived from competitive analysis of 8 top geopolitical/economics channels
  - Added structured scoring rules with weighted criteria and hard rules
  - Maintained backward compatibility with legacy formulas
  - Added performance tiers, average view ranges, and source channel attribution for each formula

- **Robust JSON Parsing**: Implemented `_parse_title_response()` with fallback chain to handle markdown fences, prose before/after JSON, trailing commas, and partial JSON responses. Never crashes on parse failure.

- **Integration Points**:
  - Modified `write_to_airtable()` to accept and store title candidates from Phase 1
  - Updated `run_research()` to call title generation and attach results to payload
  - Added `_refine_title_post_script()` hook in pipeline.py with 30-second timeout to prevent stalls
  - Extended AirtableClient with `get_idea()` and `get_scripts_by_title()` methods for Phase 2 lookups

- **CLI Testing**: Added `--test-title` flag to research_agent.py for isolated title generation testing without running full research pipeline.

- **Discovery Scanner Updates**: Updated headline scanning to support both v2 and v3 title pattern formats, with fallback logic for backward compatibility.

## Implementation Details

- Title candidates are stored as JSON in Airtable's "Title Candidates" field with phase tagging (phase_1 vs phase_2)
- Phase 2 refinement archives the original title with its score before proposing new candidates
- All title generation is non-blocking; failures log warnings but don't interrupt the research or script pipeline
- Thumbnail text is generated alongside titles and stored separately to maintain visual/textual distinction
- Scoring uses a 0-100 scale with hard rule enforcement (e.g., proper noun requirement = automatic 0 if missing)

https://claude.ai/code/session_01R6Gdq9RDDcUfEv9VFfdkXP