### PR TITLE
Fix script hallucination: strengthen grounding rules + add claim verification

### DIFF
--- a/skills/video-pipeline/brief_translator/__init__.py
+++ b/skills/video-pipeline/brief_translator/__init__.py
@@ -27,7 +27,7 @@ from .supplementer import (
     merge_supplement_into_brief,
     MAX_SUPPLEMENT_PASSES,
 )
-from .script_generator import generate_script
+from .script_generator import generate_script, verify_script_claims
 from .scene_expander import expand_scene_concepts
 from .scene_validator import validate_scene_list, auto_fix_minor_issues, check_entity_consistency
 from .pipeline_writer import graduate_to_pipeline
@@ -193,7 +193,30 @@ class BriefTranslator:
                     f"hallucination(s) detected"
                 )
 
-            # === STEP 2c: Assign Psychological Angles ===
+            # === STEP 2c: Verify factual claims (non-blocking) ===
+            unverified_claims = ""
+            try:
+                unverified_claims = await verify_script_claims(
+                    self.anthropic, script, brief
+                )
+                if unverified_claims:
+                    logger.warning(
+                        f"Claim verification flagged potential issues:\n"
+                        f"{unverified_claims[:500]}"
+                    )
+                    self._notify(
+                        f"⚠️ Claim verification flagged unverified claims "
+                        f"for '{brief.get('headline', 'Untitled')}'. "
+                        f"Check 'Unverified Claims' field in Script table."
+                    )
+                else:
+                    logger.info("Claim verification: all claims grounded")
+            except Exception as cv_err:
+                logger.warning(
+                    f"Claim verification skipped (non-blocking): {cv_err}"
+                )
+
+            # === STEP 2d: Assign Psychological Angles ===
             from .script_generator import extract_acts
             acts = extract_acts(script)
             if not acts:
@@ -256,6 +279,7 @@ class BriefTranslator:
                 slack_client=self.slack,
                 acts=acts,
                 psych_assignments=psych_assignments,
+                unverified_claims=unverified_claims,
             )
 
             result["status"] = "success"

--- a/skills/video-pipeline/brief_translator/pipeline_writer.py
+++ b/skills/video-pipeline/brief_translator/pipeline_writer.py
@@ -254,6 +254,7 @@ async def graduate_to_pipeline(
     slack_client=None,
     acts: Optional[dict] = None,
     psych_assignments: Optional[list[dict]] = None,
+    unverified_claims: str = "",
 ) -> dict:
     """Full graduation: Ideas Bank -> Pipeline Table + Scene File + Script Records.
 
@@ -268,6 +269,7 @@ async def graduate_to_pipeline(
         slack_client: SlackClient instance for notifications (optional)
         acts: Dict mapping act number to act text (for Script table records)
         psych_assignments: List of {"scene": N, "angle": str} (from psych_angle_assigner)
+        unverified_claims: Flagged claims from claim verification (written to scene 1)
 
     Returns:
         {
@@ -327,19 +329,32 @@ async def graduate_to_pipeline(
             for pa in psych_assignments:
                 angle_lookup[pa["scene"]] = pa["angle"]
 
+        first_record_id = None
         for act_num in sorted(acts.keys()):
             act_text = acts[act_num]
             psych_angle = angle_lookup.get(act_num, "")
             try:
-                airtable_client.create_script_record(
+                record = airtable_client.create_script_record(
                     scene_number=act_num,
                     scene_text=act_text,
                     title=video_title,
                     psych_angle=psych_angle,
                     sources=sources_text if act_num == 1 else "",
                 )
+                if act_num == min(acts.keys()):
+                    first_record_id = record.get("id")
             except Exception as e:
                 print(f"  ⚠️ Could not create Script record for scene {act_num}: {e}")
+
+        # Write unverified claims to the first script record (non-blocking)
+        if unverified_claims and first_record_id:
+            try:
+                airtable_client.update_script_record(
+                    first_record_id,
+                    {"Unverified Claims": unverified_claims},
+                )
+            except Exception as e:
+                print(f"  ⚠️ Could not write Unverified Claims: {e}")
 
     # 5. Update Idea Concepts record status  (was step 4)
     try:

--- a/skills/video-pipeline/brief_translator/script_generator.py
+++ b/skills/video-pipeline/brief_translator/script_generator.py
@@ -286,6 +286,46 @@ it with something from the research.
 The ONLY exception is well-known historical figures or events used in \
 framework references (e.g. Machiavelli, Sun Tzu, Athens vs Sparta) that \
 are part of the analytical framework, NOT part of the factual narrative.
+
+=== CRITICAL — FACTUAL GROUNDING (EXTENDED) ===
+
+1. Every specific claim (names, numbers, dates, events, tactics, weapons, \
+quotes) MUST come from the research payload provided. If a fact is not in \
+the payload, DO NOT USE IT.
+
+2. You may describe HOW something happened cinematically, but you MUST NOT \
+invent WHAT happened. Example: You can describe a missile strike \
+dramatically. You CANNOT invent a cyber attack that is not in the sources.
+
+3. Never fabricate technical details (weapon systems, military tactics, \
+operational specifics) to fill narrative gaps. If the payload does not \
+explain HOW something happened, say "analysts believe" or "evidence \
+suggests" — do not present speculation as confirmed fact.
+
+4. Historical parallels must come from the research payload's \
+historical_parallels field. Do not invent additional parallels.
+
+5. If a scene needs content the payload does not provide, use the \
+framework analysis to EXPLAIN the event rather than inventing new events. \
+The analytical framework is your gap-filler, not fabricated details.
+
+6. After writing each scene, mentally verify: "Could I cite a specific \
+source from the payload for every factual claim in this scene?" If not, \
+rewrite.
+
+WHAT YOU CAN CREATE:
+- Dramatic pacing, sentence structure, rhetorical questions
+- Emotional framing of sourced facts
+- Analytical connections between sourced facts using the framework
+- Metaphors and analogies that illustrate sourced concepts
+
+WHAT YOU CANNOT CREATE:
+- Events that did not happen
+- Technical details not in the payload (cyber attacks, specific weapon \
+deployments, operational sequences)
+- Quotes from people unless quoted in the payload
+- Statistics, percentages, or numbers not in the payload
+- Specific military tactics or operations not documented in sources
 """
 
 _ACT_SPECIFIC_RULES = """\
@@ -885,3 +925,94 @@ async def generate_script(
         "script": script,
         "validation": validation,
     }
+
+
+async def verify_script_claims(
+    anthropic_client,
+    script: str,
+    brief: dict,
+) -> str:
+    """Verify factual claims in the script against the research payload.
+
+    Uses a fast model (Haiku) to compare each scene's factual claims against
+    the research payload and flag any claim that cannot be traced back.
+
+    This is a NON-BLOCKING check — the script still advances to the next
+    pipeline stage regardless of the result. The output is stored in Airtable
+    for manual review.
+
+    Args:
+        anthropic_client: AnthropicClient instance.
+        script: The full generated script text.
+        brief: The research brief dict containing the source material.
+
+    Returns:
+        A string summarizing unverified claims, or empty string if all clean.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    # Build a condensed version of the research payload for comparison
+    payload_sections = []
+    for field in [
+        "fact_sheet", "historical_parallels", "character_dossier",
+        "narrative_arc", "counter_arguments", "thesis",
+        "executive_hook", "framework_analysis", "headline",
+    ]:
+        value = brief.get(field, "")
+        if value:
+            payload_sections.append(f"=== {field} ===\n{value}")
+
+    research_text = "\n\n".join(payload_sections)
+
+    system_prompt = (
+        "You are a fact-checking assistant. Your job is to compare a video "
+        "script against the research payload that was used to write it, and "
+        "flag any specific factual claims in the script that CANNOT be traced "
+        "to the research payload.\n\n"
+        "Focus on:\n"
+        "- Named events, operations, or incidents not in the research\n"
+        "- Specific technical details (weapons, cyber attacks, tactics) not sourced\n"
+        "- Statistics, numbers, dates, or percentages not in the research\n"
+        "- Quotes attributed to people that don't appear in the research\n"
+        "- Historical parallels not from the historical_parallels field\n\n"
+        "IGNORE:\n"
+        "- Dramatic phrasing, rhetorical questions, metaphors\n"
+        "- Analytical connections using the framework (these are allowed)\n"
+        "- Well-known framework references (Machiavelli, Sun Tzu, etc.)\n"
+        "- General knowledge that doesn't constitute a specific factual claim\n\n"
+        "Output format:\n"
+        "If claims are unverified, list each one as:\n"
+        "- [Act N] \"<the claim>\" — not found in research payload\n\n"
+        "If all claims are grounded, respond with exactly: ALL CLAIMS VERIFIED"
+    )
+
+    prompt = (
+        f"<research_payload>\n{research_text}\n</research_payload>\n\n"
+        f"<script>\n{script}\n</script>\n\n"
+        "Compare the script against the research payload. List any specific "
+        "factual claims in the script that cannot be traced to the research "
+        "payload."
+    )
+
+    try:
+        result = await anthropic_client.generate(
+            prompt=prompt,
+            system_prompt=system_prompt,
+            model="claude-haiku-4-5-20251001",
+            max_tokens=2000,
+            temperature=0.0,
+        )
+    except Exception as e:
+        logger.warning(f"Claim verification failed (non-blocking): {e}")
+        return ""
+
+    if not result or "ALL CLAIMS VERIFIED" in result.upper():
+        return ""
+
+    # Truncate if extremely long (Airtable Long Text field)
+    if len(result) > 5000:
+        result = result[:4950] + "\n\n[truncated]"
+
+    return result

--- a/skills/video-pipeline/clients/anthropic_client.py
+++ b/skills/video-pipeline/clients/anthropic_client.py
@@ -292,6 +292,18 @@ STYLE GUIDE:
 - FORMAT: Spoken word only. No "Scene 1" labels. No "Camera pans".
 - CONTINUITY: If this is Scene 1, start with a hook. If it is Scene 20, conclude the thought.
 
+CRITICAL — FACTUAL GROUNDING:
+- Every specific claim (names, numbers, dates, events, tactics, quotes) MUST \
+come from the scene beat provided. Do NOT invent facts, technical details, \
+or events not present in the source material.
+- You may describe events cinematically, but you MUST NOT invent WHAT happened. \
+Only dramatize HOW sourced events unfolded.
+- Never fabricate technical details (weapon systems, cyber attacks, operational \
+specifics) to fill narrative gaps. Use hedging language ("analysts believe", \
+"evidence suggests") instead of presenting speculation as fact.
+- Do not invent quotes, statistics, or specific military/political operations \
+not present in the scene beat.
+
 INSTRUCTION:
 Write the script for the scene provided. Return ONLY the narration text."""
         


### PR DESCRIPTION
The script bot was hallucinating facts not present in the research payload
(e.g., inventing cyber warfare narratives). This commit:

1. Extends _STRICT_GROUNDING_RULE in script_generator.py with explicit
   rules about what can/cannot be created (events, technical details,
   quotes, statistics vs dramatic pacing, emotional framing, metaphors)

2. Adds grounding constraints to the legacy write_scene path in
   anthropic_client.py

3. Adds verify_script_claims() - a Haiku-based post-generation check that
   compares each scene's factual claims against the research payload and
   flags unverified claims

4. Wires the verification into BriefTranslator (non-blocking) and writes
   flagged claims to the "Unverified Claims" field on the first Script
   table record for manual review

https://claude.ai/code/session_01Jnnx9qJhNkm5ApKHcKNJCd