### PR TITLE
Add video publish date tracking and backfill upload dates

### DIFF
--- a/skills/video-pipeline/bots/youtube_uploader.py
+++ b/skills/video-pipeline/bots/youtube_uploader.py
@@ -16,6 +16,7 @@ Quota:
 
 import os
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -299,11 +300,12 @@ class YouTubeUploader:
             self._cleanup(local_video, tmp_dir)
             return {"error": f"YouTube upload failed: {e}"}
 
-        # Update Airtable with YouTube info
+        # Update Airtable with YouTube info (including Upload Date for performance snapshots)
         airtable_client.update_idea_fields(record_id, {
             "YouTube Video ID": result["video_id"],
             "YouTube URL": result["video_url"],
             "Upload Status": "uploaded",
+            "Upload Date": datetime.now(timezone.utc).isoformat(),
         })
 
         # Cleanup temp files

--- a/skills/video-pipeline/performance_tracker.py
+++ b/skills/video-pipeline/performance_tracker.py
@@ -126,16 +126,16 @@ def get_uploaded_videos(airtable_client, recent_only: bool = False) -> list[dict
 
 
 def fetch_video_stats(youtube_service, video_id: str) -> dict | None:
-    """Fetch lifetime stats from YouTube Data API v3.
+    """Fetch lifetime stats and publish date from YouTube Data API v3.
 
-    Uses 1 quota unit per call (videos.list with part=statistics).
+    Uses 3 quota units per call (videos.list with part=statistics,snippet).
 
     Returns:
-        dict with views, likes, comments or None on failure
+        dict with views, likes, comments, published_at or None on failure
     """
     try:
         response = youtube_service.videos().list(
-            part="statistics",
+            part="statistics,snippet",
             id=video_id,
         ).execute()
 
@@ -143,11 +143,14 @@ def fetch_video_stats(youtube_service, video_id: str) -> dict | None:
         if not items:
             return None
 
-        stats = items[0]["statistics"]
+        item = items[0]
+        stats = item["statistics"]
+        published_at = item.get("snippet", {}).get("publishedAt")
         return {
             "views": int(stats.get("viewCount", 0)),
             "likes": int(stats.get("likeCount", 0)),
             "comments": int(stats.get("commentCount", 0)),
+            "published_at": published_at,
         }
     except Exception as e:
         print(f"     Stats fetch failed: {e}")
@@ -631,6 +634,11 @@ def main(recent_only: bool = False, dry_run: bool = False):
         else:
             print("    No stats available")
 
+        # Backfill Upload Date from YouTube publishedAt if missing in Airtable
+        if not upload_date and stats and stats.get("published_at"):
+            upload_date = stats["published_at"]
+            print(f"    Backfilling Upload Date: {upload_date}")
+
         # Fetch analytics (YouTube Analytics API)
         analytics = fetch_video_analytics(yt_analytics, video_id, upload_date)
         if analytics:
@@ -674,6 +682,10 @@ def main(recent_only: bool = False, dry_run: bool = False):
             update_fields.update(snapshots)
             for field_name in snapshots:
                 print(f"    Snapshot: {field_name} = {snapshots[field_name]}")
+
+        # Backfill Upload Date if it was missing and we got it from YouTube
+        if not video.get("Upload Date") and upload_date:
+            update_fields["Upload Date"] = upload_date
 
         update_fields["Last Analytics Sync"] = datetime.now(timezone.utc).isoformat()
 


### PR DESCRIPTION
## Summary
This PR enhances video metadata tracking by capturing YouTube publish dates and using them to backfill missing upload dates in Airtable. This ensures the performance tracking pipeline has the necessary date information for analytics queries.

## Key Changes
- **Enhanced YouTube stats fetching**: Modified `fetch_video_stats()` to retrieve both statistics and snippet data (including `publishedAt`), increasing quota usage from 1 to 3 units per call
- **Upload date backfilling in performance tracker**: Added logic to populate missing Airtable "Upload Date" fields using YouTube's `publishedAt` timestamp when available
- **Upload date capture in uploader**: Modified `upload_from_drive()` to immediately set the "Upload Date" field in Airtable when a video is successfully uploaded to YouTube

## Implementation Details
- The `fetch_video_stats()` function now returns a dict with an additional `published_at` field alongside views, likes, and comments
- In the main performance tracking loop, if a video lacks an upload date in Airtable but YouTube stats are available, the publish date is extracted and used for analytics queries
- The YouTube uploader now captures the current UTC timestamp as the upload date, ensuring this critical field is populated at the time of upload
- Both backfill and direct capture scenarios update the Airtable record with the upload date for consistency

https://claude.ai/code/session_01JkVyXKGrTZh7sgGxxwrMp3