### PR TITLE
Fix camera movement variety: add rotation enforcement to video prompts

### DIFF
--- a/skills/video-pipeline/clients/anthropic_client.py
+++ b/skills/video-pipeline/clients/anthropic_client.py
@@ -1109,6 +1109,7 @@ Every prompt describes a holographic projection with specific data points."""
         sentence_text: str = "",
         scene_type: str = None,
         is_hero_shot: bool = False,
+        prev_cameras: list[str] | None = None,
     ) -> str:
         """Generate a motion prompt for image-to-video animation.
 
@@ -1120,6 +1121,7 @@ Every prompt describes a holographic projection with specific data points."""
             sentence_text: The narration being spoken during this image (for alignment).
             scene_type: Scene type string (e.g., "isometric_diorama", "split_screen").
             is_hero_shot: If True, generate a richer prompt for 10s duration (vs 6s standard).
+            prev_cameras: Recent camera movements (most recent last) for rotation enforcement.
 
         Returns:
             Motion prompt (max 40 words for 6s, max 55 words for 10s hero).
@@ -1202,6 +1204,34 @@ DOMINANCE / POWER: override, flood, overwhelm, lock on, absorb, eclipse, tower o
 TENSION / STANDOFF: hold unnaturally still, vibrate, strain, pull apart slowly, hover, suspend, balance on edge
 LOSS / ABSENCE: extinguish, fade to nothing, leave empty, hollow out, strip away, erode, scatter
 
+## CAMERA MOVEMENT ROTATION — MANDATORY
+
+Never use the same camera movement on consecutive clips. Pick a DIFFERENT one from the previous clip.
+
+Available camera movements and when to use each:
+
+| Movement | Use When | Feel |
+|---|---|---|
+| Slow push-in | Revelation, focus, intimacy | Drawing viewer into a detail |
+| Pull-back / zoom out | Scale, overwhelm, isolation | Showing vastness or emptiness |
+| Lateral pan / tracking shot | Comparison, progression, timeline | Moving through information side to side |
+| Static / locked-off | Tension, stillness, dread | Something is deeply wrong — camera won't move |
+| Tilt up | Power, dominance, discovery | Something looms or is being revealed vertically |
+| Tilt down | Collapse, loss, submission | Falling, declining, ground-level consequence |
+| Snap zoom (fast push-in) | Shock, urgency, sudden alarm | A number spikes, a target locks, something breaks |
+| Slow orbital / rotation | Surveillance, encirclement, inevitability | Circling a subject like a predator |
+
+Match camera to the narration's dominant emotion:
+- Collapse → pull-back or static
+- Escalation → snap zoom or push-in
+- Revelation → slow push-in or tilt up
+- Comparison → lateral pan
+- Dominance → tilt up or slow orbital
+- Absence/Loss → pull-back or static
+- Tension/Standoff → static or slow orbital
+
+CRITICAL: "Slow push-in" is NOT the default. It is ONE of eight options. If you catch yourself defaulting to push-in, stop and ask: what does this sentence's emotion actually call for?
+
 REQUIRED CAMERA MOVEMENT (START your response with this exact movement):
 "{camera_motion}"
 
@@ -1213,9 +1243,18 @@ OUTPUT: Return ONLY the motion prompt text. No explanations, no formatting, no l
         if sentence_text:
             narration_context = f"\n\nNarration being spoken during this image: \"{sentence_text}\""
 
+        # Camera history context for rotation enforcement
+        camera_history_context = ""
+        if prev_cameras:
+            recent = prev_cameras[-2:]
+            camera_history_context = (
+                f"\n\nPREVIOUS CAMERA MOVEMENTS (do NOT repeat the most recent): "
+                f"{', '.join(recent)}"
+            )
+
         prompt = f"""Image Prompt (for context, do NOT repeat scene descriptions):
 {image_prompt}
-{narration_context}
+{narration_context}{camera_history_context}
 
 The camera movement is ALREADY DECIDED: "{camera_motion}"
 Generate ONLY the subject motion + ambient motion ({word_limit - 10} words max).

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -360,6 +360,37 @@ def resolve_scene_accent_color(
 
 
 # ---------------------------------------------------------------------------
+# Camera movement detection — used for rotation enforcement
+# ---------------------------------------------------------------------------
+
+CAMERA_MOVEMENTS: dict[str, list[str]] = {
+    "push-in": ["push-in", "push in", "pushing in", "dolly in", "move closer"],
+    "pull-back": ["pull-back", "pull back", "pulling back", "zoom out", "dolly out", "pulling away"],
+    "lateral-pan": ["lateral pan", "tracking shot", "pan across", "pan left", "pan right", "horizontal track"],
+    "static": ["static shot", "locked-off", "locked off", "fixed camera", "steady shot", "stationary"],
+    "tilt-up": ["tilt up", "tilting up", "crane up", "rising shot"],
+    "tilt-down": ["tilt down", "tilting down", "crane down", "descending shot"],
+    "snap-zoom": ["snap zoom", "fast push", "rapid zoom", "quick zoom", "crash zoom"],
+    "orbital": ["orbital", "rotation", "circling", "orbiting", "rotating around", "arc around", "orbit around"],
+}
+
+
+def detect_camera_movement(prompt: str) -> str:
+    """Detect which camera movement a video prompt uses.
+
+    Scans the prompt text for keywords matching the 8 canonical camera
+    movement types.  Returns the movement key (e.g. ``"push-in"``) or
+    ``"unknown"`` if nothing matches.
+    """
+    prompt_lower = prompt.lower()
+    for movement, keywords in CAMERA_MOVEMENTS.items():
+        for keyword in keywords:
+            if keyword in prompt_lower:
+                return movement
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
 # Video prompt validation — Banned pattern detector
 # ---------------------------------------------------------------------------
 
@@ -373,11 +404,15 @@ FILLER_PATTERNS = [
 SCREENSAVER_TEST_WORDS = ["gently", "softly", "subtly", "slightly"]
 
 
-def validate_video_prompt(prompt: str, sentence_text: str = "") -> dict:
+def validate_video_prompt(
+    prompt: str,
+    sentence_text: str = "",
+    prev_cameras: list[str] | None = None,
+) -> dict:
     """Validate a video prompt meets narrative quality standards.
 
     Returns a dict with ``valid`` (bool), ``issues`` (list[str]),
-    ``prompt``, and ``sentence``.
+    ``prompt``, ``sentence``, and ``camera`` (detected movement).
     """
     issues: list[str] = []
 
@@ -406,9 +441,21 @@ def validate_video_prompt(prompt: str, sentence_text: str = "") -> dict:
         if sw in last_words:
             issues.append(f"WEAK PAYOFF: Final line contains '{sw}' — rewrite for stronger landing")
 
+    # Camera movement detection and repeat check
+    current_camera = detect_camera_movement(prompt)
+
+    if current_camera == "unknown":
+        issues.append("NO CAMERA MOVEMENT DETECTED: Prompt must open with a clear camera direction")
+
+    if prev_cameras and len(prev_cameras) >= 1 and current_camera == prev_cameras[-1]:
+        issues.append(
+            f"CAMERA REPEAT: '{current_camera}' used on consecutive clips — pick a different movement"
+        )
+
     return {
         "valid": len(issues) == 0,
         "issues": issues,
         "prompt": prompt,
         "sentence": sentence_text,
+        "camera": current_camera,
     }

--- a/skills/video-pipeline/image_prompt_engine/tests/test_camera_movement.py
+++ b/skills/video-pipeline/image_prompt_engine/tests/test_camera_movement.py
@@ -1,0 +1,230 @@
+"""
+Tests for camera movement detection and rotation enforcement.
+
+Verifies:
+- detect_camera_movement() correctly identifies all 8 camera types
+- validate_video_prompt() catches consecutive camera repeats
+- validate_video_prompt() detects missing camera movements
+- Camera rotation produces variety across a full video
+"""
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from image_prompt_engine.prompt_builder import (
+    CAMERA_MOVEMENTS,
+    detect_camera_movement,
+    validate_video_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_camera_movement tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCameraMovement:
+    """Tests for detect_camera_movement()."""
+
+    def test_detects_push_in(self):
+        prompt = "Slow push-in toward the central monitor. Screens flicker to life."
+        assert detect_camera_movement(prompt) == "push-in"
+
+    def test_detects_push_in_variant(self):
+        prompt = "Dolly in toward the war table. Data nodes illuminate."
+        assert detect_camera_movement(prompt) == "push-in"
+
+    def test_detects_pull_back(self):
+        prompt = "Pull-back revealing the full scope. Networks dissolve."
+        assert detect_camera_movement(prompt) == "pull-back"
+
+    def test_detects_pull_back_zoom_out(self):
+        prompt = "Zoom out from the detail. The entire map fills the frame."
+        assert detect_camera_movement(prompt) == "pull-back"
+
+    def test_detects_lateral_pan(self):
+        prompt = "Lateral pan across the data panels. Charts cascade left to right."
+        assert detect_camera_movement(prompt) == "lateral-pan"
+
+    def test_detects_tracking_shot(self):
+        prompt = "Tracking shot following the timeline. Events light up sequentially."
+        assert detect_camera_movement(prompt) == "lateral-pan"
+
+    def test_detects_static(self):
+        prompt = "Static shot. Nothing moves except the countdown timer dropping."
+        assert detect_camera_movement(prompt) == "static"
+
+    def test_detects_locked_off(self):
+        prompt = "Locked-off camera. The figure stands perfectly still as data crumbles."
+        assert detect_camera_movement(prompt) == "static"
+
+    def test_detects_tilt_up(self):
+        prompt = "Tilt up from the rubble to the towering structure above."
+        assert detect_camera_movement(prompt) == "tilt-up"
+
+    def test_detects_crane_up(self):
+        prompt = "Crane up revealing the full network topology. Nodes multiply."
+        assert detect_camera_movement(prompt) == "tilt-up"
+
+    def test_detects_tilt_down(self):
+        prompt = "Tilt down from the summit to the wreckage below. Numbers cascade."
+        assert detect_camera_movement(prompt) == "tilt-down"
+
+    def test_detects_snap_zoom(self):
+        prompt = "Snap zoom onto the deficit counter. The number locks at 34 trillion."
+        assert detect_camera_movement(prompt) == "snap-zoom"
+
+    def test_detects_crash_zoom(self):
+        prompt = "Crash zoom into the alert indicator. Alarms blaze red."
+        assert detect_camera_movement(prompt) == "snap-zoom"
+
+    def test_detects_orbital(self):
+        prompt = "Slow orbital around the war table. Data layers peel back."
+        assert detect_camera_movement(prompt) == "orbital"
+
+    def test_detects_orbit_around(self):
+        prompt = "Orbit around the floating projection. Connection lines snap."
+        assert detect_camera_movement(prompt) == "orbital"
+
+    def test_returns_unknown_for_no_match(self):
+        prompt = "The data nodes illuminate one by one. Tension builds."
+        assert detect_camera_movement(prompt) == "unknown"
+
+    def test_all_8_types_have_at_least_one_keyword(self):
+        """Every camera movement type must be detectable."""
+        assert len(CAMERA_MOVEMENTS) == 8
+        for movement, keywords in CAMERA_MOVEMENTS.items():
+            assert len(keywords) >= 1, f"{movement} has no keywords"
+
+    def test_all_8_types_detected_from_sample_prompts(self):
+        """Each of the 8 camera types is correctly identified."""
+        samples = {
+            "push-in": "Slow push-in toward the screen.",
+            "pull-back": "Pull-back revealing the full scene.",
+            "lateral-pan": "Lateral pan across the wall display.",
+            "static": "Static shot. Nothing moves.",
+            "tilt-up": "Tilt up toward the ceiling.",
+            "tilt-down": "Tilt down to the ground.",
+            "snap-zoom": "Snap zoom onto the counter.",
+            "orbital": "Slow orbital around the subject.",
+        }
+        for expected_type, prompt in samples.items():
+            detected = detect_camera_movement(prompt)
+            assert detected == expected_type, (
+                f"Expected '{expected_type}' but got '{detected}' for: {prompt}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# validate_video_prompt camera checks
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVideoPromptCameraChecks:
+    """Tests for camera-related validation in validate_video_prompt()."""
+
+    def _make_prompt(self, camera_prefix: str) -> str:
+        """Build a prompt long enough to pass word count checks."""
+        filler = (
+            "Connection lines between nodes snap and dissolve one by one. "
+            "The central figure locks into position as surrounding data cascades "
+            "downward through three tiers. Terminal screens freeze in sequence "
+            "from outer ring inward until only the deficit counter remains "
+            "glowing alone in a dead room."
+        )
+        return f"{camera_prefix}. {filler}"
+
+    def test_no_camera_repeat_when_history_empty(self):
+        prompt = self._make_prompt("Slow push-in toward the monitor")
+        result = validate_video_prompt(prompt, prev_cameras=[])
+        camera_issues = [i for i in result["issues"] if "CAMERA REPEAT" in i]
+        assert len(camera_issues) == 0
+
+    def test_camera_repeat_detected(self):
+        prompt = self._make_prompt("Slow push-in toward the monitor")
+        result = validate_video_prompt(prompt, prev_cameras=["push-in"])
+        camera_issues = [i for i in result["issues"] if "CAMERA REPEAT" in i]
+        assert len(camera_issues) == 1
+        assert not result["valid"]
+
+    def test_no_repeat_with_different_camera(self):
+        prompt = self._make_prompt("Pull-back revealing the full scope")
+        result = validate_video_prompt(prompt, prev_cameras=["push-in"])
+        camera_issues = [i for i in result["issues"] if "CAMERA REPEAT" in i]
+        assert len(camera_issues) == 0
+
+    def test_missing_camera_detected(self):
+        prompt = (
+            "Data nodes illuminate one by one from left to right. "
+            "The central figure locks into position as surrounding data cascades "
+            "downward through three tiers. Terminal screens freeze in sequence "
+            "from outer ring inward until only the deficit counter remains "
+            "glowing alone in a dead room."
+        )
+        result = validate_video_prompt(prompt)
+        no_camera_issues = [i for i in result["issues"] if "NO CAMERA MOVEMENT" in i]
+        assert len(no_camera_issues) == 1
+
+    def test_camera_returned_in_result(self):
+        prompt = self._make_prompt("Lateral pan across the data wall")
+        result = validate_video_prompt(prompt)
+        assert result["camera"] == "lateral-pan"
+
+    def test_camera_unknown_returned(self):
+        prompt = (
+            "Data nodes illuminate one by one from left to right. "
+            "The central figure locks into position as surrounding data cascades "
+            "downward through three tiers. Terminal screens freeze in sequence "
+            "from outer ring inward until only the deficit counter remains "
+            "glowing alone in a dead room."
+        )
+        result = validate_video_prompt(prompt)
+        assert result["camera"] == "unknown"
+
+    def test_prev_cameras_none_is_safe(self):
+        """Passing None for prev_cameras should not cause errors."""
+        prompt = self._make_prompt("Tilt up from the ground level")
+        result = validate_video_prompt(prompt, prev_cameras=None)
+        camera_issues = [i for i in result["issues"] if "CAMERA REPEAT" in i]
+        assert len(camera_issues) == 0
+
+    def test_repeat_check_only_against_last(self):
+        """Only the most recent camera should trigger a repeat."""
+        prompt = self._make_prompt("Slow push-in toward the target")
+        # push-in was used 2 clips ago but NOT the most recent
+        result = validate_video_prompt(prompt, prev_cameras=["push-in", "orbital"])
+        camera_issues = [i for i in result["issues"] if "CAMERA REPEAT" in i]
+        assert len(camera_issues) == 0
+
+
+# ---------------------------------------------------------------------------
+# Camera rotation variety simulation
+# ---------------------------------------------------------------------------
+
+
+class TestCameraRotationVariety:
+    """Simulate camera rotation to verify variety enforcement."""
+
+    def test_simulated_variety_no_consecutive_repeats(self):
+        """Given 8 different movements, no two consecutive should match."""
+        movements = list(CAMERA_MOVEMENTS.keys())
+        # Simulate a 24-clip video cycling through all types
+        clip_cameras = (movements * 3)[:24]
+        for i in range(1, len(clip_cameras)):
+            assert clip_cameras[i] != clip_cameras[i - 1] or i % len(movements) == 0, (
+                f"Consecutive repeat at clips {i-1}-{i}: {clip_cameras[i]}"
+            )
+
+    def test_detect_catches_all_keyword_variants(self):
+        """Every keyword in CAMERA_MOVEMENTS should resolve to its type."""
+        for movement, keywords in CAMERA_MOVEMENTS.items():
+            for keyword in keywords:
+                prompt = f"{keyword}. Some motion description follows here."
+                detected = detect_camera_movement(prompt)
+                assert detected == movement, (
+                    f"Keyword '{keyword}' should detect as '{movement}' but got '{detected}'"
+                )

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -52,7 +52,11 @@ from bots.sound_bot import SoundBot
 from bots.animation_bot import AnimationBot
 from pipeline_config import VideoConfig
 from segmentation_engine import enforce_duration_caps, recalculate_durations
-from image_prompt_engine.prompt_builder import validate_video_prompt
+from image_prompt_engine.prompt_builder import (
+    CAMERA_MOVEMENTS,
+    detect_camera_movement,
+    validate_video_prompt,
+)
 
 
 class VideoPipeline:
@@ -1870,6 +1874,14 @@ class VideoPipeline:
 
         prompt_count = 0
         hero_count = 0
+        camera_history: list[str] = []
+
+        # Pre-populate camera history from images that already have prompts
+        for img_record in done_images:
+            existing_prompt = img_record.get("Video Prompt", "")
+            if existing_prompt:
+                camera_history.append(detect_camera_movement(existing_prompt))
+
         for img_record in done_images:
             scene = img_record.get("Scene", 0)
 
@@ -1902,12 +1914,24 @@ class VideoPipeline:
                 sentence_text=sentence_text,
                 scene_type=shot_type,
                 is_hero_shot=is_hero,
+                prev_cameras=camera_history,
             )
 
             # Validate video prompt quality — regenerate if it fails
-            validation = validate_video_prompt(motion_prompt, sentence_text)
+            validation = validate_video_prompt(motion_prompt, sentence_text, prev_cameras=camera_history)
             if not validation["valid"]:
                 print(f"    ⚠️ Video prompt failed validation: {validation['issues']}")
+
+                # Build camera-aware regeneration prompt
+                camera_block = ""
+                if camera_history:
+                    blocked = camera_history[-1]
+                    allowed = ", ".join(k for k in CAMERA_MOVEMENTS if k != blocked)
+                    camera_block = (
+                        f"\n\nCAMERA ROTATION: You MUST NOT use '{blocked}'. "
+                        f"Pick from: {allowed}"
+                    )
+
                 regen_prompt = (
                     f'This video prompt failed quality validation: {validation["issues"]}\n\n'
                     f'Sentence text: "{sentence_text}"\n'
@@ -1918,6 +1942,7 @@ class VideoPipeline:
                     "3. Sequence motions to mirror the narration timeline\n"
                     "4. End with a strong payoff line that lands emotionally\n"
                     "5. Zero filler — every motion must serve the story"
+                    f"{camera_block}"
                 )
                 motion_prompt = await self.anthropic.generate(
                     prompt=regen_prompt,
@@ -1927,6 +1952,9 @@ class VideoPipeline:
                 )
                 motion_prompt = motion_prompt.strip()
                 print(f"    ✅ Regenerated video prompt for [{idx}]")
+
+            # Track camera movement for rotation enforcement
+            camera_history.append(detect_camera_movement(motion_prompt))
 
             # Update Airtable with video prompt
             self.airtable.update_image_video_prompt(img_record["id"], motion_prompt)


### PR DESCRIPTION
Every video prompt was defaulting to "Slow push-in" — now enforced via 3 layers:

1. System prompt: Added CAMERA MOVEMENT ROTATION rules with 8 movement types
   mapped to emotional beats (collapse→pull-back, escalation→snap-zoom, etc.)

2. Pipeline loop: Camera history tracking in run_video_script_bot() passes
   recent movements as context to Claude and triggers regeneration on repeats.

3. Validation: detect_camera_movement() identifies all 8 types via keyword
   matching; validate_video_prompt() now catches consecutive repeats and
   missing camera directions.

28 new tests covering detection, validation, and rotation variety.

https://claude.ai/code/session_01VVWNVLxJcGtqTtmBc3M2JY