### PR TITLE
Overhaul title and thumbnail system: MF formulas, 55-char limit, map thumbnails

### DIFF
--- a/skills/video-pipeline/clients/anthropic_client.py
+++ b/skills/video-pipeline/clients/anthropic_client.py
@@ -44,73 +44,84 @@ WEB_SEARCH_TOOL = {
     "max_uses": 5,
 }
 
-# Thumbnail System v2 - Locked House Style
+# Thumbnail System v3 - Map + Strategic Verdict (default) with editorial illustration fallback
 ANTHROPIC_THUMBNAIL_SYSTEM_PROMPT = """You are the thumbnail prompt engineer for Economy FastForward, \
-a finance/economics YouTube channel.
+a geopolitical/economics YouTube channel.
 
 Your job: Generate a detailed image generation prompt for Nano Banana Pro that produces \
 a click-worthy, on-brand thumbnail.
 
-HOUSE STYLE (always enforce these rules):
+DETERMINE TEMPLATE FIRST:
+- If the topic is about a COUNTRY, REGION, TRADE ROUTE, MILITARY ACTION, or GEOPOLITICAL EVENT → use MAP TEMPLATE (default)
+- If the topic is about FINANCE, TECH, CORPORATE, or has no clear geographic element → use EDITORIAL ILLUSTRATION TEMPLATE (fallback)
 
-COMPOSITION:
-- Left 60% = THE TENSION (dramatic scene, emotional figure, the problem)
-- Right 40% = THE PAYOFF (the answer, protection, opportunity — brightest element)
-- Clean diagonal divide line or contrast shift between sides
-- Bold red arrow pointing from tension to payoff
+=== MAP TEMPLATE (DEFAULT — for all geopolitical content) ===
 
-FIGURE:
-- ONE central human figure in left 60%, comic/editorial illustration style
-- Thick bold black outlines, expressive face readable at small size
-- Upper body minimum, professional clothing (suit/tie)
-- Body language matches the topic's emotion (shock, reaching, stumbling, pointing)
+Bright editorial illustration of a top-down map of [REGION], \
+clean cartographic style with warm tan landmasses and light blue water, \
+[ONE strategic overlay: thick red barrier/arrows/zone marking], \
+[relevant icons: ships/military assets/infrastructure clustered near key area], \
+bold white block capital text reading "[2-WORD VERDICT]" in the bottom-left \
+corner at roughly 35% of frame width with thick black outline and heavy \
+drop shadow, country name labels in smaller black text on landmasses, \
+the map geography should be clearly visible and not obscured by text, \
+clean minimal composition, no people no faces no figures, \
+must be readable at 160x90 pixels, 16:9 aspect ratio.
 
-BACKGROUND:
-- Maximum THREE elements total (one environmental, one scattered object, one atmospheric)
-- ONE dominant mood color (deep navy, dark red, or dark green gradient)
+COMPOSITION RULES (MAP):
+- Map is the PRIMARY visual element (60%+ of frame)
+- ONE strategic overlay only (red barrier, arrows, or zone)
+- Text in bottom-left corner, ~35% of frame width
+- Country labels in small black text on landmasses
+- Maximum 3-4 colors total (tan, blue, red, white/yellow text)
+- No people, no faces, no comic illustrations
+- Must read at phone thumbnail size (160x90px)
 
-PAYOFF:
-- Glowing dome/shield/bubble OR upward growth element
-- BRIGHTEST element in entire thumbnail
-- Radiating golden or green light
-- Contains clear visual symbols of the topic's "answer"
+=== EDITORIAL ILLUSTRATION TEMPLATE (FALLBACK — non-geographic topics) ===
 
-COLOR:
-- 2+1 rule: one dark background color, one bright pop accent, white text
-- Right side always brighter than left side
+Bright editorial illustration, 16:9 landscape aspect ratio, \
+high contrast, high saturation, thick black outlines on all figures, \
+flat cel-shaded coloring, bold composition.
 
-TEXT (critical — include in every prompt):
-- Position: Upper 20% of frame, two lines stacked
-- Line 1 (larger): The hook — year, number, or dramatic claim, max 5 words
-- Line 2 (slightly smaller): The question or tension, max 5 words
-- Style: Bold white condensed sans-serif, ALL CAPS, thick black outline stroke + drop shadow
-- ONE word highlighted in bright red (the curiosity trigger word)
-- Text must NOT overlap the figure's face or the payoff element
+- ONE central visual metaphor for the topic (system, machine, institution)
+- Clean background with ONE dominant mood color
+- Bold white block capital text reading "[2-WORD VERDICT]" \
+  with thick black outline and heavy drop shadow
+- No faces, no figures when possible — focus on systems and symbols
+- Must be readable at 160x90 pixels
 
-TECHNICAL:
-- Thick black outlines on all figures and objects
-- Flat cel-shaded coloring, high contrast, high saturation
-- Bright overall luminance (dark thumbnails disappear on YouTube)
-- 16:9 aspect ratio
+=== THUMBNAIL TEXT RULES (BOTH TEMPLATES) ===
 
-WHEN A REFERENCE SPEC IS PROVIDED:
-Incorporate specific style cues from the reference (pose, color choices, separator style) \
-BUT always enforce the house style rules above. The house style overrides any reference \
-element that conflicts with it.
+Thumbnail text is a 2-word STRATEGIC VERDICT stamped on the image.
 
-WHEN NO REFERENCE SPEC IS PROVIDED:
-Generate the thumbnail prompt purely from the house style rules and video topic. \
-This is the normal operating mode. The house style is sufficient to produce on-brand thumbnails.
+RULES:
+1. EXACTLY 2 words. Maximum 3 words only if absolutely necessary.
+2. No "YOUR" or "YOU" language — ever.
+3. Must be a JUDGMENT about the situation, not a description or consequence.
+4. Think: what would a general say in a briefing room after seeing the evidence?
+5. White or yellow bold text with thick black outline.
+
+GOOD EXAMPLES: CHOKE POINT, PROXY WAR, DRONE WALL, ART OF WAR, \
+DESIGNED TO FAIL, EXITS LOCKED, MISSILE STRATEGY, FORCED WAR, POWER VACUUM
+
+BAD EXAMPLES (DO NOT USE): YOUR MONEY GETS LOCKED, $9 GAS IS COMING, \
+YOUR AI JUST GOT WEAPONIZED, YOUR BANK IS NEXT
+
+FRAMEWORK-TO-VERDICT MAPPING (use when framework is known):
+- Thucydides Trap → FORCED WAR, COLLISION COURSE, NO EXIT
+- Machiavelli → POWER GRAB, RIGGED GAME, PUPPET MASTER
+- Antifragile → HOUSE OF CARDS, ONE SPARK, FRAGILE
+- Game Theory → TRAPPED, NO GOOD MOVES, LOSE-LOSE
+- Sun Tzu → INVISIBLE ARMY, DECOY, AMBUSH
+- Grand Chessboard → CHECKMATE, GRAND PLAY, CHOKE POINT
+- Kindleberger → POWER VACUUM, NO LEADER, LEADERLESS
+- Schelling → BLUFF CALLED, RED LINE, ULTIMATUM
+- Collective Action → ROTTING EMPIRE, PARALYSIS, DEAD WEIGHT
+- Soft Power → SILENT CONQUEST, SOFT KILL, INFLUENCE WAR
 
 OUTPUT FORMAT:
 Return ONLY the image generation prompt. No explanations, no JSON, no labels. \
-The prompt should be 150-200 words and follow this structure:
-1. Style declaration
-2. Left tension scene (figure + background)
-3. Right payoff scene (dome/element + contents)
-4. Separator description
-5. Text block (exact text, placement, styling, highlight word)
-6. Technical style rules"""
+The prompt should be 100-150 words."""
 
 
 class AnthropicClient:
@@ -899,10 +910,9 @@ Start with style engine prefix, end with style engine suffix + lighting + text r
         prompt_parts.extend([
             f'',
             f'THUMBNAIL TEXT TO INCLUDE:',
-            f'Generate two lines of text for the thumbnail based on the video title.',
-            f'Line 1: The hook (year/number/dramatic claim) — max 5 words, ALL CAPS',
-            f'Line 2: The question/tension — max 5 words, ALL CAPS',
-            f'Pick ONE word to highlight in red (the curiosity trigger).',
+            f'Generate a 2-word STRATEGIC VERDICT for the thumbnail based on the video topic.',
+            f'This should be a judgment about the situation (like CHOKE POINT, PROXY WAR, POWER VACUUM).',
+            f'EXACTLY 2 words, ALL CAPS. No YOUR/YOU language. No descriptions — a verdict.',
             f'',
             f'Generate the complete image prompt now.',
         ])

--- a/skills/video-pipeline/discovery_prompt.md
+++ b/skills/video-pipeline/discovery_prompt.md
@@ -9,8 +9,9 @@ news — the power dynamics, hidden systems, historical cycles, and strategic
 maneuvers that shape the world. They want to feel like insiders who see what
 the masses cannot.
 
-**Most importantly: your audience clicks because they see THEMSELVES in the
-title.** The geopolitical event is the CASE STUDY. The power lesson is the HOOK.
+**Most importantly: your audience clicks because the TITLE tells them exactly
+what they'll learn.** Short. Direct. Proper noun first. No cleverness — the
+EVENT is inherently interesting.
 
 ---
 
@@ -18,8 +19,8 @@ title.** The geopolitical event is the CASE STUDY. The power lesson is the HOOK.
 
 Scan the provided headlines and select the **2-3 stories** with the highest
 potential to become a viral Economy FastForward video. For each story, generate
-**4 viewer-first title options** using the Power Doctrine formula system, each
-with a complementary thumbnail text.
+**3 title options** using the Master Formula (MF) title system, each with a
+complementary 2-word thumbnail verdict.
 
 ---
 
@@ -27,10 +28,11 @@ with a complementary thumbnail text.
 
 - Economy FastForward reveals hidden power systems, cycles, and patterns
 - We bridge **geopolitical analysis** with **Machiavellian framing**
-- Our audience wants to feel like they're learning power lessons that protect them
-- Tone: **dark, authoritative, revelatory** — never clickbait without substance
-- We are NOT a news channel. We don't report events. We reveal the **power
-  lessons** behind events that the viewer can apply to their own life.
+- Tone: **authoritative, analytical, revelatory** — like a military briefing, not clickbait
+- We are NOT a news channel. We don't report events. We explain the **mechanisms and strategies** behind events.
+- MODEL THESE CHANNELS for title style:
+  - **CaspianReport** (1.8M subs): "How the Iran War set off a regional conflict" — short, declarative, proper noun first
+  - **AiTelly** (2M subs): "How Iran Breached US Israeli Air Defenses" — direct mechanism, tells you exactly what you'll learn
 
 ---
 
@@ -71,10 +73,10 @@ Score each headline on these 6 dimensions (1-10 each):
 - Geographic scope: world maps, trade routes, pipelines, borders
 
 ### 6. Emotional Trigger (PREFERRED)
-- Fear: "This threatens YOUR money/savings/retirement"
-- Outrage: "They did this SECRETLY and nobody noticed"
-- Curiosity: "I had no idea this was happening"
-- Vindication: "You were right to be suspicious"
+- Curiosity: "I need to understand how this works"
+- Stakes: "This mechanism affects global stability"
+- Revelation: "There's a hidden strategy at play here"
+- Pattern recognition: "This has happened before"
 
 ---
 
@@ -95,68 +97,71 @@ Score each headline on these 6 dimensions (1-10 each):
 
 ---
 
-## TITLE GENERATION — POWER DOCTRINE SYSTEM
+## TITLE GENERATION — MASTER FORMULA (MF) SYSTEM
 
-Generate 4 title options for each story. Each must use a different formula from
-the Power Doctrine title system:
+Generate 3 title options for each story. Each must use a DIFFERENT formula.
 
-### PD-1: Dark Command + Framework Tag
-Start with a DARK COMMAND in caps (NEVER, STOP, DON'T). Follow with the
-consequence. End with a framework tag (Machiavelli, Law of Power, The Pentagon
-Playbook, etc.)
-- Example: "NEVER Let Them See Your Strategy. Here's Why — Law 3 of Power"
-- Example: "STOP Trusting Allies. This Is What Happens — The Pentagon Just Proved It"
+### HARD RULES (STRICT):
+1. MAXIMUM 55 characters. Ideal is 35-50. Count every character.
+2. Start with "How" or "Why" — these are the two highest-performing openers in this niche.
+3. First word after How/Why MUST be a proper noun (country, company, institution, person).
+4. NEVER use "YOU" or "YOUR" — this is analysis, not self-help.
+5. NEVER use commands (NEVER, STOP, DON'T) — this is not Mindplicit.
+6. NEVER use ALL CAPS words except acronyms (US, NATO, PBOC, LNG).
+7. No em dashes (—), no parenthetical asides, no pipe separators (|).
+8. No cleverness. The event itself is interesting. Just state what the video explains.
+9. Declarative statements only. No question marks unless genuinely unanswered.
+10. The title should read like a military briefing header or CaspianReport episode title.
 
-### PD-2: How To Power Move Using Real Event as Proof
-Start with 'How to' plus a power verb (destroy, control, kill, weaponize,
-trap). The real-world event is proof/example, not the subject.
-- Example: "How to Destroy Your Competition Using the Government as Your Weapon"
-- Example: "How to Kill a Company in 4 Hours (OpenAI Just Showed You)"
+### FORMULA OPTIONS (pick the best fit):
 
-### PD-3: The Power Principle That Consequence
-Start with 'The' plus a named principle, trap, or weapon. Follow with a
-shocking consequence. Include a specific number ($400B, 4 hours, $20,000).
-- Example: "The Chokepoint Trap That Holds $400 Billion Hostage"
-- Example: "The $20,000 Weapon That Makes Billion-Dollar Defenses Useless"
+#### MF-0: Direct Mechanism (Search-First)
+"How [Entity] [Clear Action] [Target]" — for breaking events, mechanisms.
+- Example: "How Iran Breached US Israeli Air Defenses"
+- Example: "How US & Israel Tracked Down Ayatollah Khamenei"
+- Example: "How the Iran War set off a regional conflict"
 
-### PD-4: Why Thing You Trust Is Actually Dark Truth
-Start with 'Why' plus something the viewer trusts or takes for granted.
-Reveal it is actually a weapon, trap, or lie. End with framework tag.
-- Example: "Why 'National Security' Is Actually a Weapon to Pick Winners"
-- Example: "Why Your AI Subscription Is Actually Funding Military Intelligence"
+#### MF-1: Hidden Mechanism Exposé
+"How [Entity] [Secretly/Quietly] [Action] [Mechanism]" — for hidden strategies.
+- Example: "How BlackRock Quietly Bought Every Government"
+- Example: "How Saudi Arabia Is Secretly Reshaping Finance"
 
-### PD-5: Number Signs Dark Pattern
-Start with a number (3-9) plus 'Signs' plus a dark pattern the viewer
-might be subject to. End with framework tag.
-- Example: "5 Signs Your Government Is Rigging the Market — Machiavelli Warned You"
-- Example: "4 Signs You're in Someone's Trap and Don't Know It"
+#### MF-2: Causal Authority
+"Why [Country/Entity] [Dramatic Present-Tense Claim]" — for causal analysis.
+- Example: "Why the US Navy Can't Stop Houthi Rebels"
+- Example: "Why Argentina Is Doomed To Fail Over and Over"
 
-### CRITICAL TITLE RULES:
-- The VIEWER must see themselves in every title. The event is the case study, not the subject.
-- Every title must make the viewer think "I need to learn this to protect myself" or "I need to understand this power dynamic."
-- **Never lead with a country name or company name.** Lead with the POWER LESSON.
-- Include at least one specific number in 3 of the 4 titles.
-- Each of the 4 titles MUST use a different PD formula. You may skip one formula but never repeat one.
+#### MF-6: Ominous Possessive Decline
+"[Country]'s [Adjective] [Crisis/Collapse/Trap]" — for decline stories (shortest format).
+- Example: "Australia's Quiet Collapse"
+- Example: "Germany's Unexpected Economic Crisis"
 
 ---
 
-## THUMBNAIL YIN-YANG SYSTEM
+## THUMBNAIL TEXT — STRATEGIC VERDICT SYSTEM
 
-For each title, also generate a 2-5 word ALL CAPS thumbnail text that is
-DIFFERENT from the title but complements it emotionally.
+For each title, generate a 2-word ALL CAPS thumbnail text that reads like
+a classified document stamp or intelligence assessment.
 
 ### Thumbnail Rules:
-- 2-5 words maximum, ALL CAPS
-- Must be readable at mobile thumbnail size
-- Should trigger an emotional reaction BEFORE the viewer reads the title
-- If the title is analytical, the thumbnail is emotional
-- If the title is emotional, the thumbnail is specific
+- EXACTLY 2 words. Maximum 3 words only if absolutely necessary.
+- No "YOUR" or "YOU" language — ever.
+- Must be a JUDGMENT about the situation, not a description or consequence.
+- Think: what would a general say in a briefing room after seeing the evidence?
 
-### Examples:
-- Title: "How to Destroy Your Competition Using the Government" / Thumbnail: "KILLED IN 4 HOURS"
-- Title: "The Chokepoint Trap That Holds $400B Hostage" / Thumbnail: "ECONOMIC HOSTAGE"
-- Title: "Why 'National Security' Is Actually a Weapon to Pick Winners" / Thumbnail: "RIGGED GAME"
-- Title: "STOP Trusting Allies. This Is What Happens" / Thumbnail: "BETRAYED BY DESIGN"
+### Good Examples:
+- CHOKE POINT, PROXY WAR, DRONE WALL, ART OF WAR, DESIGNED TO FAIL
+- EXITS LOCKED, MISSILE STRATEGY, FORCED WAR, POWER VACUUM
+
+### Bad Examples (DO NOT USE):
+- YOUR MONEY GETS LOCKED (too long, uses YOUR)
+- $9 GAS IS COMING (prediction, not verdict)
+- YOUR BANK IS NEXT (uses YOUR)
+
+### Pairing Examples:
+- Title: "How Vietnam Is Beating China at Its Own Game" / Thumbnail: "RIGGED GAME"
+- Title: "Why the US Navy Can't Stop Houthi Rebels" / Thumbnail: "DRONE WALL"
+- Title: "How France Is Becoming a Third-World Economy" / Thumbnail: "DESIGNED TO FAIL"
 
 ---
 
@@ -200,31 +205,28 @@ For each of the 2-3 selected stories, output:
   "ideas": [
     {
       "headline_source": "Original headline text — Source Name (URL if available)",
-      "our_angle": "2-3 sentences on the Machiavellian/power dynamics angle we'd take. This is NOT a summary of the news — it's our UNIQUE SPIN framed as a power lesson the viewer can learn.",
+      "our_angle": "2-3 sentences on the Machiavellian/power dynamics angle we'd take. This is NOT a summary of the news — it's our UNIQUE analytical SPIN.",
       "title_options": [
         {
-          "title": "STOP Trusting Your AI Company. They Just Chose the Pentagon Over You",
-          "formula_id": "PD-1",
-          "formula_name": "Dark Command + Framework Tag",
-          "thumbnail_text": "THEY CHOSE WEAPONS"
+          "title": "How OpenAI Became a Pentagon Contractor",
+          "formula_id": "MF-0",
+          "formula_name": "Direct Mechanism (Search-First)",
+          "thumbnail_text": "POWER GRAB",
+          "score": 88
         },
         {
-          "title": "How to Kill a Company in 4 Hours (OpenAI Just Showed You)",
-          "formula_id": "PD-2",
-          "formula_name": "How To Power Move",
-          "thumbnail_text": "KILLED IN 4 HOURS"
+          "title": "Why OpenAI Can't Escape the Military",
+          "formula_id": "MF-2",
+          "formula_name": "Causal Authority",
+          "thumbnail_text": "NO EXIT",
+          "score": 82
         },
         {
-          "title": "The 4-Hour Power Play That Assassinated America's Best AI Company",
-          "formula_id": "PD-3",
-          "formula_name": "The Power Principle That Consequence",
-          "thumbnail_text": "CORPORATE ASSASSINATION"
-        },
-        {
-          "title": "Why Your Favorite AI Company Just Got Weaponized by the Government",
-          "formula_id": "PD-4",
-          "formula_name": "Why Thing You Trust Is Actually Dark Truth",
-          "thumbnail_text": "GOVERNMENT HIT JOB"
+          "title": "How the Pentagon Quietly Captured Silicon Valley",
+          "formula_id": "MF-1",
+          "formula_name": "Hidden Mechanism Exposé",
+          "thumbnail_text": "SILENT CONQUEST",
+          "score": 85
         }
       ],
       "hook": "2-3 sentence pitch for the video opening. Must create immediate curiosity gap.",
@@ -247,13 +249,14 @@ For each of the 2-3 selected stories, output:
 
 ## QUALITY CHECKLIST (verify before outputting)
 
-- [ ] Every title makes the VIEWER see themselves — not a news headline about a country
-- [ ] Every idea has 4 title options, each using a DIFFERENT PD formula
-- [ ] Every title has a complementary thumbnail text (2-4 words, ALL CAPS, DIFFERENT from title)
-- [ ] Thumbnail text uses personal stakes language ($amounts, YOUR, power words like TRAP/CHECKMATE/COLLAPSE)
-- [ ] Thumbnail text is the emotional gut punch; title is the intellectual framework (yin-yang)
-- [ ] At least 3 of the 4 titles per idea include a specific number
-- [ ] No title leads with a country name or company name
+- [ ] Every title is UNDER 55 characters. Ideal is 35-50.
+- [ ] Every title starts with "How" or "Why" (or MF-6 possessive format)
+- [ ] First word after How/Why is a proper noun (country, company, person)
+- [ ] NO title uses "YOU", "YOUR", "NEVER", "STOP", or ALL CAPS words (except acronyms)
+- [ ] NO em dashes, parenthetical asides, or pipe separators in titles
+- [ ] Every idea has 3 title options, each using a DIFFERENT MF formula
+- [ ] Every title has a 2-word thumbnail verdict (ALL CAPS, no YOUR language)
+- [ ] Thumbnail text is a strategic judgment, not a description
 - [ ] Every idea has a clear **power dynamics** angle (not generic news)
 - [ ] Every idea has a **Machiavellian framing** (not just economic analysis)
 - [ ] The hook creates an **irresistible curiosity gap**

--- a/skills/video-pipeline/discovery_scanner.py
+++ b/skills/video-pipeline/discovery_scanner.py
@@ -93,17 +93,15 @@ def _build_headline_scan_prompt(
     Combines the gathered headlines with the Power Doctrine formula library
     and instructions for viewer-first title generation.
     """
-    # Extract master formulas (v3) with fallback to legacy formulas (v2)
+    # Extract master formulas only (v3) — legacy PD formulas excluded from primary generation
     master_formulas = title_patterns.get("master_formulas", [])
-    legacy_formulas = title_patterns.get("legacy_formulas", {}).get("formulas", [])
     # Also support old v2 format where formulas are under "formulas" key
     if not master_formulas:
         master_formulas = title_patterns.get("formulas", [])
 
-    all_formulas = master_formulas + legacy_formulas
     formulas_summary = "\n".join(
         f"- {f['id']}: {f['name']} — Template: \"{f['template']}\""
-        for f in all_formulas
+        for f in master_formulas
     )
 
     # Extract scoring rules if available (v3 feature)
@@ -120,13 +118,17 @@ def _build_headline_scan_prompt(
         if hard_rules:
             scoring_text += "\nHard rules:\n" + "\n".join(f"- {r}" for r in hard_rules)
 
-    # Extract critical rules (v2 compat)
-    critical_rules = title_patterns.get("critical_rules", [])
-    rules_text = "\n".join(f"- {r}" for r in critical_rules)
-
     # Extract thumbnail system rules
-    thumbnail_rules = title_patterns.get("thumbnail_system", {}).get("rules", [])
+    thumbnail_system = title_patterns.get("thumbnail_system", {})
+    thumbnail_rules = thumbnail_system.get("rules", [])
     thumbnail_text = "\n".join(f"- {r}" for r in thumbnail_rules)
+    # Include good/bad examples if available
+    good_examples = thumbnail_system.get("good_examples", [])
+    bad_examples = thumbnail_system.get("bad_examples", [])
+    if good_examples:
+        thumbnail_text += "\nGood examples: " + ", ".join(good_examples)
+    if bad_examples:
+        thumbnail_text += "\nBad examples (DO NOT USE): " + ", ".join(bad_examples)
 
     focus_instruction = ""
     if focus:
@@ -143,47 +145,61 @@ def _build_headline_scan_prompt(
 
     return f"""\
 Analyze these current headlines and select the 2-3 best stories for
-Economy FastForward videos. Apply the Machiavellian lens and generate
-4 VIEWER-FIRST title options per story using the title formula system.
+Economy FastForward videos. Apply the analytical lens and generate
+3 title options per story using the Master Formula (MF) title system.
 
 === CURRENT HEADLINES ===
 {headlines}
 
-=== TITLE FORMULA LIBRARY ===
+=== TITLE FORMULA LIBRARY (MF system — use ONLY these) ===
 {formulas_summary}
 
 === FULL FORMULA LIBRARY (for variable reference and examples) ===
-{json.dumps(all_formulas, indent=2)}
+{json.dumps(master_formulas, indent=2)}
 {scoring_text}
 
-=== CRITICAL TITLE RULES ===
-{rules_text}
-
-=== THUMBNAIL YIN-YANG SYSTEM ===
+=== THUMBNAIL STRATEGIC VERDICT SYSTEM ===
 {thumbnail_text}
 {focus_instruction}
+
+TITLE GENERATION RULES (STRICT):
+
+You are generating titles for Economy FastForward, a geopolitical analysis YouTube channel.
+
+MODEL THESE CHANNELS (study their title patterns):
+- CaspianReport (1.8M subs): "How the Iran War set off a regional conflict" — short, declarative, proper noun first
+- AiTelly (2M subs): "How Iran Breached US Israeli Air Defenses" — direct mechanism, tells you exactly what you'll learn
+
+HARD RULES:
+1. MAXIMUM 55 characters. Ideal is 35-50. Count every character.
+2. Start with "How" or "Why" — these are the two highest-performing openers in this niche
+3. First word after How/Why MUST be a proper noun (country, company, institution, person)
+4. NEVER use "YOU" or "YOUR" — this is analysis, not self-help
+5. NEVER use commands (NEVER, STOP, DON'T) — this is not Mindplicit
+6. NEVER use ALL CAPS words except acronyms (US, NATO, PBOC, LNG)
+7. No em dashes (—), no parenthetical asides, no pipe separators (|)
+8. No cleverness. The event itself is interesting. Just state what the video explains.
+9. Declarative statements only. No question marks unless genuinely unanswered.
+10. The title should read like a military briefing header or CaspianReport episode title.
+
+FORMULA OPTIONS (pick the best fit):
+- MF-0: "How [Entity] [Clear Action] [Target]" — for breaking events, mechanisms
+- MF-1: "How [Entity] [Secret Action] [Surprising Detail]" — for hidden strategies
+- MF-2: "Why [Country/Entity] [Dramatic Present-Tense Claim]" — for causal analysis
+- MF-6: "[Country]'s [Adjective] [Crisis/Collapse/Trap]" — for decline stories (shortest format)
+
+Generate exactly 3 title candidates per story. Each must use a DIFFERENT formula. Score each 0-100.
 
 INSTRUCTIONS:
 1. Select exactly 2-3 stories (not more, not less)
 2. Each story must pass the power dynamics filter (minimum 6/10)
-3. Generate 4 title options per story. Each must use a DIFFERENT formula from the library (prefer MF-1 through MF-7 master formulas, but legacy PD formulas are also valid):
-
-   MF-1 (Hidden Mechanism Exposé): "How [Entity] [Secretly/Quietly] [Action] [Mechanism]"
-   MF-2 (Causal Authority): "Why [Country/Entity] [Dramatic Present-Tense Claim]"
-   MF-3 (Vague Alarm): "Something [Alarming Adjective] Is Happening in [Place]"
-   MF-4 (Superlative Drama): "[Entity] — The [Superlative] [Drama Noun] in History"
-   MF-5 (Worse Than You Thought): "[Thing] Is [Worse/Deeper] Than You Thought"
-   MF-6 (Ominous Decline): "[Country]'s [Ominous Adjective] [Decline Noun]"
-   MF-7 (Stakes Escalation): "[Country] is [dramatic state] ([escalated consequence])"
-
+3. Generate 3 title options per story, each using a DIFFERENT MF formula
 4. Every title MUST contain at least one proper noun (country, company, person)
-5. For EACH title, also generate a 2-5 word ALL CAPS thumbnail text that is DIFFERENT from the title but complements it emotionally
-6. Score each title 0-100 using the scoring criteria if available
-7. Front-load the entity in the first 50 characters (mobile truncation)
-8. Include at least one specific number in 3 of the 4 titles
-9. Rate each story's appeal (1-10) with breakdown by criterion
-10. Suggest a historical parallel for the research phase
-11. Write a 2-3 sentence hook that creates a curiosity gap
+5. For EACH title, generate a 2-word ALL CAPS thumbnail verdict (strategic judgment, no YOUR language)
+6. Score each title 0-100 using the scoring criteria
+7. Rate each story's appeal (1-10) with breakdown by criterion
+8. Suggest a historical parallel for the research phase
+9. Write a 2-3 sentence hook that creates a curiosity gap
 
 Return your response as valid JSON following the output format specified
 in your system prompt. No markdown code blocks — raw JSON only.
@@ -238,10 +254,10 @@ def _parse_scanner_output(response_text: str) -> dict:
 
         # Validate title_options have formula_id and thumbnail_text
         title_opts = idea.get("title_options", [])
-        if len(title_opts) < 4:
+        if len(title_opts) < 3:
             logger.warning(
                 f"Idea {i+1} has {len(title_opts)} title options "
-                f"(expected 4, one per PD formula)"
+                f"(expected 3, one per MF formula)"
             )
         for j, title_opt in enumerate(title_opts):
             if "formula_id" not in title_opt:
@@ -454,11 +470,11 @@ async def run_discovery(
 def format_ideas_for_slack(result: dict) -> str:
     """Format discovery results as a readable Slack message.
 
-    Each idea shows 4 title options (one per PD formula) with thumbnail
+    Each idea shows 3 title options (one per MF formula) with thumbnail
     text. Each title option gets its own number so the user can select
     both the idea AND the specific title they want.
 
-    For 3 ideas with 4 titles each, generates up to 12 numbered options.
+    For 3 ideas with 3 titles each, generates up to 9 numbered options.
 
     Args:
         result: Output from DiscoveryScanner.scan()
@@ -470,7 +486,7 @@ def format_ideas_for_slack(result: dict) -> str:
     if not ideas:
         return "No ideas found. Try running with a different focus keyword."
 
-    # Number emojis for up to 12 options (3 ideas x 4 titles)
+    # Number emojis for up to 9 options (3 ideas x 3 titles)
     number_emojis = [
         "1\ufe0f\u20e3", "2\ufe0f\u20e3", "3\ufe0f\u20e3",
         "4\ufe0f\u20e3", "5\ufe0f\u20e3", "6\ufe0f\u20e3",

--- a/skills/video-pipeline/research_agent.py
+++ b/skills/video-pipeline/research_agent.py
@@ -39,7 +39,10 @@ def _load_title_patterns() -> dict:
 
 
 def _build_title_formulas_text(patterns: dict) -> str:
-    """Build a text summary of all formulas for the title generation prompt."""
+    """Build a text summary of master formulas for the title generation prompt.
+
+    Legacy PD formulas are excluded from primary generation — only MF formulas are used.
+    """
     lines = []
     for f in patterns.get("master_formulas", []):
         lines.append(
@@ -49,10 +52,6 @@ def _build_title_formulas_text(patterns: dict) -> str:
         examples = f.get("examples", [])
         if examples:
             lines.append(f"  Examples: {'; '.join(examples[:2])}")
-    for f in patterns.get("legacy_formulas", {}).get("formulas", []):
-        lines.append(
-            f"- {f['id']}: {f['name']} — Template: \"{f['template']}\" (Legacy)"
-        )
     return "\n".join(lines)
 
 
@@ -71,7 +70,7 @@ def _build_scoring_rules_text(patterns: dict) -> str:
 
 
 TITLE_GENERATION_PROMPT = """\
-You are the title strategist for Power Doctrine / Economy FastForward, a faceless \
+You are the title strategist for Economy FastForward, a faceless \
 YouTube channel producing 15-20 minute geopolitical and economic analysis videos.
 
 TOPIC DATA:
@@ -86,19 +85,35 @@ TITLE FORMULA LIBRARY:
 SCORING CRITERIA:
 {scoring_rules}
 
+MODEL THESE CHANNELS (study their title patterns):
+- CaspianReport (1.8M subs): "How the Iran War set off a regional conflict" — short, declarative, proper noun first
+- AiTelly (2M subs): "How Iran Breached US Israeli Air Defenses" — direct mechanism, tells you exactly what you'll learn
+
 TASK:
 Generate exactly 3 title candidates. Each must use a DIFFERENT formula from the library. For each:
-1. Write the title (50-90 characters)
-2. Identify which formula ID you used (e.g., MF-2)
+1. Write the title (MAXIMUM 55 characters. Ideal is 35-50. Count every character.)
+2. Identify which formula ID you used (e.g., MF-0, MF-2)
 3. Score it 0-100 using the weighted criteria
 4. Write 1 sentence explaining why this angle works
-5. Generate matching thumbnail text (2-4 words, DIFFERENT from title)
+5. Generate matching 2-word thumbnail verdict (strategic judgment, no YOUR language)
 
 HARD RULES:
-- Every title MUST contain at least one proper noun
-- Front-load the entity in the first 50 characters
-- Default to negative/crisis framing
-- The 3 titles should offer genuinely different angles, not variations of the same idea
+1. MAXIMUM 55 characters. HARD CEILING. Under 45 is ideal.
+2. Start with "How" or "Why" — the two highest-performing openers in this niche
+3. First word after How/Why MUST be a proper noun (country, company, institution, person)
+4. NEVER use "YOU" or "YOUR" — this is analysis, not self-help
+5. NEVER use commands (NEVER, STOP, DON'T) — no imperatives
+6. NEVER use ALL CAPS words except acronyms (US, NATO, PBOC, LNG)
+7. No em dashes (—), no parenthetical asides, no pipe separators (|)
+8. No cleverness. The event itself is interesting. Just state what the video explains.
+9. Declarative statements only. No question marks unless genuinely unanswered.
+10. The 3 titles should offer genuinely different angles, not variations of the same idea
+
+PREFERRED FORMULAS:
+- MF-0: "How [Entity] [Clear Action] [Target]" — for breaking events, mechanisms
+- MF-1: "How [Entity] [Secret Action] [Surprising Detail]" — for hidden strategies
+- MF-2: "Why [Country/Entity] [Dramatic Present-Tense Claim]" — for causal analysis
+- MF-6: "[Country]'s [Adjective] [Crisis/Collapse/Trap]" — for decline stories
 
 Respond ONLY in this JSON format (no markdown, raw JSON):
 {{
@@ -117,7 +132,7 @@ Respond ONLY in this JSON format (no markdown, raw JSON):
 
 
 TITLE_REFINEMENT_PROMPT = """\
-You are refining the title for a Power Doctrine / Economy FastForward video. \
+You are refining the title for an Economy FastForward video. \
 The script is now written and you have access to the actual content.
 
 CURRENT TITLE: {current_title}
@@ -131,6 +146,10 @@ TITLE FORMULA LIBRARY:
 
 SCORING CRITERIA:
 {scoring_rules}
+
+MODEL THESE CHANNELS for title style:
+- CaspianReport (1.8M subs): "How the Iran War set off a regional conflict" — short, declarative
+- AiTelly (2M subs): "How Iran Breached US Israeli Air Defenses" — direct mechanism
 
 YOUR TASK:
 The current title was a working title generated before the script existed. \
@@ -152,10 +171,24 @@ Step 3: Score all titles (including the current one) using the criteria.
 Step 4: If any new title scores higher than the current title, recommend the switch. \
 If the current title is already optimal, say so.
 
+HARD RULES:
+1. MAXIMUM 55 characters. HARD CEILING. Under 45 is ideal.
+2. Start with "How" or "Why" — the two highest-performing openers
+3. First word after How/Why MUST be a proper noun
+4. NEVER use "YOU" or "YOUR" — this is analysis, not self-help
+5. NEVER use commands (NEVER, STOP, DON'T) — no imperatives
+6. NEVER use ALL CAPS words except acronyms (US, NATO, PBOC, LNG)
+7. No em dashes (—), no parenthetical asides, no pipe separators (|)
+8. Declarative statements only. No question marks unless genuinely unanswered.
+
+When refining the title post-script, prefer SHORTER over LONGER. \
+If the working title is 50 characters and a refinement is 55 characters \
+but only slightly better, keep the shorter one. Brevity wins.
+
 CRITICAL: The #1 reason titles underperform is vagueness. The script gives you \
-specific numbers, names, and mechanisms — USE THEM.
+specific numbers, names, and mechanisms — USE THEM. But keep it SHORT.
 Example: "China's Economic Problems" (vague, score: 35) → \
-"Why China Is Quietly Dumping $800B in US Treasuries" (specific, score: 82)
+"Why China Is Dumping $800B in US Treasuries" (specific + short, score: 88)
 
 Respond ONLY in this JSON format (no markdown, raw JSON):
 {{

--- a/skills/video-pipeline/thumbnail_generator/generator.py
+++ b/skills/video-pipeline/thumbnail_generator/generator.py
@@ -22,7 +22,7 @@ import time
 import requests
 from pathlib import Path
 
-from .templates import TEMPLATE_A, TEMPLATE_B, select_template
+from .templates import TEMPLATE_A, TEMPLATE_B, TEMPLATE_MAP, select_template
 from .titles import TITLE_FORMULAS, generate_title
 from .validator import validate_thumbnail
 from .config import (
@@ -201,6 +201,7 @@ def produce_thumbnail_and_title(
 
     # 2. Fill prompt template
     templates = {
+        "template_map": TEMPLATE_MAP,
         "template_a": TEMPLATE_A,
         "template_b": TEMPLATE_B,
     }

--- a/skills/video-pipeline/thumbnail_generator/templates.py
+++ b/skills/video-pipeline/thumbnail_generator/templates.py
@@ -1,17 +1,41 @@
 """Thumbnail prompt templates for Economy FastForward.
 
-Two cinematic photorealistic templates:
-  - Template A: Cinematic Scene (default, ~60% usage)
-  - Template B: Cinematic Close-Up (~40% usage, person-focused)
+Three templates:
+  - Template Map: Top-down map + strategic verdict (default, ~60% usage)
+  - Template A: Cinematic Scene (fallback for non-geographic topics, ~25%)
+  - Template B: Cinematic Close-Up (~15%, person-focused)
 
-All templates produce 16:9 cinematic photorealistic images via Nano Banana Pro
+All templates produce 16:9 images via Nano Banana Pro
 with text baked directly into the image.
 """
 
 
 # ---------------------------------------------------------------------------
-# Template A: Cinematic Scene (default — ~60% of thumbnails)
-# Select when: Systems, countries, markets, institutions, economic breakdowns.
+# Template Map: Top-down Map + Strategic Verdict (default — ~60% of thumbnails)
+# Select when: Countries, regions, trade routes, military actions, geopolitical events.
+# ---------------------------------------------------------------------------
+TEMPLATE_MAP = (
+    "Bright editorial illustration of a top-down map of {region}, "
+    "clean cartographic style with warm tan landmasses and light blue water, "
+    "{strategic_overlay}, "
+    "{map_icons}, "
+    "bold white block capital text reading '{verdict}' in the bottom-left "
+    "corner at roughly 35% of frame width with thick black outline and heavy "
+    "drop shadow, country name labels in smaller black text on landmasses, "
+    "the map geography should be clearly visible and not obscured by text, "
+    "clean minimal composition, no people no faces no figures, "
+    "must be readable at 160x90 pixels, 16:9 aspect ratio"
+)
+
+# Template Map required variables
+TEMPLATE_MAP_VARS = [
+    "region", "strategic_overlay", "map_icons", "verdict",
+]
+
+
+# ---------------------------------------------------------------------------
+# Template A: Cinematic Scene (fallback — ~25% of thumbnails)
+# Select when: Finance, tech, corporate — non-geographic topics.
 # ---------------------------------------------------------------------------
 TEMPLATE_A = (
     "Cinematic photorealistic movie poster composition, 16:9 landscape aspect "
@@ -21,24 +45,21 @@ TEMPLATE_A = (
     "consequence,\n\n"
     "Extreme contrast — highlights pushed bright, shadows near black, desaturated "
     "color palette with only {accent_color} as the single vivid accent color,\n\n"
-    "Bold text anchored to upper-right 30% of frame reading '{line_1}' in massive "
-    "white bold condensed all-caps font with heavy black outline stroke, the word "
-    "'{red_word}' is bright red and is the LARGEST element in the entire image at "
-    "approximately 3x the size of other text. Directly below with no gap, smaller "
-    "white bold text '{line_2}' with black outline. Text must not overlap the main "
-    "focal point,\n\n"
+    "Bold white block capital text reading '{verdict}' with thick black outline "
+    "and heavy drop shadow, anchored to upper-right 30% of frame, "
+    "must not overlap the main focal point,\n\n"
     "Movie poster composition, high contrast, must be instantly readable at "
     "120x68 pixel mobile thumbnail size"
 )
 
 # Template A required variables
 TEMPLATE_A_VARS = [
-    "scene_description", "accent_color", "line_1", "red_word", "line_2",
+    "scene_description", "accent_color", "verdict",
 ]
 
 
 # ---------------------------------------------------------------------------
-# Template B: Cinematic Close-Up (~40% of thumbnails)
+# Template B: Cinematic Close-Up (~15% of thumbnails)
 # Select when: Person-focused stories, assassinations, leaders, CEO,
 #               president, dictator, commander, general, individual power figures.
 # ---------------------------------------------------------------------------
@@ -50,10 +71,8 @@ TEMPLATE_B = (
     "{emotion_detail},\n\n"
     "Background is dark with subtle {background_element} visible in bokeh, "
     "desaturated palette with only {accent_color} as vivid accent,\n\n"
-    "Bold text block anchored to right 40% of frame reading '{line_1}' in "
-    "massive white bold condensed all-caps font with heavy black outline stroke, "
-    "the word '{red_word}' is bright red and LARGEST element. '{line_2}' directly "
-    "below, smaller white text with black outline,\n\n"
+    "Bold white block capital text reading '{verdict}' with thick black outline "
+    "and heavy drop shadow, anchored to right 40% of frame,\n\n"
     "Cinematic color grade, crushed blacks, single light source, readable at "
     "mobile thumbnail size"
 )
@@ -61,7 +80,7 @@ TEMPLATE_B = (
 # Template B required variables
 TEMPLATE_B_VARS = [
     "close_up_subject", "emotion_detail", "background_element",
-    "accent_color", "line_1", "red_word", "line_2",
+    "accent_color", "verdict",
 ]
 
 
@@ -69,6 +88,7 @@ TEMPLATE_B_VARS = [
 # Template registry
 # ---------------------------------------------------------------------------
 TEMPLATES = {
+    "template_map": {"name": "Map + Verdict", "prompt": TEMPLATE_MAP, "variables": TEMPLATE_MAP_VARS},
     "template_a": {"name": "Cinematic Scene", "prompt": TEMPLATE_A, "variables": TEMPLATE_A_VARS},
     "template_b": {"name": "Cinematic Close-Up", "prompt": TEMPLATE_B, "variables": TEMPLATE_B_VARS},
 }
@@ -94,16 +114,30 @@ _PERSON_KEYWORDS = [
     "his plan", "her plan", "his secret", "her secret",
 ]
 
+# Keywords that trigger Template A: Cinematic Scene (non-geographic fallback)
+_NON_GEO_KEYWORDS = [
+    "crypto", "bitcoin", "blockchain", "ai ", "artificial intelligence",
+    "stock market", "wall street", "silicon valley", "tech company",
+    "startup", "venture capital", "hedge fund", "private equity",
+    "algorithm", "software", "platform", "social media",
+    "bank", "banking", "financial", "fintech",
+]
+
 
 def select_template(topic: str, tags: list[str] = None) -> str:
     """Select thumbnail template based on topic and tags.
+
+    Priority:
+    1. Template B (Cinematic Close-Up) — person-focused stories
+    2. Template A (Cinematic Scene) — non-geographic topics (finance, tech)
+    3. Template Map (default) — all geopolitical/geographic content
 
     Args:
         topic: Video topic string.
         tags: Optional list of tags for template selection.
 
     Returns:
-        One of 'template_a', 'template_b'.
+        One of 'template_map', 'template_a', 'template_b'.
     """
     topic_lower = topic.lower()
     tags_lower = [t.lower() for t in (tags or [])]
@@ -113,5 +147,9 @@ def select_template(topic: str, tags: list[str] = None) -> str:
     if any(kw in all_text for kw in _PERSON_KEYWORDS):
         return "template_b"
 
-    # Template A: Cinematic Scene — default for systems, countries, markets
-    return "template_a"
+    # Template A: Cinematic Scene — non-geographic topics
+    if any(kw in all_text for kw in _NON_GEO_KEYWORDS):
+        return "template_a"
+
+    # Template Map: Map + Verdict — default for geopolitical content
+    return "template_map"

--- a/skills/video-pipeline/title_patterns.json
+++ b/skills/video-pipeline/title_patterns.json
@@ -10,34 +10,78 @@
     ]
   },
   "thumbnail_system": {
-    "name": "Yin-Yang Thumbnail Text",
+    "name": "Strategic Verdict Thumbnail Text",
     "rules": [
-      "2-5 words maximum, ALL CAPS",
-      "Must be readable at mobile thumbnail size",
-      "Should trigger an emotional reaction BEFORE the viewer reads the title",
-      "If the title is analytical, the thumbnail is emotional",
-      "If the title is emotional, the thumbnail is specific",
-      "Thumbnail text and title must be DIFFERENT but complementary"
-    ]
+      "EXACTLY 2 words. Maximum 3 words only if absolutely necessary.",
+      "No YOUR or YOU language — ever.",
+      "Must be a JUDGMENT about the situation, not a description or consequence.",
+      "Think: what would a general say in a briefing room after seeing the evidence?",
+      "White or yellow bold text with thick black outline.",
+      "Must be readable at mobile thumbnail size (160x90px)."
+    ],
+    "good_examples": [
+      "CHOKE POINT", "PROXY WAR", "DRONE WALL", "ART OF WAR",
+      "DESIGNED TO FAIL", "EXITS LOCKED", "MISSILE STRATEGY",
+      "FORCED WAR", "POWER VACUUM"
+    ],
+    "bad_examples": [
+      "YOUR MONEY GETS LOCKED (too long, uses YOUR)",
+      "$9 GAS IS COMING (prediction, not verdict)",
+      "YOUR AI JUST GOT WEAPONIZED (too long, uses YOUR)",
+      "YOUR BANK IS NEXT (uses YOUR)"
+    ],
+    "framework_to_verdict": {
+      "Thucydides Trap": ["FORCED WAR", "COLLISION COURSE", "NO EXIT"],
+      "Machiavelli": ["POWER GRAB", "RIGGED GAME", "PUPPET MASTER"],
+      "Antifragile": ["HOUSE OF CARDS", "ONE SPARK", "FRAGILE"],
+      "Game Theory": ["TRAPPED", "NO GOOD MOVES", "LOSE-LOSE"],
+      "Sun Tzu": ["INVISIBLE ARMY", "DECOY", "AMBUSH"],
+      "Grand Chessboard": ["CHECKMATE", "GRAND PLAY", "CHOKE POINT"],
+      "Kindleberger Trap": ["POWER VACUUM", "NO LEADER", "LEADERLESS"],
+      "Schelling": ["BLUFF CALLED", "RED LINE", "ULTIMATUM"],
+      "Collective Action": ["ROTTING EMPIRE", "PARALYSIS", "DEAD WEIGHT"],
+      "Soft Power": ["SILENT CONQUEST", "SOFT KILL", "INFLUENCE WAR"]
+    }
   },
   "title_thumbnail_pairing": {
-    "rule": "Title and thumbnail text must cover different parts of the curiosity gap. Title carries the 'what' and 'who'. Thumbnail text carries the emotional reaction or consequence.",
+    "rule": "Title and thumbnail text must cover different parts of the curiosity gap. Title carries the 'what' and 'who'. Thumbnail text is a 2-word strategic verdict — a judgment, not a description.",
     "examples": [
       {
-        "title": "Why Germany Is Quietly Falling Apart",
-        "thumbnail_text": "THE HIDDEN CRISIS"
+        "title": "How Vietnam Is Beating China at Its Own Game",
+        "thumbnail_text": "RIGGED GAME"
       },
       {
-        "title": "How Saudi Arabia Is Secretly Reshaping Global Finance",
-        "thumbnail_text": "THE $3T PLAY"
+        "title": "Why the US Navy Can't Stop Houthi Rebels",
+        "thumbnail_text": "DRONE WALL"
       },
       {
-        "title": "Something Strange Is Happening to China's Economy",
-        "thumbnail_text": "NOBODY'S READY"
+        "title": "How France Is Becoming a Third-World Economy",
+        "thumbnail_text": "DESIGNED TO FAIL"
       }
     ]
   },
   "master_formulas": [
+    {
+      "id": "MF-0",
+      "name": "Direct Mechanism (Search-First)",
+      "template": "How [Entity] [Clear Action] [Target/Object]",
+      "psychology": "Maximum clarity. Tells viewer exactly what they'll learn. Optimized for YouTube Search ranking. No cleverness — the EVENT is inherently interesting.",
+      "trigger_words": [],
+      "performance_tier": "S",
+      "avg_views": "1M-4M (AiTelly proof)",
+      "best_for": "Breaking/recent events, military/geopolitical actions, mechanism explanations",
+      "source_channels": ["AiTelly", "CaspianReport"],
+      "examples": [
+        "How Iran Breached US Israeli Air Defenses",
+        "How US & Israel Tracked Down Ayatollah Khamenei",
+        "How the Iran War set off a regional conflict",
+        "How Vietnam is beating China at its own game"
+      ],
+      "power_doctrine_adaptations": [
+        "How [Country] [Action] [Target/System]",
+        "Why [Country] [Can't/Won't] [Action]"
+      ]
+    },
     {
       "id": "MF-1",
       "name": "Hidden Mechanism Exposé",
@@ -180,7 +224,7 @@
     }
   ],
   "legacy_formulas": {
-    "note": "Original Power Doctrine formulas from v2. Still valid, use as supplementary options.",
+    "note": "Original Power Doctrine formulas from v2. LEGACY ONLY — do not use as primary generation formulas. Kept for backward compatibility and edge cases.",
     "formulas": [
       {
         "id": "PD-1",
@@ -250,13 +294,15 @@
       }
     ],
     "hard_rules": [
-      "Total length: 50-90 characters (sweet spot for CTR + mobile visibility)",
-      "NEVER use all-caps for entire title (1-2 words max for emphasis)",
+      "Total length: 30-55 characters. HARD CEILING of 55 characters. Under 45 is ideal. Mobile truncation occurs at 45-50 characters — the ENTIRE title must be visible on mobile.",
+      "NEVER use second-person 'YOU/YOUR' language in titles. No commands ('NEVER trust...', 'STOP doing...'). No imperatives. Titles are declarative statements or 'How/Why' questions about entities, not instructions to the viewer.",
+      "NEVER use ALL CAPS words in titles except for acronyms (US, NATO, PBOC). No 'NEVER', 'STOP', 'ACTUALLY'. These signal clickbait and reduce CTR on analytical content.",
+      "No question marks unless the question is genuinely unanswered. Declarative titles outperform questions.",
       "ALWAYS include a proper noun — no exceptions",
-      "Front-load the entity: first 50 chars must contain the main subject",
-      "Prefer 'Why' as opener when the video explains causation",
+      "Front-load the entity: proper noun must appear within first 5 words",
+      "Prefer 'How' or 'Why' as opener — these are the two highest-performing openers in this niche",
       "Use numbers/dollar amounts when available (15-25% CTR boost)",
-      "Thumbnail text must be DIFFERENT from title (yin-yang system)"
+      "Thumbnail text must be DIFFERENT from title — 2-word strategic verdict"
     ]
   }
 }


### PR DESCRIPTION
Replace PD-1 through PD-5 formulas with MF-0 through MF-7 as primary title
generation system. Modeled on CaspianReport and AiTelly title patterns that
drive 1M-4M views with short, direct, proper-noun-first titles.

Key changes:
- Add MF-0 "Direct Mechanism" formula (search-first, highest clarity)
- Hard ceiling of 55 characters (was 50-90), ideal under 45
- Ban YOU/YOUR language, ALL CAPS words (except acronyms), commands
- Replace "Yin-Yang" thumbnail text with 2-word strategic verdict system
- Default thumbnail template is now map-based (top-down cartographic)
- Move PD formulas to legacy section (kept for backward compatibility)
- Update discovery_prompt.md, discovery_scanner.py, research_agent.py
- Update anthropic_client.py thumbnail system prompt (map + verdict)
- Add TEMPLATE_MAP to thumbnail_generator with geographic auto-detection
- Phase 2 title refinement now prefers shorter over longer

https://claude.ai/code/session_01XtiCCXoNqcBrvL1goDqvQN