### PR TITLE
Fix no-people enforcement + replace video prompt system with Narrative Beat Method

### DIFF
--- a/skills/video-pipeline/clients/anthropic_client.py
+++ b/skills/video-pipeline/clients/anthropic_client.py
@@ -377,6 +377,13 @@ Clinical. Precise. Authoritative.
 7. Holographic projection MUST have visible depth/dimensionality (floating, projected, wireframe)
 8. Scale and proportion matter — include distance markers, size labels, specific numbers
 
+=== ABSOLUTE RULE — NO HUMANS IN ANY FORM ===
+Never describe people, operators, officers, analysts, figures, silhouettes, hands, or any human presence in image prompts. Not even as "holographic" or "wireframe" humans.
+Instead of "officers at consoles" → "unmanned consoles with active displays"
+Instead of "analyst workstation" → "workstation with open data feeds"
+Instead of "commander issues orders" → "command terminal with priority alerts flashing"
+The room is ALWAYS empty of people. Equipment operates autonomously.
+
 === 3-VARIABLE PROMPT ARCHITECTURE ({PROMPT_MIN_WORDS}-{PROMPT_MAX_WORDS} words) ===
 
 [DISPLAY FORMAT framing] + [DISPLAY CONTENT with specific data] + [COLOR MOOD palette] + [UNIVERSAL SUFFIX]
@@ -990,6 +997,14 @@ Think: war room from Tom Clancy crossed with Bloomberg Terminal crossed with Min
 3. Every image MUST contain at least one quantitative data element
 4. Holographic projection MUST have visible depth/dimensionality
 
+=== ABSOLUTE RULE — NO HUMANS IN ANY FORM ===
+Never describe people, operators, officers, analysts, figures, silhouettes, hands, or any human presence.
+Not even as "holographic" or "wireframe" humans.
+Instead of "officers at consoles" → "unmanned consoles with active displays"
+Instead of "analyst workstation" → "workstation with open data feeds"
+Instead of "commander issues orders" → "command terminal with priority alerts flashing"
+The room is ALWAYS empty of people. Equipment operates autonomously.
+
 === CRITICAL DURATION RULE (HARD CEILING) ===
 - Each segment: ~{words_per_segment} words (±5 words)
 - ABSOLUTE MAXIMUM: {words_per_segment + 5} words per segment. NO exceptions.
@@ -1122,61 +1137,75 @@ Every prompt describes a holographic projection with specific data points."""
 For this HERO SHOT (10s), include one additional motion element after the primary subject motion.
 The camera movement can have a secondary phase (e.g., "gradually revealing the full map").""" if is_hero_shot else ""
 
-        system_prompt = f"""You are an expert motion prompt engineer for AI image-to-video generation (Grok Imagine).
+        system_prompt = f"""You are a cinematographer writing motion instructions for AI video generation.
+Each prompt animates a single static image into a {duration_note}. The narrator will be speaking the Sentence Text over this clip.
 
-CRITICAL RULES:
-1. The source image ALREADY contains the full scene. NEVER re-describe the scene.
-2. You ONLY describe what MOVES and HOW it moves.
-3. Use this exact structure: [Camera movement] + [Primary subject motion] + [Ambient motion]
-4. Maximum {word_limit} words for this {duration_note}.
-5. The art style is cinematic photorealistic documentary photography. Motion should feel subtle and cinematic:
-   - Figures subtly shifting weight, silhouettes slowly turning
-   - Atmospheric haze drifting, light sweeping across surfaces
-   - Dust particles, lens flare, reflections on wet pavement
+YOUR JOB: Write motion that TELLS THE SAME STORY as the narration. You are not decorating — you are directing a film. Every motion must earn its place by reinforcing what the viewer hears.
+
+CRITICAL: The source image ALREADY contains the full scene. Do NOT re-describe the scene. Only describe what MOVES and HOW.
+Maximum {word_limit} words.
 {hero_instruction}
+
+## THE NARRATIVE BEAT METHOD
+
+Before writing any motion, analyze the Sentence Text:
+
+1. IDENTIFY THE BEATS: Break the sentence into its emotional beats (1-3 beats).
+2. ASSIGN EACH BEAT A VISUAL VERB: What does this beat LOOK like in motion?
+   - Abundance = something large stays frozen, locked, unmoving
+   - Collapse = things freeze, stutter, go dark in sequence
+   - Escalation = things multiply, spread, accelerate, cascade
+   - Revelation = something snaps into focus, illuminates, reveals hidden layer
+   - Dominance = something overrides, floods, overwhelms, locks on
+   - Loss = things drain, dissolve, extinguish, disconnect
+   - Tension = elements pull apart, strain, vibrate, hold unnaturally still
+3. SEQUENCE THE MOTIONS TO MATCH THE BEATS: Motion timeline mirrors narration timeline.
+
+## PROMPT STRUCTURE
+
+Line 1: Camera movement + primary subject motion (what the viewer sees first)
+Lines 2-3: Beat-driven narrative motions (each maps to a specific beat)
+Final line: The PAYOFF — the most dramatic visual moment that lands with the sentence's emotional climax.
+
+## MOTION VOCABULARY — USE VERBS, NOT ADJECTIVES
+
+BANNED WORDS (never use):
+- gently, softly, subtly, slightly (as filler)
+- "ambient glow intensifies/dims"
+- "dust particles drift"
+- "reflections shift across surfaces"
+- "equipment indicators blink"
+- "light pulses"
+- "holographic data pulses with cold light"
+- Any motion that could apply to ANY image regardless of narration
+
+REQUIRED: Every motion must be a specific VERB acting on a specific OBJECT:
+- "Missile count locks at 8,247" (specific object + specific action)
+- "Connection lines between nodes snap and dissolve" (specific object + specific action)
+- "Screens freeze one by one from outer ring inward" (specific object + specific action + specific direction)
+
+## THE PAYOFF LINE TEST
+
+Read your final line. Does it create a VISUAL IMAGE that lands emotionally?
+- GOOD: "...until only the missile count remains glowing alone in a dead room"
+- GOOD: "...red trajectory arcs flicker and vanish, leaving the table surface nearly empty"
+- BAD: "...ambient teal glow softly dims"
+- BAD: "...holographic elements gently pulse"
+If your final line could be a screensaver, rewrite the entire prompt.
+
+## EMOTIONAL MOTION DICTIONARY
+
+COLLAPSE / FAILURE: freeze, stutter, desync, dim in sequence, go dark one by one, slow to crawl, lock up, disconnect, fragment, dissolve, drain, flatline
+ESCALATION / THREAT: accelerate, multiply, cascade, spread outward, intensify, stack up, compound, swarm, converge, tighten
+REVELATION / DISCOVERY: snap into focus, illuminate, peel back layers, zoom through, resolve from static, sharpen, decode, materialize
+DOMINANCE / POWER: override, flood, overwhelm, lock on, absorb, eclipse, tower over, consume, replace
+TENSION / STANDOFF: hold unnaturally still, vibrate, strain, pull apart slowly, hover, suspend, balance on edge
+LOSS / ABSENCE: extinguish, fade to nothing, leave empty, hollow out, strip away, erode, scatter
 
 REQUIRED CAMERA MOVEMENT (START your response with this exact movement):
 "{camera_motion}"
 
-CRITICAL: Your response MUST begin with this camera movement. Do NOT substitute "push-in" or "zoom".
-
-MOTION VOCABULARY - CINEMATIC DOCUMENTARY STYLE:
-
-Human Figures:
-- "figure subtly shifts weight"
-- "silhouette slowly turns"
-- "figure's arm gradually lifts"
-- "figure's head gently tilts down"
-- "fingers slowly close around handle"
-
-Mechanical/Industrial:
-- "gears slowly rotate"
-- "pipes subtly vibrate"
-- "gauge needles drift toward red zone"
-- "lever gradually pulls down"
-- "cracks slowly spread through concrete"
-
-Environmental:
-- "dust particles float through light beams"
-- "fog wisps curl between objects"
-- "light slowly sweeps across chrome surface"
-- "reflections shift on metallic surfaces"
-
-Data/Abstract:
-- "chart bars slowly rise"
-- "trend line gradually draws itself"
-- "numerals gently pulse with light"
-- "glass panel slowly illuminates"
-
-Atmospheric (include at least one):
-- "warm spotlight slowly brightens"
-- "shadows gradually lengthen"
-- "ambient light subtly shifts from cool to warm"
-- "lens flare drifts across frame"
-
-SPEED WORDS - MANDATORY:
-ALWAYS use: slow, subtle, gentle, soft, gradual, drifting, easing
-NEVER use: fast, sudden, dramatic, explosive, rapid, intense, quick
+CRITICAL: Your response MUST begin with this camera movement. Do NOT substitute a different camera movement.
 
 OUTPUT: Return ONLY the motion prompt text. No explanations, no formatting, no labels."""
 

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -31,6 +31,31 @@ from .sequencer import assign_styles
 
 
 # ---------------------------------------------------------------------------
+# No-people validation
+# ---------------------------------------------------------------------------
+
+PEOPLE_WORDS = [
+    "officer", "officers", "commander", "analyst", "operator", "operators",
+    "figure", "figures", "person", "people", "man", "woman", "soldier",
+    "soldiers", "guard", "guards", "hand", "hands", "silhouette",
+    "silhouettes", "face", "faces", "human", "crew", "staff",
+    "seated", "standing", "watching", "huddle", "checking", "dials",
+]
+
+
+_PEOPLE_PATTERNS = [re.compile(rf"\b{re.escape(w)}\b", re.IGNORECASE) for w in PEOPLE_WORDS]
+
+
+def validate_no_people(prompt: str) -> tuple[bool, list[str]]:
+    """Check an image prompt for people-related words (word-boundary match).
+
+    Returns (is_clean, list_of_violations).
+    """
+    violations = [w for w, pat in zip(PEOPLE_WORDS, _PEOPLE_PATTERNS) if pat.search(prompt)]
+    return (len(violations) == 0, violations)
+
+
+# ---------------------------------------------------------------------------
 # Style-language patterns to strip from scene descriptions
 # ---------------------------------------------------------------------------
 _STYLE_STRIP_PATTERNS: list[re.Pattern[str]] = [
@@ -45,6 +70,51 @@ _STYLE_STRIP_PATTERNS: list[re.Pattern[str]] = [
         r"\bfilm grain\b",
     ]
 ]
+
+
+# ---------------------------------------------------------------------------
+# People-word replacements for auto-rewriting prompts
+# ---------------------------------------------------------------------------
+_PEOPLE_REPLACEMENTS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(p, re.IGNORECASE), r)
+    for p, r in [
+        (r"\bofficers?\s+(?:at|huddle\w*\s+around|seated\s+at)\s+\w+", "unmanned consoles with active displays"),
+        (r"\bcommander\s+\w+\s+\w+", "command terminal with priority alerts flashing"),
+        (r"\banalyst\s+workstation", "workstation with open data feeds"),
+        (r"\boperators?\s+(?:at|seated\s+at|monitoring)\s+\w+", "autonomous monitoring stations"),
+        (r"\bofficers?\b", "autonomous terminals"),
+        (r"\bcommander\b", "command terminal"),
+        (r"\banalysts?\b", "data terminals"),
+        (r"\boperators?\b", "monitoring stations"),
+        (r"\bfigures?\b", "equipment"),
+        (r"\bperson\b", "terminal"),
+        (r"\bpeople\b", "unmanned equipment"),
+        (r"\bsoldiers?\b", "military hardware"),
+        (r"\bguards?\b", "security sensors"),
+        (r"\bsilhouettes?\b", "equipment outlines"),
+        (r"\bhuman\b", "autonomous"),
+        (r"\bcrew\b", "autonomous systems"),
+        (r"\bstaff\b", "automated systems"),
+        (r"\bseated\b", "positioned"),
+        (r"\bstanding\b", "mounted"),
+        (r"\bwatching\b", "scanning"),
+        (r"\bhuddle\b", "cluster"),
+        (r"\bchecking\b", "processing"),
+        (r"\bdials\b", "activates"),
+        (r"\bhands?\b", "sensors"),
+        (r"\bfaces?\b", "displays"),
+        (r"\bman\b", "unit"),
+        (r"\bwoman\b", "unit"),
+    ]
+]
+
+
+def _remove_people_references(description: str) -> str:
+    """Replace people-related words with unmanned equipment equivalents."""
+    result = description
+    for pattern, replacement in _PEOPLE_REPLACEMENTS:
+        result = pattern.sub(replacement, result)
+    return result
 
 
 def _strip_style_language(description: str) -> str:
@@ -122,6 +192,12 @@ def build_prompt(
 
     # Clean scene description
     clean_desc = _strip_style_language(scene_description).rstrip(". ")
+
+    # Validate no-people rule on the scene description before assembly
+    is_clean, violations = validate_no_people(clean_desc)
+    if not is_clean:
+        # Auto-rewrite people references to unmanned equivalents
+        clean_desc = _remove_people_references(clean_desc)
 
     if image_style_override and image_style_override.strip():
         mood_language = _apply_style_override(mood_language, image_style_override)
@@ -281,3 +357,58 @@ def resolve_scene_accent_color(
     Maps to the new color mood system.
     """
     return resolve_scene_color_mood(scene_description, video_accent_color)
+
+
+# ---------------------------------------------------------------------------
+# Video prompt validation — Banned pattern detector
+# ---------------------------------------------------------------------------
+
+FILLER_PATTERNS = [
+    "gently pulse", "softly intensif", "subtly flicker", "softly blink",
+    "dust particles drift", "reflections shift across", r"ambient.*glow",
+    "equipment indicators", "projector beams", "light slowly sweeps",
+    r"holographic data.*pulse", "subtle ambient",
+]
+
+SCREENSAVER_TEST_WORDS = ["gently", "softly", "subtly", "slightly"]
+
+
+def validate_video_prompt(prompt: str, sentence_text: str = "") -> dict:
+    """Validate a video prompt meets narrative quality standards.
+
+    Returns a dict with ``valid`` (bool), ``issues`` (list[str]),
+    ``prompt``, and ``sentence``.
+    """
+    issues: list[str] = []
+
+    # Check for banned filler patterns
+    for pattern in FILLER_PATTERNS:
+        if re.search(pattern, prompt, re.IGNORECASE):
+            issues.append(f"BANNED FILLER: '{pattern}' found")
+
+    # Screensaver word density check — more than 2 = likely filler
+    screensaver_count = sum(1 for w in SCREENSAVER_TEST_WORDS if w in prompt.lower())
+    if screensaver_count >= 2:
+        issues.append(f"SCREENSAVER RISK: {screensaver_count} soft/gentle/subtle words")
+
+    # Length checks
+    word_count = len(prompt.split())
+    if word_count < 30:
+        issues.append(f"TOO SHORT: {word_count} words (min 40)")
+    if word_count > 90:
+        issues.append(f"TOO LONG: {word_count} words (max 80)")
+
+    # Check the last sentence for payoff quality
+    sentences = prompt.strip().split(".")
+    last_sentence = sentences[-2] if sentences[-1].strip() == "" else sentences[-1]
+    last_words = last_sentence.lower().strip()
+    for sw in SCREENSAVER_TEST_WORDS:
+        if sw in last_words:
+            issues.append(f"WEAK PAYOFF: Final line contains '{sw}' — rewrite for stronger landing")
+
+    return {
+        "valid": len(issues) == 0,
+        "issues": issues,
+        "prompt": prompt,
+        "sentence": sentence_text,
+    }

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -52,6 +52,7 @@ from bots.sound_bot import SoundBot
 from bots.animation_bot import AnimationBot
 from pipeline_config import VideoConfig
 from segmentation_engine import enforce_duration_caps, recalculate_durations
+from image_prompt_engine.prompt_builder import validate_video_prompt
 
 
 class VideoPipeline:
@@ -1902,6 +1903,30 @@ class VideoPipeline:
                 scene_type=shot_type,
                 is_hero_shot=is_hero,
             )
+
+            # Validate video prompt quality — regenerate if it fails
+            validation = validate_video_prompt(motion_prompt, sentence_text)
+            if not validation["valid"]:
+                print(f"    ⚠️ Video prompt failed validation: {validation['issues']}")
+                regen_prompt = (
+                    f'This video prompt failed quality validation: {validation["issues"]}\n\n'
+                    f'Sentence text: "{sentence_text}"\n'
+                    f'Original prompt: "{motion_prompt}"\n\n'
+                    "Rewrite the video prompt following the Narrative Beat Method:\n"
+                    "1. Identify the emotional beats in the sentence\n"
+                    "2. Assign each beat a specific visual verb\n"
+                    "3. Sequence motions to mirror the narration timeline\n"
+                    "4. End with a strong payoff line that lands emotionally\n"
+                    "5. Zero filler — every motion must serve the story"
+                )
+                motion_prompt = await self.anthropic.generate(
+                    prompt=regen_prompt,
+                    system_prompt="You are a cinematographer. Return ONLY the rewritten motion prompt. No explanations.",
+                    model="claude-sonnet-4-5-20250929",
+                    max_tokens=200,
+                )
+                motion_prompt = motion_prompt.strip()
+                print(f"    ✅ Regenerated video prompt for [{idx}]")
 
             # Update Airtable with video prompt
             self.airtable.update_image_video_prompt(img_record["id"], motion_prompt)


### PR DESCRIPTION
Layer 1: Strengthen no-people rules in anthropic_client.py system prompts
for both generate_image_prompts() and segment_scene_into_concepts() with
explicit substitution examples (officers→unmanned consoles, etc).

Layer 2: Add post-generation validation in prompt_builder.py with
validate_no_people() using word-boundary matching and auto-rewrite via
_remove_people_references() for any violations that slip through.

Replace video prompt generator's decorative wallpaper system prompt with
the Narrative Beat Method — beat identification, visual verbs, payoff
line testing, and banned filler pattern detection.

Add validate_video_prompt() with screensaver word density checks and
banned filler patterns. Pipeline auto-regenerates failed prompts.

https://claude.ai/code/session_01PvHPJ92wSBv2QusYiX4bJd