### PR TITLE
Implement verb-first animation rules with static camera default

### DIFF
--- a/skills/video-pipeline/animation_prompt_engine.py
+++ b/skills/video-pipeline/animation_prompt_engine.py
@@ -42,7 +42,11 @@ RULE 3 — TWO ACTIONS MAXIMUM PER CLIP
 
 from __future__ import annotations
 
+import logging
 import re
+from typing import Callable, Awaitable, Optional
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -502,6 +506,169 @@ _VERB_MOTION_MAP: dict[str, str] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Claude Haiku fallback for unknown verbs — long tail coverage
+# ---------------------------------------------------------------------------
+# The _VERB_MOTION_MAP handles common verbs fast. For verbs not in the map,
+# a single Claude Haiku call turns {verb + sentence} into a concrete motion.
+# Cost: ~$0.001 per call. Results are cached per-video so repeat verbs are free.
+# ---------------------------------------------------------------------------
+
+_HAIKU_VERB_PROMPT = (
+    "Given the sentence '{sentence}' and the action verb '{verb}', "
+    "describe ONE concrete visual motion in under 20 words that literally "
+    "enacts this verb on a holographic data display. No camera movement, "
+    "no metaphors, no people. Just the physical motion."
+)
+
+# Per-run cache: verb -> motion description (avoids repeat API calls within one video)
+_verb_motion_cache: dict[str, str] = {}
+
+# Track total Haiku fallback calls for cost logging
+_haiku_call_count: int = 0
+_haiku_input_tokens: int = 0
+_haiku_output_tokens: int = 0
+
+
+def clear_verb_motion_cache() -> None:
+    """Clear the per-run verb motion cache. Call between videos."""
+    global _haiku_call_count, _haiku_input_tokens, _haiku_output_tokens
+    _verb_motion_cache.clear()
+    _haiku_call_count = 0
+    _haiku_input_tokens = 0
+    _haiku_output_tokens = 0
+
+
+def get_verb_motion_cache_stats() -> dict:
+    """Return stats on Haiku fallback usage for cost logging."""
+    return {
+        "cache_size": len(_verb_motion_cache),
+        "haiku_calls": _haiku_call_count,
+        "haiku_input_tokens": _haiku_input_tokens,
+        "haiku_output_tokens": _haiku_output_tokens,
+        "estimated_cost_usd": round(_haiku_call_count * 0.001, 4),
+    }
+
+
+async def resolve_verb_motion_async(
+    verb: str,
+    sentence_text: str,
+    anthropic_client: Optional[object] = None,
+) -> str:
+    """Resolve a verb to a motion description, using Claude Haiku for unknown verbs.
+
+    Lookup order:
+    1. _VERB_MOTION_MAP (instant, free)
+    2. _verb_motion_cache (instant, previously resolved)
+    3. Claude Haiku API call (async, ~$0.001)
+
+    Args:
+        verb: The extracted verb from sentence text.
+        sentence_text: Full sentence for context.
+        anthropic_client: An AnthropicClient instance with a generate() method.
+            If None, falls back to empty string (no API call).
+
+    Returns:
+        A concrete motion description string, or empty string if resolution fails.
+    """
+    global _haiku_call_count, _haiku_input_tokens, _haiku_output_tokens
+
+    if not verb:
+        return ""
+
+    # 1. Check static map
+    motion = _VERB_MOTION_MAP.get(verb, "")
+    if motion:
+        return motion
+
+    # 2. Check per-run cache
+    if verb in _verb_motion_cache:
+        return _verb_motion_cache[verb]
+
+    # 3. Claude Haiku fallback
+    if anthropic_client is None:
+        logger.debug("No anthropic_client provided, skipping Haiku fallback for verb '%s'", verb)
+        return ""
+
+    try:
+        prompt = _HAIKU_VERB_PROMPT.format(sentence=sentence_text, verb=verb)
+        response = await anthropic_client.generate(
+            prompt=prompt,
+            system_prompt="You describe visual motion for holographic data displays. Return ONLY the motion description, nothing else.",
+            model="claude-haiku-4-5-20251001",
+            max_tokens=60,
+            temperature=0.3,
+        )
+        motion = response.strip().rstrip(".")  + "."
+        # Cache for this run
+        _verb_motion_cache[verb] = motion
+        _haiku_call_count += 1
+        # Rough token estimate for cost tracking
+        _haiku_input_tokens += len(prompt.split()) + 20  # ~system prompt
+        _haiku_output_tokens += len(motion.split())
+        logger.info(
+            "Haiku verb fallback: '%s' -> '%s' (call #%d, ~$%.4f total)",
+            verb, motion, _haiku_call_count, _haiku_call_count * 0.001,
+        )
+        return motion
+    except Exception as e:
+        logger.warning("Haiku verb fallback failed for '%s': %s", verb, e)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Verbless streak detection — quality warning
+# ---------------------------------------------------------------------------
+# When 3+ consecutive clips extract no verb, it means the script isn't
+# giving the engine enough action language. Log a warning and return
+# the streak info so callers can notify via Slack.
+# ---------------------------------------------------------------------------
+
+VERBLESS_STREAK_THRESHOLD = 3
+
+
+def detect_verbless_streaks(
+    results: list[dict],
+) -> list[dict]:
+    """Find runs of 3+ consecutive clips with no extracted verb.
+
+    Args:
+        results: Output of generate_prompts_for_segments.
+
+    Returns:
+        List of dicts with "start_index", "end_index", "length" for each streak.
+    """
+    streaks: list[dict] = []
+    streak_start: int | None = None
+    streak_len = 0
+
+    for r in results:
+        if not r.get("core_verb"):
+            if streak_start is None:
+                streak_start = r["segment_index"]
+            streak_len += 1
+        else:
+            if streak_len >= VERBLESS_STREAK_THRESHOLD and streak_start is not None:
+                streaks.append({
+                    "start_index": streak_start,
+                    "end_index": r["segment_index"] - 1,
+                    "length": streak_len,
+                })
+            streak_start = None
+            streak_len = 0
+
+    # Handle streak at end of results
+    if streak_len >= VERBLESS_STREAK_THRESHOLD and streak_start is not None:
+        last_idx = results[-1]["segment_index"] if results else 0
+        streaks.append({
+            "start_index": streak_start,
+            "end_index": last_idx,
+            "length": streak_len,
+        })
+
+    return streaks
+
+
 def generate_animation_prompt(
     segment: dict,
     image_content_type: str = "",
@@ -580,7 +747,10 @@ def generate_prompts_for_segments(
     content_types: dict[int, str] | None = None,
     clip_duration: int = 10,
 ) -> list[dict]:
-    """Generate animation prompts for all segments.
+    """Generate animation prompts for all segments (sync, map-only).
+
+    Uses only _VERB_MOTION_MAP for verb resolution. For Claude Haiku fallback
+    on unknown verbs, use generate_prompts_for_segments_async() instead.
 
     Args:
         segments: List of segment dicts from segmentation engine.
@@ -596,7 +766,7 @@ def generate_prompts_for_segments(
 
     Returns:
         List of dicts with segment index, clip_duration, camera_purpose,
-        core_verb, and animation_prompt.
+        core_verb, verb_source, and animation_prompt.
     """
     if content_types is None:
         content_types = {}
@@ -609,12 +779,144 @@ def generate_prompts_for_segments(
         prompt = generate_animation_prompt(seg, ct, seg_clip_duration)
 
         sentence_text = seg.get("text", "")
+        verb = extract_core_verb(sentence_text)
+        verb_source = "map" if (verb and verb in _VERB_MOTION_MAP) else ("extracted" if verb else "none")
         results.append({
             "segment_index": idx,
             "intensity": seg.get("intensity", "low"),
             "clip_duration": seg_clip_duration,
             "animation_prompt": prompt,
             "camera_purpose": classify_camera_purpose(sentence_text),
-            "core_verb": extract_core_verb(sentence_text),
+            "core_verb": verb,
+            "verb_source": verb_source,
         })
     return results
+
+
+async def generate_prompts_for_segments_async(
+    segments: list[dict],
+    content_types: dict[int, str] | None = None,
+    clip_duration: int = 10,
+    anthropic_client: Optional[object] = None,
+) -> tuple[list[dict], list[dict]]:
+    """Generate animation prompts with Claude Haiku fallback for unknown verbs.
+
+    Like generate_prompts_for_segments but resolves unknown verbs via a single
+    Claude Haiku API call (~$0.001 each). Results are cached per-run so
+    the same verb doesn't trigger multiple calls.
+
+    Call clear_verb_motion_cache() between videos to reset the cache.
+
+    Args:
+        segments: Segment dicts (see generate_prompts_for_segments).
+        content_types: Content type mapping (see generate_prompts_for_segments).
+        clip_duration: Default clip duration.
+        anthropic_client: AnthropicClient instance for Haiku fallback.
+
+    Returns:
+        Tuple of (results, verbless_streaks).
+        results: List of prompt dicts (same as sync version + verb_source field).
+        verbless_streaks: List of streaks where 3+ clips had no verb.
+    """
+    if content_types is None:
+        content_types = {}
+
+    results = []
+    for seg in segments:
+        idx = seg["index"]
+        ct = content_types.get(idx, _DEFAULT_CONTENT_TYPE)
+        seg_clip_duration = seg.get("clip_duration", clip_duration)
+        sentence_text = seg.get("text", "")
+
+        # Extract verb
+        verb = extract_core_verb(sentence_text)
+
+        # Check if verb has a map entry
+        verb_motion = _VERB_MOTION_MAP.get(verb, "") if verb else ""
+        verb_source = "none"
+
+        if verb and not verb_motion:
+            # Verb extracted but not in map — try Haiku fallback
+            verb_motion = await resolve_verb_motion_async(
+                verb, sentence_text, anthropic_client
+            )
+            if verb_motion:
+                verb_source = "haiku"
+            else:
+                verb_source = "extracted"
+        elif verb_motion:
+            verb_source = "map"
+
+        # Generate the prompt (will use map if verb is in _VERB_MOTION_MAP)
+        prompt = generate_animation_prompt(seg, ct, seg_clip_duration)
+
+        # If Haiku resolved a motion not in the map, patch the prompt
+        if verb_source == "haiku" and verb_motion:
+            # Replace the generic template motion with Haiku's motion
+            prompt = _patch_prompt_with_verb_motion(prompt, verb_motion)
+
+        results.append({
+            "segment_index": idx,
+            "intensity": seg.get("intensity", "low"),
+            "clip_duration": seg_clip_duration,
+            "animation_prompt": prompt,
+            "camera_purpose": classify_camera_purpose(sentence_text),
+            "core_verb": verb,
+            "verb_source": verb_source,
+        })
+
+    # Detect verbless streaks
+    streaks = detect_verbless_streaks(results)
+    if streaks:
+        for streak in streaks:
+            logger.warning(
+                "VERBLESS STREAK: %d consecutive clips (segments %d-%d) extracted "
+                "no action verb. Script may need stronger action language.",
+                streak["length"], streak["start_index"], streak["end_index"],
+            )
+
+    # Log cache stats
+    stats = get_verb_motion_cache_stats()
+    if stats["haiku_calls"] > 0:
+        logger.info(
+            "Haiku verb fallback stats: %d calls, %d cached, ~$%.4f total cost",
+            stats["haiku_calls"], stats["cache_size"], stats["estimated_cost_usd"],
+        )
+
+    return results, streaks
+
+
+def _patch_prompt_with_verb_motion(prompt: str, verb_motion: str) -> str:
+    """Replace the generic template motion in a prompt with a Haiku-resolved motion.
+
+    Keeps the camera note (if any), boilerplate suffix, and universal rules.
+    Only swaps the content-type template body.
+    """
+    # The prompt structure is:
+    # [camera_note?] Static wide shot. [TEMPLATE MOTION]. [boilerplate]...
+    # We want to replace [TEMPLATE MOTION] with verb_motion.
+
+    # Find where the boilerplate starts
+    boilerplate_marker = "Data labels and text remain stable"
+    marker_pos = prompt.find(boilerplate_marker)
+    if marker_pos < 0:
+        return prompt
+
+    prefix_part = prompt[:marker_pos].strip()
+    suffix_part = prompt[marker_pos:]
+
+    # In the prefix, keep any camera note and "Static wide shot." but replace the rest
+    static_marker = "Static wide shot."
+    static_pos = prefix_part.find(static_marker)
+    if static_pos >= 0:
+        camera_prefix = prefix_part[:static_pos + len(static_marker)]
+        return f"{camera_prefix} {verb_motion} {suffix_part}"
+
+    # If no static marker (camera was added), keep the camera note
+    # and just replace everything after the first sentence
+    first_period = prefix_part.find(". ")
+    if first_period >= 0:
+        camera_prefix = prefix_part[:first_period + 1]
+        return f"{camera_prefix} {verb_motion} {suffix_part}"
+
+    return prompt

--- a/skills/video-pipeline/animation_prompt_engine.py
+++ b/skills/video-pipeline/animation_prompt_engine.py
@@ -76,6 +76,15 @@ _PHRASAL_VERB_PATTERNS = [
     re.compile(r"\b(don'?t\s+matter)\b", re.IGNORECASE),
     re.compile(r"\b(wip(?:e[sd]?|ing)\s+out)\b", re.IGNORECASE),
     re.compile(r"\b(spread(?:s|ing)?\s+(?:across|out))\b", re.IGNORECASE),
+    re.compile(r"\b(turn(?:s|ed|ing)?\s+on)\b", re.IGNORECASE),
+    re.compile(r"\b(turn(?:s|ed|ing)?\s+off)\b", re.IGNORECASE),
+    re.compile(r"\b(kick(?:s|ed|ing)?\s+in)\b", re.IGNORECASE),
+    re.compile(r"\b(pull(?:s|ed|ing)?\s+(?:back|away|out))\b", re.IGNORECASE),
+    re.compile(r"\b(zero(?:s|ed|ing)?\s+(?:in|out))\b", re.IGNORECASE),
+    re.compile(r"\b(cut(?:ting|s)?\s+off)\b", re.IGNORECASE),
+    re.compile(r"\b(snap(?:s|ped|ping)?\s+(?:shut|open|back))\b", re.IGNORECASE),
+    re.compile(r"\b(open(?:s|ed|ing)?\s+up)\b", re.IGNORECASE),
+    re.compile(r"\b(peel(?:s|ed|ing)?\s+(?:back|away))\b", re.IGNORECASE),
 ]
 
 # Single-word action verbs (gerunds, past tense, base forms) that drive motion
@@ -115,6 +124,27 @@ _ACTION_VERB_PATTERN = re.compile(
 )
 
 
+# Common words that look verb-like but aren't (prepositions, adverbs, nouns)
+_NON_VERB_WORDS = frozenset({
+    "the", "and", "but", "for", "not", "its", "this", "that", "these",
+    "those", "their", "them", "his", "her", "from", "with", "into",
+    "across", "between", "after", "before", "about", "against", "over",
+    "under", "every", "each", "most", "more", "less", "other", "another",
+    "some", "all", "many", "much", "behind", "around", "along", "among",
+    "during", "through", "within", "without", "toward", "towards",
+    "beside", "besides", "beyond", "despite", "until", "unless",
+    "since", "while", "where", "when", "then", "than", "thus",
+    "hence", "once", "twice", "here", "there", "never", "ever",
+    "often", "always", "already", "also", "just", "still", "even",
+    "only", "very", "quite", "rather", "really", "almost", "enough",
+    "indeed", "perhaps", "maybe", "however", "although", "because",
+    "three", "thousand", "hundred", "million", "billion",
+    "real", "closed", "doors", "designed", "hardened",
+    "money", "printer", "missiles", "bunkers", "launchers",
+    "numbers", "troop", "tanks",
+})
+
+
 def extract_core_verb(sentence_text: str) -> str:
     """Extract the core action verb or phrasal verb from sentence text.
 
@@ -135,18 +165,14 @@ def extract_core_verb(sentence_text: str) -> str:
     if match:
         return match.group(1).lower().strip()
 
-    # Fallback: scan all words for any verb-like word not in stop list
-    words = re.findall(r"\b[a-z]+(?:ing|ed|es|s)?\b", sentence_text.lower())
+    # Fallback: only accept words ending in verb-like suffixes (-ing, -ed, -es)
+    # to avoid catching prepositions, adverbs, and nouns.
+    # We require the -ing/-ed/-es suffix to be confident it's actually a verb form.
+    words = re.findall(r"\b([a-z]+(?:ing|ed|es))\b", sentence_text.lower())
     for word in words:
-        base = re.sub(r"(ing|ed|es|s)$", "", word)
+        base = re.sub(r"(ing|ed|es)$", "", word)
         if len(base) >= 3 and word not in _STOP_VERBS and base not in _STOP_VERBS:
-            # Skip common non-verbs
-            if word not in {"the", "and", "but", "for", "not", "its", "this",
-                            "that", "these", "those", "their", "them", "his",
-                            "her", "from", "with", "into", "across", "between",
-                            "after", "before", "about", "against", "over",
-                            "under", "every", "each", "most", "more", "less",
-                            "other", "another", "some", "all", "many", "much"}:
+            if word not in _NON_VERB_WORDS:
                 return word
 
     return ""
@@ -369,6 +395,112 @@ _CAMERA_BY_PURPOSE = {
     CAMERA_PURPOSE_ISOLATION: "Slow push-in isolating",
 }
 
+# ---------------------------------------------------------------------------
+# Verb-to-motion mapping — Rule 1: the verb IS the animation
+# ---------------------------------------------------------------------------
+# Maps extracted verbs (or verb categories) to concrete motion descriptions
+# that literally enact the verb. When a verb matches, this REPLACES the
+# generic content-type template motion, ensuring the animation is driven
+# by what the sentence says, not by what content type the image happens to be.
+# ---------------------------------------------------------------------------
+
+_VERB_MOTION_MAP: dict[str, str] = {
+    # Phrasal verbs
+    "going dark": "Lights and indicator points extinguish one by one across the display until the screen is nearly black.",
+    "shutting down": "Systems deactivate in sequence — screens go black, indicators flatline, power drains from the edges inward.",
+    "shut down": "Systems deactivate in sequence — screens go black, indicators flatline, power drains from the edges inward.",
+    "turning on": "Elements activate in rapid sequence — displays ignite, numbers spin up from zero, power surges outward from center.",
+    "turned on": "Elements activate in rapid sequence — displays ignite, numbers spin up from zero, power surges outward from center.",
+    "turn on": "Elements activate in rapid sequence — displays ignite, numbers spin up from zero, power surges outward from center.",
+    "breaking apart": "Structure fractures along stress lines, sections separate and drift apart, fragments dissolve at the edges.",
+    "falling apart": "Components detach and drift downward, connections sever, pieces separate and scatter.",
+    "don't matter": "Asset icons dissolve to static noise, then fade to blank one by one.",
+    "wiped out": "Elements are erased in a sweep from one side to the other, leaving empty black space.",
+    "spread across": "A single point multiplies and dots spread outward across the surface in all directions.",
+    "spreading across": "A single point multiplies and dots spread outward across the surface in all directions.",
+    "blown up": "Central element detonates outward — fragments scatter radially, shockwave ripples through surrounding data.",
+    "blowing up": "Central element detonates outward — fragments scatter radially, shockwave ripples through surrounding data.",
+    "locks frozen": "Number or counter stops mid-increment and holds completely still, all motion ceases.",
+    "locked in": "Elements snap into fixed positions and hold rigid, all motion ceases.",
+    "piling up": "Items stack vertically, each new element landing on top of the last with increasing speed.",
+    "turned off": "Displays go dark in sequence, indicators flatline, ambient light drains to black.",
+    "kicked in": "Elements slam into active state — numbers jump, indicators spike, displays flash to life.",
+    "cut off": "Connection lines sever sharply, separated sections drift apart, data flow stops.",
+    "cutting off": "Connection lines sever sharply, separated sections drift apart, data flow stops.",
+
+    # Single-word verbs
+    "scattered": "A single dot multiplies and spreads across the terrain, points appearing in dispersed positions.",
+    "scattering": "A single dot multiplies and spreads across the terrain, points appearing in dispersed positions.",
+    "scatter": "A single dot multiplies and spreads across the terrain, points appearing in dispersed positions.",
+    "collapsed": "Structure buckles inward, data lines flatline, elements compress and go dark from the edges.",
+    "collapsing": "Structure buckles inward, data lines flatline, elements compress and go dark from the edges.",
+    "collapse": "Structure buckles inward, data lines flatline, elements compress and go dark from the edges.",
+    "collapses": "Structure buckles inward, data lines flatline, elements compress and go dark from the edges.",
+    "surging": "Values spike upward violently, chart line rockets past thresholds, warning indicators flood on.",
+    "surge": "Values spike upward violently, chart line rockets past thresholds, warning indicators flood on.",
+    "surges": "Values spike upward violently, chart line rockets past thresholds, warning indicators flood on.",
+    "surged": "Values spike upward violently, chart line rockets past thresholds, warning indicators flood on.",
+    "frozen": "All motion ceases — counter stops mid-digit, indicators freeze in place, complete stillness.",
+    "freeze": "All motion ceases — counter stops mid-digit, indicators freeze in place, complete stillness.",
+    "freezes": "All motion ceases — counter stops mid-digit, indicators freeze in place, complete stillness.",
+    "exploded": "Central element detonates outward, shockwave ripples through surrounding elements, fragments scatter.",
+    "explodes": "Central element detonates outward, shockwave ripples through surrounding elements, fragments scatter.",
+    "exploding": "Central element detonates outward, shockwave ripples through surrounding elements, fragments scatter.",
+    "dissolved": "Elements lose opacity and fade to nothing, leaving empty space where data once was.",
+    "dissolving": "Elements lose opacity and fade to nothing, leaving empty space where data once was.",
+    "dissolves": "Elements lose opacity and fade to nothing, leaving empty space where data once was.",
+    "cascading": "Effect triggers from one element to the next in rapid sequence, each activation triggering the next.",
+    "cascade": "Effect triggers from one element to the next in rapid sequence, each activation triggering the next.",
+    "cascades": "Effect triggers from one element to the next in rapid sequence, each activation triggering the next.",
+    "flooding": "Data or color washes across the display in a wave, overwhelming existing elements.",
+    "floods": "Data or color washes across the display in a wave, overwhelming existing elements.",
+    "flooded": "Data or color washes across the display in a wave, overwhelming existing elements.",
+    "draining": "Values count down, levels drop, elements empty from top to bottom.",
+    "drains": "Values count down, levels drop, elements empty from top to bottom.",
+    "drained": "Values count down, levels drop, elements empty from top to bottom.",
+    "shattering": "Element fractures into angular fragments that scatter outward, cracks propagate through the structure.",
+    "shatters": "Element fractures into angular fragments that scatter outward, cracks propagate through the structure.",
+    "shattered": "Element fractures into angular fragments that scatter outward, cracks propagate through the structure.",
+    "accelerating": "Motion speeds up — elements move faster, numbers increment more rapidly, pace builds.",
+    "accelerates": "Motion speeds up — elements move faster, numbers increment more rapidly, pace builds.",
+    "multiplying": "Elements duplicate — one becomes two, two becomes four, copies spread outward.",
+    "multiply": "Elements duplicate — one becomes two, two becomes four, copies spread outward.",
+    "ignited": "Element blazes to life — light erupts, color saturates, energy radiates outward.",
+    "ignites": "Element blazes to life — light erupts, color saturates, energy radiates outward.",
+    "extinguished": "Light dies — element dims to black, glow fades, surrounding area darkens.",
+    "extinguishes": "Light dies — element dims to black, glow fades, surrounding area darkens.",
+    "severed": "Connection line snaps apart cleanly, separated ends recoil, data flow between nodes stops.",
+    "severs": "Connection line snaps apart cleanly, separated ends recoil, data flow between nodes stops.",
+    "snapped": "Element breaks with sudden force, fragments fly apart, sharp discontinuity appears.",
+    "snaps": "Element breaks with sudden force, fragments fly apart, sharp discontinuity appears.",
+    "overwhelmed": "Dominant element grows to fill the frame, pushing all other elements to the margins.",
+    "overwhelms": "Dominant element grows to fill the frame, pushing all other elements to the margins.",
+    "spreading": "Effect or mark expands outward from its origin point, covering more area with each moment.",
+    "spreads": "Effect or mark expands outward from its origin point, covering more area with each moment.",
+    "rising": "Elements lift upward — values climb, chart lines ascend, indicators move toward the top of frame.",
+    "rises": "Elements lift upward — values climb, chart lines ascend, indicators move toward the top of frame.",
+    "sinking": "Elements descend — values drop, chart lines fall, indicators move toward the bottom of frame.",
+    "sinks": "Elements descend — values drop, chart lines fall, indicators toward the bottom of frame.",
+    "burning": "Element glows hot, edges char and curl, material consumed from the outside in.",
+    "burns": "Element glows hot, edges char and curl, material consumed from the outside in.",
+    "melting": "Structure loses rigidity, edges soften and drip downward, form distorts and pools.",
+    "melts": "Structure loses rigidity, edges soften and drip downward, form distorts and pools.",
+    "tearing": "Material rips apart along a line, edges fray, separated halves pull away from each other.",
+    "tears": "Material rips apart along a line, edges fray, separated halves pull away from each other.",
+    "cracking": "Fracture lines propagate across the surface, spreading from impact point outward.",
+    "cracks": "Fracture lines propagate across the surface, spreading from impact point outward.",
+    "expanding": "Element grows outward in all directions, boundaries push further, space fills.",
+    "expands": "Element grows outward in all directions, boundaries push further, space fills.",
+    "contracting": "Element shrinks inward from all edges, boundaries tighten, space compresses.",
+    "contracts": "Element shrinks inward from all edges, boundaries tighten, space compresses.",
+    "dropping": "Element falls from its position, descending through the frame with increasing speed.",
+    "drops": "Element falls from its position, descending through the frame with increasing speed.",
+    "spiking": "Value shoots upward sharply, chart line goes vertical, threshold indicators trip.",
+    "spikes": "Value shoots upward sharply, chart line goes vertical, threshold indicators trip.",
+    "plunging": "Value drops sharply downward, chart line nosedives, floor indicators trip.",
+    "plunges": "Value drops sharply downward, chart line nosedives, floor indicators trip.",
+}
+
 
 def generate_animation_prompt(
     segment: dict,
@@ -403,11 +535,14 @@ def generate_animation_prompt(
     )
     content_motion = template["motion_by_type"][content_type]
 
-    # Rule 1: Extract verb and build verb-driven motion note
+    # Rule 1: Extract verb and use verb-driven motion if available
     verb = extract_core_verb(sentence_text)
-    verb_note = ""
-    if verb:
-        verb_note = f"Primary motion driven by verb: \"{verb}\". "
+    verb_motion = _VERB_MOTION_MAP.get(verb, "") if verb else ""
+
+    if verb_motion:
+        # Verb-driven motion REPLACES the generic content-type template.
+        # The verb IS the animation — the template is just the fallback.
+        content_motion = f"Static wide shot. {verb_motion}"
 
     # Rule 2: Camera purpose — static by default
     camera_purpose = classify_camera_purpose(sentence_text)
@@ -424,7 +559,6 @@ def generate_animation_prompt(
             )
 
     parts = [
-        verb_note,
         camera_note if camera_note else "",
         content_motion,
         "Data labels and text remain stable and legible throughout.",

--- a/skills/video-pipeline/animation_prompt_engine.py
+++ b/skills/video-pipeline/animation_prompt_engine.py
@@ -8,73 +8,366 @@ Each segment gets:
 1. An image (from the holographic display image prompt engine)
 2. An animation prompt (from this engine)
 3. An intensity level (from the segmentation engine)
+
+==========================================================================
+ANIMATION PROMPT RULES (established Mar 2026)
+==========================================================================
+
+RULE 1 — VERB-FIRST MOTION DESIGN
+  The animation prompt derives its primary motion from the VERB in the
+  sentence text. Process:
+    1. Read the sentence text for this clip
+    2. Identify the core verb or action
+    3. The subject animation must LITERALLY ENACT that verb
+    4. Everything else in frame holds still
+  The verb IS the animation. Not a metaphor. Not decoration. The literal
+  visual enactment of what the sentence describes.
+
+RULE 2 — CAMERA MOVES ONLY WHEN CAMERA IS THE MEANING
+  Camera is STATIC by default. Only add camera motion for exactly one of:
+    REVEAL   — motion uncovers something new
+    SCALE    — motion communicates size
+    ISOLATION — motion narrows focus on one critical element
+  If the camera move doesn't serve REVEAL, SCALE, or ISOLATION, it's a
+  static shot. No default orbits, drifts, or push-ins.
+
+RULE 3 — TWO ACTIONS MAXIMUM PER CLIP
+  Each prompt gets AT MOST:
+    - 1 camera action (only if it passes Rule 2) + 1 subject action
+    - OR 0 camera action + 2 subject actions
+    - NEVER more than 2 total animated elements
+  If a sentence needs more complexity, split across multiple clips.
+==========================================================================
 """
 
+from __future__ import annotations
+
+import re
+
+
+# ---------------------------------------------------------------------------
+# Verb extraction — Rule 1 support
+# ---------------------------------------------------------------------------
+
+# Common "stop verbs" that are too generic to drive animation
+_STOP_VERBS = frozenset({
+    "is", "are", "was", "were", "be", "been", "being", "has", "have", "had",
+    "do", "does", "did", "can", "could", "will", "would", "shall", "should",
+    "may", "might", "must", "get", "got", "say", "said", "says", "know",
+    "knew", "think", "thought", "see", "saw", "make", "made", "come", "came",
+    "go", "went", "take", "took", "give", "gave", "find", "found", "tell",
+    "told", "let", "put", "seem", "need", "mean", "keep", "begin", "show",
+    "hear", "play", "run", "move", "live", "believe", "happen", "call",
+    "try", "ask", "use", "want", "look",
+})
+
+# Phrasal verbs / multi-word actions that should be captured whole
+_PHRASAL_VERB_PATTERNS = [
+    re.compile(r"\b(going\s+dark)\b", re.IGNORECASE),
+    re.compile(r"\b(shut(?:ting)?\s+down)\b", re.IGNORECASE),
+    re.compile(r"\b(break(?:ing)?\s+apart)\b", re.IGNORECASE),
+    re.compile(r"\b(fall(?:ing)?\s+apart)\b", re.IGNORECASE),
+    re.compile(r"\b(lock(?:s|ed|ing)?\s+(?:in|on|frozen|up))\b", re.IGNORECASE),
+    re.compile(r"\b(pile(?:s|d|ing)?\s+up)\b", re.IGNORECASE),
+    re.compile(r"\b(dry(?:s|ing|ied)?\s+up)\b", re.IGNORECASE),
+    re.compile(r"\b(light(?:s|ing|ed)?\s+up)\b", re.IGNORECASE),
+    re.compile(r"\b(blow(?:s|n|ing)?\s+(?:up|apart))\b", re.IGNORECASE),
+    re.compile(r"\b(rip(?:s|ped|ping)?\s+(?:through|apart))\b", re.IGNORECASE),
+    re.compile(r"\b(don'?t\s+matter)\b", re.IGNORECASE),
+    re.compile(r"\b(wip(?:e[sd]?|ing)\s+out)\b", re.IGNORECASE),
+    re.compile(r"\b(spread(?:s|ing)?\s+(?:across|out))\b", re.IGNORECASE),
+]
+
+# Single-word action verbs (gerunds, past tense, base forms) that drive motion
+_ACTION_VERB_PATTERN = re.compile(
+    r"\b("
+    r"scatter(?:s|ed|ing)?|launch(?:es|ed|ing)?|freeze(?:s|d)?|freez(?:ing)|frozen|"
+    r"crash(?:es|ed|ing)?|collapse(?:s|d)?|collaps(?:ing)|"
+    r"explod(?:e[sd]?|ing)|dissolv(?:e[sd]?|ing)|shatter(?:s|ed|ing)?|"
+    r"surge(?:s|d)?|surg(?:ing)|spike(?:s|d)?|spik(?:ing)|"
+    r"plunge(?:s|d)?|plung(?:ing)|plummet(?:s|ed|ing)?|"
+    r"spread(?:s|ing)?|multiply|multipli(?:es|ed)|"
+    r"flood(?:s|ed|ing)?|drain(?:s|ed|ing)?|"
+    r"extinguish(?:es|ed|ing)?|ignit(?:e[sd]?|ing)|"
+    r"sever(?:s|ed|ing)?|snap(?:s|ped|ping)?|"
+    r"cascade(?:s|d)?|cascad(?:ing)|rippl(?:e[sd]?|ing)|"
+    r"lock(?:s|ed|ing)?|unlock(?:s|ed|ing)?|"
+    r"block(?:s|ed|ing)?|halt(?:s|ed|ing)?|stall(?:s|ed|ing)?|"
+    r"climb(?:s|ed|ing)?|drop(?:s|ped|ping)?|"
+    r"erode(?:s|d)?|erod(?:ing)|strip(?:s|ped|ping)?|"
+    r"consum(?:e[sd]?|ing)|devour(?:s|ed|ing)?|"
+    r"overwhelm(?:s|ed|ing)?|dominat(?:e[sd]?|ing)|"
+    r"fractur(?:e[sd]?|ing)|crack(?:s|ed|ing)?|"
+    r"accelerat(?:e[sd]?|ing)|decelerat(?:e[sd]?|ing)|"
+    r"assembl(?:e[sd]?|ing)|disassembl(?:e[sd]?|ing)|"
+    r"connect(?:s|ed|ing)?|disconnect(?:s|ed|ing)?|"
+    r"activate(?:s|d)?|activat(?:ing)|deactivat(?:e[sd]?|ing)|"
+    r"engulf(?:s|ed|ing)?|swarm(?:s|ed|ing)?|"
+    r"tighten(?:s|ed|ing)?|loosen(?:s|ed|ing)?|"
+    r"expand(?:s|ed|ing)?|contract(?:s|ed|ing)?|"
+    r"burn(?:s|ed|ing)?|melt(?:s|ed|ing)?|"
+    r"rise(?:s)?|rising|risen|rose|"
+    r"fall(?:s|ing)?|fell|fallen|"
+    r"split(?:s|ting)?|tear(?:s|ing)?|tore|torn|"
+    r"sink(?:s|ing)?|sank|sunk"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def extract_core_verb(sentence_text: str) -> str:
+    """Extract the core action verb or phrasal verb from sentence text.
+
+    Returns the verb/phrase that should drive the animation motion.
+    Falls back to an empty string if no meaningful verb is found.
+    """
+    if not sentence_text:
+        return ""
+
+    # Try phrasal verbs first (multi-word actions are more specific)
+    for pattern in _PHRASAL_VERB_PATTERNS:
+        match = pattern.search(sentence_text)
+        if match:
+            return match.group(1).lower().strip()
+
+    # Try single-word action verbs
+    match = _ACTION_VERB_PATTERN.search(sentence_text)
+    if match:
+        return match.group(1).lower().strip()
+
+    # Fallback: scan all words for any verb-like word not in stop list
+    words = re.findall(r"\b[a-z]+(?:ing|ed|es|s)?\b", sentence_text.lower())
+    for word in words:
+        base = re.sub(r"(ing|ed|es|s)$", "", word)
+        if len(base) >= 3 and word not in _STOP_VERBS and base not in _STOP_VERBS:
+            # Skip common non-verbs
+            if word not in {"the", "and", "but", "for", "not", "its", "this",
+                            "that", "these", "those", "their", "them", "his",
+                            "her", "from", "with", "into", "across", "between",
+                            "after", "before", "about", "against", "over",
+                            "under", "every", "each", "most", "more", "less",
+                            "other", "another", "some", "all", "many", "much"}:
+                return word
+
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Camera purpose validation — Rule 2 support
+# ---------------------------------------------------------------------------
+
+# Camera purpose tags
+CAMERA_PURPOSE_REVEAL = "REVEAL"
+CAMERA_PURPOSE_SCALE = "SCALE"
+CAMERA_PURPOSE_ISOLATION = "ISOLATION"
+CAMERA_PURPOSE_STATIC = "STATIC"
+
+VALID_CAMERA_PURPOSES = frozenset({
+    CAMERA_PURPOSE_REVEAL,
+    CAMERA_PURPOSE_SCALE,
+    CAMERA_PURPOSE_ISOLATION,
+    CAMERA_PURPOSE_STATIC,
+})
+
+
+def classify_camera_purpose(sentence_text: str) -> str:
+    """Determine if camera motion is justified and what purpose it serves.
+
+    Returns one of: REVEAL, SCALE, ISOLATION, or STATIC (default).
+    Camera motion is only justified for REVEAL, SCALE, or ISOLATION.
+    """
+    if not sentence_text:
+        return CAMERA_PURPOSE_STATIC
+
+    text_lower = sentence_text.lower()
+
+    # REVEAL keywords: uncovering, discovering, exposing
+    reveal_words = [
+        "reveal", "uncover", "discover", "expose", "behind", "hidden",
+        "beneath", "underneath", "secret", "unknown", "unseen", "emerges",
+        "appears", "showing", "unveil",
+    ]
+    if any(w in text_lower for w in reveal_words):
+        return CAMERA_PURPOSE_REVEAL
+
+    # SCALE keywords: vastness, quantity, magnitude
+    scale_words = [
+        "thousands", "millions", "billions", "trillions", "massive", "vast",
+        "enormous", "entire", "all of", "every single", "across the",
+        "spanning", "worldwide", "global", "continent", "ocean",
+        "how many", "how much", "scale", "magnitude",
+    ]
+    if any(w in text_lower for w in scale_words):
+        return CAMERA_PURPOSE_SCALE
+
+    # ISOLATION keywords: one specific thing, focus, critical detail
+    isolation_words = [
+        "only one", "single", "lone", "just one", "the one", "critical",
+        "this specific", "that exact", "pinpoint", "zero in", "focus on",
+        "the key", "the crucial",
+    ]
+    if any(w in text_lower for w in isolation_words):
+        return CAMERA_PURPOSE_ISOLATION
+
+    return CAMERA_PURPOSE_STATIC
+
+
+# ---------------------------------------------------------------------------
+# Animated element counting — Rule 3 support
+# ---------------------------------------------------------------------------
+
+# Patterns that indicate a distinct animated element
+_ANIMATION_ACTION_PATTERNS = [
+    re.compile(r"\b(?:push[- ]in|pull[- ]back|zoom (?:in|out)|dolly (?:in|out))\b", re.IGNORECASE),
+    re.compile(r"\b(?:pan (?:left|right|across)|lateral pan|tracking shot)\b", re.IGNORECASE),
+    re.compile(r"\b(?:tilt (?:up|down)|crane (?:up|down))\b", re.IGNORECASE),
+    re.compile(r"\b(?:snap zoom|crash zoom|fast push)\b", re.IGNORECASE),
+    re.compile(r"\b(?:orbit(?:al|s|ing)?|rotat(?:e[sd]?|ing|ion))\b", re.IGNORECASE),
+]
+
+# Sentence-splitting pattern to count independent actions
+_ACTION_SENTENCE_SPLIT = re.compile(r"[.;,]\s+(?=[A-Z])")
+
+
+def count_animated_elements(prompt: str) -> int:
+    """Count the number of distinct animated elements in an animation prompt.
+
+    Counts camera motions + subject actions. Returns total count.
+    A prompt should have at most 2 animated elements per Rule 3.
+    """
+    if not prompt:
+        return 0
+
+    count = 0
+
+    # Count camera motions (any non-static camera direction counts as 1)
+    has_camera = False
+    for pattern in _ANIMATION_ACTION_PATTERNS:
+        if pattern.search(prompt):
+            has_camera = True
+            break
+    if has_camera:
+        count += 1
+
+    # Count subject actions by splitting on sentence boundaries
+    # Each clause with an action verb is one animated element
+    clauses = _ACTION_SENTENCE_SPLIT.split(prompt)
+    subject_actions = 0
+    for clause in clauses:
+        clause_lower = clause.lower().strip()
+        # Skip camera-only clauses
+        if any(p.search(clause) for p in _ANIMATION_ACTION_PATTERNS):
+            if len(clause.split()) < 8:  # Short clause = camera-only
+                continue
+        # Check if clause has a subject action verb
+        action_verbs = [
+            "extinguish", "dissolve", "spread", "multiply", "freeze",
+            "lock", "snap", "sever", "cascade", "ripple", "collapse",
+            "explode", "shatter", "surge", "spike", "plunge", "drain",
+            "flood", "ignite", "crack", "tear", "burn", "melt",
+            "assemble", "materialize", "illuminate", "activate",
+            "draw", "scroll", "appear", "flash", "slam", "drop",
+            "retract", "expand", "contract", "accelerate", "decelerate",
+            "pulse", "flicker", "shimmer", "glow",
+        ]
+        if any(v in clause_lower for v in action_verbs):
+            subject_actions += 1
+
+    count += subject_actions
+    return max(count, 1)  # At least 1 if prompt is non-empty
+
+
+def validate_max_actions(prompt: str, max_actions: int = 2) -> tuple[bool, int]:
+    """Validate that a prompt doesn't exceed the maximum animated elements.
+
+    Returns (is_valid, element_count).
+    """
+    count = count_animated_elements(prompt)
+    return (count <= max_actions, count)
+
+
+# ---------------------------------------------------------------------------
 # Universal rules appended to every animation prompt
+# ---------------------------------------------------------------------------
+
 UNIVERSAL_RULES = (
-    "Maintain the full original frame composition and camera angle, do not zoom or reframe. "
+    "Maintain the full original frame composition. "
     "No human figures, faces, or hands should appear at any point during the animation. "
     "All text and data labels must remain legible throughout the animation. "
     "Holographic elements maintain their established color palette."
 )
 
-# Content-specific motion descriptions by intensity and content type
+
+# ---------------------------------------------------------------------------
+# Content-specific motion templates — VERB-FIRST, STATIC CAMERA, 2-ACTION MAX
+# ---------------------------------------------------------------------------
+# Each template describes 1-2 subject actions. No camera motion by default.
+# Camera motion is added separately only when justified by REVEAL/SCALE/ISOLATION.
+# ---------------------------------------------------------------------------
+
 _LOW_MOTION = {
-    "A_geographic_map": "Map contour lines shimmer subtly, route arrows pulse with faint traveling light dots moving along the paths, country label text glows slightly brighter then dims in a slow rhythm",
-    "B_data_terminal": "Chart lines have a faint pixel shimmer, ticker tape scrolls slowly at the bottom, numerical values hold steady with occasional last-digit flicker",
-    "C_object_comparison": "Wireframe objects rotate very slowly in place, holographic grid lines on the display surface pulse gently, floating labels sway almost imperceptibly",
-    "D_document_display": "Document has subtle translucent shimmer as if projected through moving air, stamps and highlights pulse gently, page edges have faint particle drift",
-    "E_network_diagram": "Network connection lines pulse with faint traveling light, nodes glow brighter and dimmer in slow rhythm, percentage labels hold steady",
-    "F_timeline": "Timeline panels have subtle internal animation, connecting thread pulses with traveling light, era labels glow gently",
-    "G_satellite": "Satellite image has subtle scan line moving across it, annotation markers pulse, timestamp updates slowly",
-    "H_abstract_concept": "Conceptual elements drift very slightly, force arrows pulse, symbolic objects rotate imperceptibly slowly",
+    "A_geographic_map": "Static wide shot. Route arrows pulse with faint traveling light dots moving along paths.",
+    "B_data_terminal": "Static wide shot. Numerical values hold steady with occasional last-digit flicker.",
+    "C_object_comparison": "Static wide shot. Floating labels hold position, wireframe edges shimmer faintly.",
+    "D_document_display": "Static wide shot. Document text holds steady, stamps pulse with faint glow.",
+    "E_network_diagram": "Static wide shot. Connection lines pulse with faint traveling light between nodes.",
+    "F_timeline": "Static wide shot. Connecting thread pulses with traveling light across panels.",
+    "G_satellite": "Static wide shot. A single scan line moves slowly across the satellite image.",
+    "H_abstract_concept": "Static wide shot. Force arrows pulse faintly, all other elements hold still.",
 }
 
 _MEDIUM_MOTION = {
-    "A_geographic_map": "Route lines draw themselves across the map progressively, position markers appear one by one with brief flash effects, a highlighted zone expands outward with pulsing border, country labels illuminate sequentially",
-    "B_data_terminal": "Chart line draws itself from left to right revealing the trend in real time, data panels populate line by line as if being typed, warning indicators flash on at key thresholds, ticker tape accelerates",
-    "C_object_comparison": "Objects materialize from particle clouds assembling into wireframe form, measurement lines extend and lock into position with data appearing, comparison panel illuminates section by section",
-    "D_document_display": "Document scrolls or pages turn revealing new content, highlight annotations draw themselves around key clauses, stamps materialize and slam down with impact particle effects",
-    "E_network_diagram": "Connection lines between nodes light up sequentially showing flow direction, a disruption pulse travels from the source node outward through the network, affected nodes change color as the pulse reaches them",
-    "F_timeline": "Timeline panels appear left to right revealing each era in sequence, connecting thread draws itself between them, data overlays within each panel animate their charts or markers",
-    "G_satellite": "Image resolves from blurry to sharp as if the satellite is focusing, annotation markers drop in from above and lock to positions, comparison overlay slides in from the side",
-    "H_abstract_concept": "Conceptual elements assemble from scattered particles into their final configuration, force arrows extend and lock, the balance or dynamic of the concept becomes visible through motion",
+    "A_geographic_map": "Static wide shot. Route lines draw themselves across the map progressively. Position markers appear one by one with brief flash effects.",
+    "B_data_terminal": "Static wide shot. Chart line draws itself from left to right revealing the trend. Warning indicators flash on at key thresholds.",
+    "C_object_comparison": "Static wide shot. Objects materialize from particle clouds assembling into wireframe form. Measurement lines extend and lock into position.",
+    "D_document_display": "Static wide shot. Highlight annotations draw themselves around key clauses. A stamp materializes and slams down with impact particles.",
+    "E_network_diagram": "Static wide shot. Connection lines light up sequentially showing flow direction. A disruption pulse travels from source node outward through the network.",
+    "F_timeline": "Static wide shot. Timeline panels appear left to right revealing each era in sequence. Connecting thread draws itself between them.",
+    "G_satellite": "Static wide shot. Image resolves from blurry to sharp as if focusing. Annotation markers drop in from above and lock to positions.",
+    "H_abstract_concept": "Static wide shot. Conceptual elements assemble from scattered particles into final configuration. Force arrows extend and lock.",
 }
 
 _HIGH_MOTION = {
-    "A_geographic_map": "A shockwave or disruption pulse explodes outward from the crisis point, route lines sever and retract with sparking particle effects, affected regions flash red and glitch, the entire map flickers with interference at the moment of impact",
-    "B_data_terminal": "Chart line spikes violently upward or crashes downward with the screen shaking from the force, warning klaxon indicators flood the display in red, numbers spin rapidly before locking on extreme values, the entire terminal flashes emergency colors",
-    "C_object_comparison": "One object attacks or impacts the other — projectile crosses the frame leaving a particle trail, the target object glitches violently on impact with wireframe sections breaking apart and dissolving into scattered particles, cost labels flash and update rapidly",
-    "D_document_display": "Document is overridden — a massive stamp slams down with shockwave, or the document tears apart, or red DENIED or CLASSIFIED overlays cascade across the content, particle effects explode from the impact",
-    "E_network_diagram": "A critical node goes dark with an explosion of particles, its connections snap and recoil like severed cables with sparking effects, cascade failure ripples outward as connected nodes flash warning colors and fail sequentially",
-    "F_timeline": "The final panel ignites or activates dramatically, connecting thread turns from gold to red as the pattern completes, the current-era panel pulses with urgency as if the lesson is happening right now",
-    "G_satellite": "Impact strikes are visible — explosions, fire, structural damage appearing on the facility, before/after split slides dramatically revealing destruction, smoke or debris particles rise",
-    "H_abstract_concept": "The conceptual balance breaks dramatically — one side overwhelms the other, scales tip violently, chess pieces shatter, dominoes fall in rapid succession with each impact creating a burst of particles",
+    "A_geographic_map": "Static wide shot. A shockwave explodes outward from the crisis point. Route lines sever and retract with sparking particle effects.",
+    "B_data_terminal": "Static wide shot. Chart line spikes violently upward with the screen shaking from the force. Warning indicators flood the display in red.",
+    "C_object_comparison": "Static wide shot. Projectile crosses the frame leaving a particle trail. Target object glitches violently on impact with wireframe sections breaking apart.",
+    "D_document_display": "Static wide shot. A massive stamp slams down with shockwave. Red DENIED overlays cascade across the content.",
+    "E_network_diagram": "Static wide shot. A critical node goes dark with an explosion of particles. Its connections snap and recoil like severed cables.",
+    "F_timeline": "Static wide shot. The final panel ignites dramatically. Connecting thread turns from gold to red as the pattern completes.",
+    "G_satellite": "Static wide shot. Impact strikes appear on the facility — explosions, structural damage. Smoke and debris particles rise from impact points.",
+    "H_abstract_concept": "Static wide shot. The conceptual balance breaks — one side overwhelms the other. Scales tip violently with burst of particles.",
 }
 
 ANIMATION_TEMPLATES = {
     "low": {
-        "description": "Subtle ambient motion. Data pulses, gentle glow shifts, minimal movement.",
-        "prefix": "Subtle ambient motion only.",
-        "suffix": "No dramatic movements or camera changes.",
+        "description": "Subtle ambient motion. Single element animates, everything else still.",
+        "prefix": "Static shot.",
+        "suffix": "No camera movement.",
         "motion_by_type": _LOW_MOTION,
     },
     "medium": {
-        "description": "Active reveal motion. Data appearing, elements activating, builds energy.",
-        "prefix": "Active reveal animation.",
-        "suffix": "Slow deliberate camera push or pull acceptable (max 10% frame shift).",
+        "description": "Active reveal motion. Up to two subject actions, static camera unless justified.",
+        "prefix": "Static shot.",
+        "suffix": "No camera movement unless serving REVEAL, SCALE, or ISOLATION.",
         "motion_by_type": _MEDIUM_MOTION,
     },
     "high": {
-        "description": "Dramatic action. Impacts, destructions, cascades, maximum visual energy.",
-        "prefix": "Dramatic high-energy animation.",
-        "suffix": "Camera may push in toward impact point (max 15% frame shift).",
+        "description": "Dramatic action. Up to two subject actions, camera only for REVEAL/SCALE/ISOLATION.",
+        "prefix": "Static shot.",
+        "suffix": "Camera motion only if serving REVEAL, SCALE, or ISOLATION.",
         "motion_by_type": _HIGH_MOTION,
     },
 }
 
 # Default content type when image type is unknown
 _DEFAULT_CONTENT_TYPE = "B_data_terminal"
+
+# Camera motion templates keyed by purpose — only used when purpose is not STATIC
+_CAMERA_BY_PURPOSE = {
+    CAMERA_PURPOSE_REVEAL: "Slow lateral pan revealing",
+    CAMERA_PURPOSE_SCALE: "Gradual pull-back showing full scale of",
+    CAMERA_PURPOSE_ISOLATION: "Slow push-in isolating",
+}
 
 
 def generate_animation_prompt(
@@ -84,8 +377,14 @@ def generate_animation_prompt(
 ) -> str:
     """Generate a Grok Imagine animation prompt for a segment.
 
+    Applies the three animation rules:
+    - Rule 1: Verb from sentence text drives the primary motion
+    - Rule 2: Camera is static unless REVEAL/SCALE/ISOLATION is justified
+    - Rule 3: Maximum 2 animated elements per prompt
+
     Args:
-        segment: Segment dict from segmentation engine (must have "intensity" key).
+        segment: Segment dict from segmentation engine. Must have "intensity" key.
+            May have "text" key with sentence text for verb extraction.
         image_content_type: One of A_geographic_map through H_abstract_concept.
             Falls back to B_data_terminal if empty or unknown.
         clip_duration: Duration in seconds (6 or 10).
@@ -94,25 +393,52 @@ def generate_animation_prompt(
         Complete animation prompt string.
     """
     intensity = segment.get("intensity", "low")
+    sentence_text = segment.get("text", "")
     template = ANIMATION_TEMPLATES.get(intensity, ANIMATION_TEMPLATES["low"])
 
-    content_type = image_content_type if image_content_type in template["motion_by_type"] else _DEFAULT_CONTENT_TYPE
+    content_type = (
+        image_content_type
+        if image_content_type in template["motion_by_type"]
+        else _DEFAULT_CONTENT_TYPE
+    )
     content_motion = template["motion_by_type"][content_type]
 
+    # Rule 1: Extract verb and build verb-driven motion note
+    verb = extract_core_verb(sentence_text)
+    verb_note = ""
+    if verb:
+        verb_note = f"Primary motion driven by verb: \"{verb}\". "
+
+    # Rule 2: Camera purpose — static by default
+    camera_purpose = classify_camera_purpose(sentence_text)
+    camera_note = ""
+    if camera_purpose != CAMERA_PURPOSE_STATIC:
+        camera_prefix = _CAMERA_BY_PURPOSE.get(camera_purpose, "")
+        if camera_prefix:
+            camera_note = f"{camera_prefix} the scene. "
+            # Replace "Static wide shot" prefix in content_motion
+            content_motion = re.sub(
+                r"^Static wide shot\.\s*",
+                "",
+                content_motion,
+            )
+
     parts = [
-        template["prefix"],
+        verb_note,
+        camera_note if camera_note else "",
         content_motion,
         "Data labels and text remain stable and legible throughout.",
-        "Dark room background unchanged." if intensity == "low" else (
-            "Dark room background may have subtle reactive ambient light changes." if intensity == "medium"
-            else "Room ambient lighting reacts dramatically — screens flash, warning lights activate."
-        ),
-        template["suffix"],
+        "Dark room background unchanged.",
         f"{clip_duration} seconds.",
         UNIVERSAL_RULES,
     ]
 
-    return " ".join(parts)
+    # Filter empty parts and join
+    prompt = " ".join(p for p in parts if p)
+    # Clean up double spaces
+    prompt = re.sub(r"\s{2,}", " ", prompt).strip()
+
+    return prompt
 
 
 def generate_prompts_for_segments(
@@ -127,13 +453,16 @@ def generate_prompts_for_segments(
             Each segment may have a "clip_duration" field (6 or 10) set
             dynamically based on narration length. If present, it overrides
             the global clip_duration parameter.
+            Each segment may have a "text" field with sentence text for
+            verb extraction (Rule 1).
         content_types: Optional mapping of segment index to content type string.
             When None, defaults to B_data_terminal for all segments.
         clip_duration: Default duration in seconds (6 or 10). Used only when
             a segment doesn't have its own clip_duration.
 
     Returns:
-        List of dicts with segment index, clip_duration, and animation_prompt.
+        List of dicts with segment index, clip_duration, camera_purpose,
+        core_verb, and animation_prompt.
     """
     if content_types is None:
         content_types = {}
@@ -144,10 +473,14 @@ def generate_prompts_for_segments(
         ct = content_types.get(idx, _DEFAULT_CONTENT_TYPE)
         seg_clip_duration = seg.get("clip_duration", clip_duration)
         prompt = generate_animation_prompt(seg, ct, seg_clip_duration)
+
+        sentence_text = seg.get("text", "")
         results.append({
             "segment_index": idx,
             "intensity": seg.get("intensity", "low"),
             "clip_duration": seg_clip_duration,
             "animation_prompt": prompt,
+            "camera_purpose": classify_camera_purpose(sentence_text),
+            "core_verb": extract_core_verb(sentence_text),
         })
     return results

--- a/skills/video-pipeline/bots/animation_bot.py
+++ b/skills/video-pipeline/bots/animation_bot.py
@@ -203,5 +203,12 @@ class AnimationBot:
 
         content_type = img_record.get("Content Type", "")
 
-        segment = {"intensity": intensity, "index": img_record.get("Image Index", 0)}
+        # Include Sentence Text for verb-first motion extraction (Rule 1)
+        sentence_text = img_record.get("Sentence Text", "")
+
+        segment = {
+            "intensity": intensity,
+            "index": img_record.get("Image Index", 0),
+            "text": sentence_text,
+        }
         return generate_animation_prompt(segment, content_type, clip_duration)

--- a/skills/video-pipeline/clients/anthropic_client.py
+++ b/skills/video-pipeline/clients/anthropic_client.py
@@ -1128,46 +1128,72 @@ Every prompt describes a holographic projection with specific data points."""
         """
         from .style_engine import get_camera_motion
 
-        # Determine camera motion based on scene type
-        # Pass string directly - get_camera_motion handles both strings and SceneType enums
-        camera_motion = get_camera_motion(scene_type, is_hero_shot) if scene_type else "Slow push-in"
+        # Determine camera purpose from sentence text
+        # Camera is STATIC by default — only moves for REVEAL, SCALE, or ISOLATION
+        from animation_prompt_engine import classify_camera_purpose, CAMERA_PURPOSE_STATIC
+        camera_purpose = classify_camera_purpose(sentence_text)
+
+        # Only request camera motion when purpose justifies it
+        if camera_purpose != CAMERA_PURPOSE_STATIC and scene_type:
+            camera_motion = get_camera_motion(scene_type, is_hero_shot)
+        else:
+            camera_motion = "Static shot"
 
         # Word limit based on duration
         word_limit = 55 if is_hero_shot else 40
         duration_note = "10-second HERO SHOT" if is_hero_shot else "6-second clip"
         hero_instruction = """
-For this HERO SHOT (10s), include one additional motion element after the primary subject motion.
-The camera movement can have a secondary phase (e.g., "gradually revealing the full map").""" if is_hero_shot else ""
+For this HERO SHOT (10s), you may use 2 subject actions instead of 1, but still no more than 2 total animated elements.""" if is_hero_shot else ""
 
         system_prompt = f"""You are a cinematographer writing motion instructions for AI video generation.
 Each prompt animates a single static image into a {duration_note}. The narrator will be speaking the Sentence Text over this clip.
 
-YOUR JOB: Write motion that TELLS THE SAME STORY as the narration. You are not decorating — you are directing a film. Every motion must earn its place by reinforcing what the viewer hears.
+YOUR JOB: Write motion that LITERALLY ENACTS the verb in the narration. You are not decorating — you are directing a film.
 
 CRITICAL: The source image ALREADY contains the full scene. Do NOT re-describe the scene. Only describe what MOVES and HOW.
 Maximum {word_limit} words.
 {hero_instruction}
 
-## THE NARRATIVE BEAT METHOD
+## RULE 1 — VERB-FIRST MOTION DESIGN
 
-Before writing any motion, analyze the Sentence Text:
+Before writing ANY motion, do this:
+1. Read the Sentence Text
+2. Identify the CORE VERB or action ("going dark", "scattered", "freeze", "don't matter")
+3. The subject animation must LITERALLY ENACT that verb
+4. Everything else in frame HOLDS STILL — the animated verb is the only motion
 
-1. IDENTIFY THE BEATS: Break the sentence into its emotional beats (1-3 beats).
-2. ASSIGN EACH BEAT A VISUAL VERB: What does this beat LOOK like in motion?
-   - Abundance = something large stays frozen, locked, unmoving
-   - Collapse = things freeze, stutter, go dark in sequence
-   - Escalation = things multiply, spread, accelerate, cascade
-   - Revelation = something snaps into focus, illuminates, reveals hidden layer
-   - Dominance = something overrides, floods, overwhelms, locks on
-   - Loss = things drain, dissolve, extinguish, disconnect
-   - Tension = elements pull apart, strain, vibrate, hold unnaturally still
-3. SEQUENCE THE MOTIONS TO MATCH THE BEATS: Motion timeline mirrors narration timeline.
+Examples:
+- "Launch site after launch site going dark" → lights/points extinguish one by one
+- "Your missiles don't matter" → asset icons dissolve to static, then blank
+- "Scattered across hardened bunkers" → single dot multiplies and spreads across terrain
+- "The count locks frozen" → number stops mid-increment, holds completely still
 
-## PROMPT STRUCTURE
+The verb IS the animation. Not a metaphor for it. Not a decoration around it.
 
-Line 1: Camera movement + primary subject motion (what the viewer sees first)
-Lines 2-3: Beat-driven narrative motions (each maps to a specific beat)
-Final line: The PAYOFF — the most dramatic visual moment that lands with the sentence's emotional climax.
+## RULE 2 — CAMERA MOVES ONLY WHEN CAMERA IS THE MEANING
+
+Camera must be STATIC by default. Only add camera motion if it serves exactly one of three purposes:
+1. REVEAL — motion uncovers something new (satellite drift exposing geography)
+2. SCALE — motion communicates size (pull-back showing quantity)
+3. ISOLATION — motion narrows focus (push-in on one critical element)
+
+If the camera move doesn't serve REVEAL, SCALE, or ISOLATION — it's a static shot.
+Remove all default orbit/drift/push-in that exists as cinematography habit.
+
+WRONG: "Slow orbit around the table with gradual push-in revealing layers of data. Left screen: bomber bay doors snap open, bombs drop in rapid sequence. Right screen: strike data timestamps accelerate..."
+→ Camera eating attention budget, 4+ simultaneous subject actions
+
+RIGHT: "Static wide shot of command center. Bomber bay doors snap open on left display, bombs drop in rapid sequence."
+→ Camera still, one meaningful motion
+
+## RULE 3 — TWO ACTIONS MAXIMUM PER CLIP
+
+Each animation prompt gets AT MOST:
+- 1 camera action (only if it passes Rule 2) + 1 subject action
+- OR 0 camera action + 2 subject actions
+- NEVER more than 2 total animated elements
+
+Count your actions before submitting. If you have more than 2, delete until you have 2.
 
 ## MOTION VOCABULARY — USE VERBS, NOT ADJECTIVES
 
@@ -1204,38 +1230,12 @@ DOMINANCE / POWER: override, flood, overwhelm, lock on, absorb, eclipse, tower o
 TENSION / STANDOFF: hold unnaturally still, vibrate, strain, pull apart slowly, hover, suspend, balance on edge
 LOSS / ABSENCE: extinguish, fade to nothing, leave empty, hollow out, strip away, erode, scatter
 
-## CAMERA MOVEMENT ROTATION — MANDATORY
+## CAMERA DECISION
 
-Never use the same camera movement on consecutive clips. Pick a DIFFERENT one from the previous clip.
+The camera purpose for this clip is: "{camera_purpose}"
+The camera direction is: "{camera_motion}"
 
-Available camera movements and when to use each:
-
-| Movement | Use When | Feel |
-|---|---|---|
-| Slow push-in | Revelation, focus, intimacy | Drawing viewer into a detail |
-| Pull-back / zoom out | Scale, overwhelm, isolation | Showing vastness or emptiness |
-| Lateral pan / tracking shot | Comparison, progression, timeline | Moving through information side to side |
-| Static / locked-off | Tension, stillness, dread | Something is deeply wrong — camera won't move |
-| Tilt up | Power, dominance, discovery | Something looms or is being revealed vertically |
-| Tilt down | Collapse, loss, submission | Falling, declining, ground-level consequence |
-| Snap zoom (fast push-in) | Shock, urgency, sudden alarm | A number spikes, a target locks, something breaks |
-| Slow orbital / rotation | Surveillance, encirclement, inevitability | Circling a subject like a predator |
-
-Match camera to the narration's dominant emotion:
-- Collapse → pull-back or static
-- Escalation → snap zoom or push-in
-- Revelation → slow push-in or tilt up
-- Comparison → lateral pan
-- Dominance → tilt up or slow orbital
-- Absence/Loss → pull-back or static
-- Tension/Standoff → static or slow orbital
-
-CRITICAL: "Slow push-in" is NOT the default. It is ONE of eight options. If you catch yourself defaulting to push-in, stop and ask: what does this sentence's emotion actually call for?
-
-REQUIRED CAMERA MOVEMENT (START your response with this exact movement):
-"{camera_motion}"
-
-CRITICAL: Your response MUST begin with this camera movement. Do NOT substitute a different camera movement.
+If camera is "Static shot", do NOT add any camera motion. Your entire budget is for subject action.
 
 OUTPUT: Return ONLY the motion prompt text. No explanations, no formatting, no labels."""
 
@@ -1256,9 +1256,10 @@ OUTPUT: Return ONLY the motion prompt text. No explanations, no formatting, no l
 {image_prompt}
 {narration_context}{camera_history_context}
 
-The camera movement is ALREADY DECIDED: "{camera_motion}"
-Generate ONLY the subject motion + ambient motion ({word_limit - 10} words max).
-Do NOT include any camera movement - I will prepend it."""
+Camera decision: "{camera_motion}" (purpose: {camera_purpose})
+Generate the subject motion ({word_limit - 10} words max).
+RULE 3 CHECK: Your response + camera = MAX 2 animated elements total.
+If camera is "Static shot", you may have up to 2 subject actions."""
 
         response = await self.generate(
             prompt=prompt,
@@ -1267,6 +1268,8 @@ Do NOT include any camera movement - I will prepend it."""
             max_tokens=200,
         )
 
-        # Prepend the camera motion to guarantee variety
+        # Prepend the camera motion to guarantee format
         subject_motion = response.strip()
+        if camera_motion == "Static shot":
+            return f"Static shot. {subject_motion}"
         return f"{camera_motion}. {subject_motion}"

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -411,9 +411,21 @@ def validate_video_prompt(
 ) -> dict:
     """Validate a video prompt meets narrative quality standards.
 
+    Enforces three animation rules:
+    - Rule 1: Verb-first motion design (verb from sentence drives animation)
+    - Rule 2: Camera static by default (only REVEAL/SCALE/ISOLATION justify motion)
+    - Rule 3: Maximum 2 animated elements per clip
+
     Returns a dict with ``valid`` (bool), ``issues`` (list[str]),
-    ``prompt``, ``sentence``, and ``camera`` (detected movement).
+    ``prompt``, ``sentence``, ``camera`` (detected movement),
+    ``camera_purpose``, and ``animated_element_count``.
     """
+    from animation_prompt_engine import (
+        classify_camera_purpose,
+        count_animated_elements,
+        CAMERA_PURPOSE_STATIC,
+    )
+
     issues: list[str] = []
 
     # Check for banned filler patterns
@@ -441,15 +453,29 @@ def validate_video_prompt(
         if sw in last_words:
             issues.append(f"WEAK PAYOFF: Final line contains '{sw}' — rewrite for stronger landing")
 
-    # Camera movement detection and repeat check
+    # Camera movement detection
     current_camera = detect_camera_movement(prompt)
 
-    if current_camera == "unknown":
-        issues.append("NO CAMERA MOVEMENT DETECTED: Prompt must open with a clear camera direction")
-
-    if prev_cameras and len(prev_cameras) >= 1 and current_camera == prev_cameras[-1]:
+    # Rule 2: Camera should be static unless purpose justifies it
+    camera_purpose = classify_camera_purpose(sentence_text)
+    if current_camera not in ("static", "unknown") and camera_purpose == CAMERA_PURPOSE_STATIC:
         issues.append(
-            f"CAMERA REPEAT: '{current_camera}' used on consecutive clips — pick a different movement"
+            f"UNJUSTIFIED CAMERA: '{current_camera}' detected but sentence doesn't justify "
+            f"REVEAL, SCALE, or ISOLATION — use static shot"
+        )
+
+    # Camera repeat check (still valid when camera motion IS justified)
+    if current_camera not in ("static", "unknown") and prev_cameras and len(prev_cameras) >= 1:
+        if current_camera == prev_cameras[-1]:
+            issues.append(
+                f"CAMERA REPEAT: '{current_camera}' used on consecutive clips — pick a different movement"
+            )
+
+    # Rule 3: Max 2 animated elements
+    element_count = count_animated_elements(prompt)
+    if element_count > 2:
+        issues.append(
+            f"TOO MANY ACTIONS: {element_count} animated elements detected (max 2)"
         )
 
     return {
@@ -458,4 +484,6 @@ def validate_video_prompt(
         "prompt": prompt,
         "sentence": sentence_text,
         "camera": current_camera,
+        "camera_purpose": camera_purpose,
+        "animated_element_count": element_count,
     }

--- a/skills/video-pipeline/image_prompt_engine/tests/test_camera_movement.py
+++ b/skills/video-pipeline/image_prompt_engine/tests/test_camera_movement.py
@@ -157,7 +157,8 @@ class TestValidateVideoPromptCameraChecks:
         camera_issues = [i for i in result["issues"] if "CAMERA REPEAT" in i]
         assert len(camera_issues) == 0
 
-    def test_missing_camera_detected(self):
+    def test_missing_camera_is_valid_static(self):
+        """No camera movement is valid — static is the default (Rule 2)."""
         prompt = (
             "Data nodes illuminate one by one from left to right. "
             "The central figure locks into position as surrounding data cascades "
@@ -166,8 +167,9 @@ class TestValidateVideoPromptCameraChecks:
             "glowing alone in a dead room."
         )
         result = validate_video_prompt(prompt)
+        # Static/unknown camera should NOT be flagged as an issue
         no_camera_issues = [i for i in result["issues"] if "NO CAMERA MOVEMENT" in i]
-        assert len(no_camera_issues) == 1
+        assert len(no_camera_issues) == 0
 
     def test_camera_returned_in_result(self):
         prompt = self._make_prompt("Lateral pan across the data wall")

--- a/skills/video-pipeline/tests/test_animation_prompt_engine.py
+++ b/skills/video-pipeline/tests/test_animation_prompt_engine.py
@@ -1,4 +1,12 @@
-"""Tests for animation_prompt_engine.py — animation prompt generation."""
+"""Tests for animation_prompt_engine.py — animation prompt generation.
+
+Tests cover:
+- Template structure integrity
+- Rule 1: Verb-first motion design (verb extraction)
+- Rule 2: Static camera default, camera only for REVEAL/SCALE/ISOLATION
+- Rule 3: Maximum 2 animated elements per prompt
+- Batch generation
+"""
 
 import pytest
 import sys
@@ -9,8 +17,16 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from animation_prompt_engine import (
     generate_animation_prompt,
     generate_prompts_for_segments,
+    extract_core_verb,
+    classify_camera_purpose,
+    count_animated_elements,
+    validate_max_actions,
     ANIMATION_TEMPLATES,
     UNIVERSAL_RULES,
+    CAMERA_PURPOSE_STATIC,
+    CAMERA_PURPOSE_REVEAL,
+    CAMERA_PURPOSE_SCALE,
+    CAMERA_PURPOSE_ISOLATION,
 )
 
 
@@ -38,14 +54,133 @@ class TestAnimationTemplateStructure:
             for content_type, motion in tmpl["motion_by_type"].items():
                 assert len(motion) > 20, f"Motion for {intensity}/{content_type} too short"
 
+    def test_all_templates_start_with_static(self):
+        """Rule 2: All templates should default to static camera."""
+        for intensity, tmpl in ANIMATION_TEMPLATES.items():
+            for content_type, motion in tmpl["motion_by_type"].items():
+                assert motion.startswith("Static wide shot"), (
+                    f"{intensity}/{content_type} doesn't start with 'Static wide shot': {motion[:50]}"
+                )
+
+    def test_low_templates_have_max_one_action(self):
+        """Rule 3: Low intensity templates should have at most 1 subject action."""
+        for content_type, motion in ANIMATION_TEMPLATES["low"]["motion_by_type"].items():
+            # Count sentences after "Static wide shot."
+            rest = motion.replace("Static wide shot.", "").strip()
+            sentences = [s.strip() for s in rest.split(".") if s.strip()]
+            assert len(sentences) <= 2, (
+                f"Low/{content_type} has {len(sentences)} action sentences (max 1 expected): {motion}"
+            )
+
+
+class TestVerbExtraction:
+    """Rule 1: Verb extraction from sentence text."""
+
+    def test_extracts_going_dark(self):
+        verb = extract_core_verb("Launch site after launch site going dark")
+        assert verb == "going dark"
+
+    def test_extracts_scattered(self):
+        verb = extract_core_verb("Scattered across hardened bunkers")
+        assert "scatter" in verb
+
+    def test_extracts_frozen(self):
+        verb = extract_core_verb("The count locks frozen at zero")
+        assert verb == "locks frozen"
+
+    def test_extracts_dont_matter(self):
+        verb = extract_core_verb("Your missiles don't matter")
+        assert verb == "don't matter"
+
+    def test_extracts_collapse(self):
+        verb = extract_core_verb("The entire network collapses overnight")
+        assert "collapse" in verb
+
+    def test_extracts_surge(self):
+        verb = extract_core_verb("Oil prices surge past $200 a barrel")
+        assert "surge" in verb
+
+    def test_empty_text_returns_empty(self):
+        assert extract_core_verb("") == ""
+
+    def test_no_verb_returns_empty_or_fallback(self):
+        result = extract_core_verb("The big red thing")
+        # May return empty or a fallback — should not crash
+        assert isinstance(result, str)
+
+    def test_phrasal_verb_takes_priority(self):
+        verb = extract_core_verb("Systems are shutting down rapidly")
+        assert verb == "shutting down"
+
+    def test_extracts_spread_across(self):
+        verb = extract_core_verb("Forces spread across the continent")
+        assert "spread" in verb
+
+
+class TestCameraPurpose:
+    """Rule 2: Camera purpose classification."""
+
+    def test_default_is_static(self):
+        assert classify_camera_purpose("The chart shows a decline") == CAMERA_PURPOSE_STATIC
+
+    def test_empty_text_is_static(self):
+        assert classify_camera_purpose("") == CAMERA_PURPOSE_STATIC
+
+    def test_reveal_keywords(self):
+        assert classify_camera_purpose("Behind the data reveals a hidden network") == CAMERA_PURPOSE_REVEAL
+
+    def test_scale_keywords(self):
+        assert classify_camera_purpose("Thousands of missiles spanning the entire continent") == CAMERA_PURPOSE_SCALE
+
+    def test_isolation_keywords(self):
+        assert classify_camera_purpose("Only one critical node remains active") == CAMERA_PURPOSE_ISOLATION
+
+    def test_generic_sentence_is_static(self):
+        assert classify_camera_purpose("Oil prices dropped last quarter") == CAMERA_PURPOSE_STATIC
+
+    def test_valid_purposes(self):
+        from animation_prompt_engine import VALID_CAMERA_PURPOSES
+        assert CAMERA_PURPOSE_STATIC in VALID_CAMERA_PURPOSES
+        assert CAMERA_PURPOSE_REVEAL in VALID_CAMERA_PURPOSES
+        assert CAMERA_PURPOSE_SCALE in VALID_CAMERA_PURPOSES
+        assert CAMERA_PURPOSE_ISOLATION in VALID_CAMERA_PURPOSES
+
+
+class TestAnimatedElementCount:
+    """Rule 3: Maximum 2 animated elements per prompt."""
+
+    def test_static_with_one_action(self):
+        prompt = "Static wide shot. Chart line draws itself left to right."
+        count = count_animated_elements(prompt)
+        assert count <= 2
+
+    def test_camera_plus_one_action(self):
+        prompt = "Slow push-in toward the central node. Connection lines snap and dissolve."
+        count = count_animated_elements(prompt)
+        assert count <= 2
+
+    def test_validate_max_actions_passes(self):
+        prompt = "Static wide shot. Route lines draw themselves across the map."
+        valid, count = validate_max_actions(prompt)
+        assert valid is True
+
+    def test_empty_prompt(self):
+        assert count_animated_elements("") == 0
+
+    def test_validate_max_actions_returns_count(self):
+        prompt = "Static wide shot. Labels hold steady."
+        valid, count = validate_max_actions(prompt)
+        assert isinstance(count, int)
+        assert isinstance(valid, bool)
+
 
 class TestGenerateAnimationPrompt:
     """Individual prompt generation."""
 
-    def _make_segment(self, intensity: str = "low") -> dict:
+    def _make_segment(self, intensity: str = "low", text: str = "Test segment text.") -> dict:
         return {
             "index": 0,
-            "text": "Test segment text.",
+            "text": text,
             "word_count": 25,
             "intensity": intensity,
         }
@@ -53,25 +188,24 @@ class TestGenerateAnimationPrompt:
     def test_low_intensity_prompt(self):
         seg = self._make_segment("low")
         prompt = generate_animation_prompt(seg, "B_data_terminal", 10)
-        assert "ambient" in prompt.lower() or "subtle" in prompt.lower()
+        assert "static" in prompt.lower()
         assert "10 seconds" in prompt
 
     def test_medium_intensity_prompt(self):
         seg = self._make_segment("medium")
         prompt = generate_animation_prompt(seg, "A_geographic_map", 10)
-        assert "reveal" in prompt.lower() or "active" in prompt.lower()
+        assert "static" in prompt.lower()
 
     def test_high_intensity_prompt(self):
         seg = self._make_segment("high")
         prompt = generate_animation_prompt(seg, "E_network_diagram", 6)
-        assert "dramatic" in prompt.lower()
+        assert "static" in prompt.lower()
         assert "6 seconds" in prompt
 
     def test_universal_rules_present(self):
         seg = self._make_segment("low")
         prompt = generate_animation_prompt(seg, "B_data_terminal", 10)
-        assert "no zoom or reframe" in prompt.lower() or "do not zoom" in prompt.lower()
-        assert "no human figures" in prompt.lower() or "No human" in prompt
+        assert "No human figures" in prompt
 
     def test_unknown_content_type_falls_back(self):
         seg = self._make_segment("medium")
@@ -105,6 +239,31 @@ class TestGenerateAnimationPrompt:
             prompt = generate_animation_prompt(seg, ct, 10)
             assert len(prompt) > 50, f"Empty prompt for {ct}"
 
+    def test_verb_extracted_in_prompt(self):
+        """Rule 1: Verb from sentence text should appear in the prompt."""
+        seg = self._make_segment("medium", text="Oil prices surge past $200")
+        prompt = generate_animation_prompt(seg, "B_data_terminal", 10)
+        assert "surge" in prompt.lower()
+
+    def test_static_camera_default(self):
+        """Rule 2: Default prompt should have static camera."""
+        seg = self._make_segment("medium", text="The chart shows a decline")
+        prompt = generate_animation_prompt(seg, "B_data_terminal", 10)
+        assert "static" in prompt.lower()
+
+    def test_camera_added_for_reveal(self):
+        """Rule 2: Camera motion added when sentence justifies REVEAL."""
+        seg = self._make_segment("medium", text="Behind the curtain reveals hidden assets")
+        prompt = generate_animation_prompt(seg, "B_data_terminal", 10)
+        # Should have camera motion (lateral pan revealing) instead of static
+        assert "reveal" in prompt.lower() or "pan" in prompt.lower()
+
+    def test_camera_added_for_scale(self):
+        """Rule 2: Camera motion added when sentence justifies SCALE."""
+        seg = self._make_segment("medium", text="Thousands of missiles across the entire globe")
+        prompt = generate_animation_prompt(seg, "A_geographic_map", 10)
+        assert "pull-back" in prompt.lower() or "scale" in prompt.lower()
+
 
 class TestGeneratePromptsForSegments:
     """Batch prompt generation."""
@@ -119,16 +278,15 @@ class TestGeneratePromptsForSegments:
 
     def test_respects_content_type_mapping(self):
         segments = [
-            {"index": 0, "text": "Map segment.", "word_count": 25, "intensity": "high"},
-            {"index": 1, "text": "Chart segment.", "word_count": 25, "intensity": "low"},
+            {"index": 0, "text": "Map explodes.", "word_count": 25, "intensity": "high"},
+            {"index": 1, "text": "Chart holds steady.", "word_count": 25, "intensity": "low"},
         ]
         content_types = {0: "A_geographic_map", 1: "B_data_terminal"}
         results = generate_prompts_for_segments(segments, content_types, 10)
 
-        # High intensity segment should have dramatic language
-        assert "dramatic" in results[0]["animation_prompt"].lower() or "high-energy" in results[0]["animation_prompt"].lower()
-        # Low intensity should have subtle language
-        assert "subtle" in results[1]["animation_prompt"].lower() or "ambient" in results[1]["animation_prompt"].lower()
+        # Both should have static camera (default)
+        assert "static" in results[0]["animation_prompt"].lower()
+        assert "static" in results[1]["animation_prompt"].lower()
 
     def test_result_has_required_fields(self):
         segments = [{"index": 0, "text": "Test.", "word_count": 25, "intensity": "medium"}]
@@ -137,6 +295,8 @@ class TestGeneratePromptsForSegments:
         assert "intensity" in results[0]
         assert "clip_duration" in results[0]
         assert "animation_prompt" in results[0]
+        assert "camera_purpose" in results[0]
+        assert "core_verb" in results[0]
 
     def test_per_segment_clip_duration_override(self):
         """Segments with their own clip_duration override the global default."""
@@ -149,3 +309,19 @@ class TestGeneratePromptsForSegments:
         assert results[0]["clip_duration"] == 6
         assert "10 seconds" in results[1]["animation_prompt"]
         assert results[1]["clip_duration"] == 10
+
+    def test_camera_purpose_in_results(self):
+        segments = [
+            {"index": 0, "text": "Behind the data reveals hidden truth.", "word_count": 25, "intensity": "medium"},
+            {"index": 1, "text": "Oil prices dropped.", "word_count": 25, "intensity": "low"},
+        ]
+        results = generate_prompts_for_segments(segments, clip_duration=10)
+        assert results[0]["camera_purpose"] == CAMERA_PURPOSE_REVEAL
+        assert results[1]["camera_purpose"] == CAMERA_PURPOSE_STATIC
+
+    def test_core_verb_in_results(self):
+        segments = [
+            {"index": 0, "text": "The network collapses overnight.", "word_count": 25, "intensity": "high"},
+        ]
+        results = generate_prompts_for_segments(segments, clip_duration=10)
+        assert "collapse" in results[0]["core_verb"]

--- a/skills/video-pipeline/tests/test_animation_prompt_engine.py
+++ b/skills/video-pipeline/tests/test_animation_prompt_engine.py
@@ -17,16 +17,23 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from animation_prompt_engine import (
     generate_animation_prompt,
     generate_prompts_for_segments,
+    generate_prompts_for_segments_async,
     extract_core_verb,
     classify_camera_purpose,
     count_animated_elements,
     validate_max_actions,
+    detect_verbless_streaks,
+    resolve_verb_motion_async,
+    clear_verb_motion_cache,
+    get_verb_motion_cache_stats,
+    _VERB_MOTION_MAP,
     ANIMATION_TEMPLATES,
     UNIVERSAL_RULES,
     CAMERA_PURPOSE_STATIC,
     CAMERA_PURPOSE_REVEAL,
     CAMERA_PURPOSE_SCALE,
     CAMERA_PURPOSE_ISOLATION,
+    VERBLESS_STREAK_THRESHOLD,
 )
 
 
@@ -356,3 +363,230 @@ class TestGeneratePromptsForSegments:
         ]
         results = generate_prompts_for_segments(segments, clip_duration=10)
         assert "collapse" in results[0]["core_verb"]
+
+    def test_verb_source_map_when_known(self):
+        """verb_source should be 'map' for verbs in _VERB_MOTION_MAP."""
+        segments = [
+            {"index": 0, "text": "Oil prices surge past $200.", "word_count": 25, "intensity": "high"},
+        ]
+        results = generate_prompts_for_segments(segments, clip_duration=10)
+        assert results[0]["verb_source"] == "map"
+
+    def test_verb_source_extracted_when_not_in_map(self):
+        """verb_source should be 'extracted' for verbs not in the map (no async client)."""
+        # Use a verb that's in _ACTION_VERB_PATTERN but NOT in _VERB_MOTION_MAP
+        # "launch" is in the pattern but not in the map
+        segments = [
+            {"index": 0, "text": "They launch the satellite.", "word_count": 25, "intensity": "medium"},
+        ]
+        results = generate_prompts_for_segments(segments, clip_duration=10)
+        assert results[0]["core_verb"] == "launch"
+        assert results[0]["verb_source"] == "extracted"
+
+    def test_verb_source_none_when_no_verb(self):
+        """verb_source should be 'none' when no verb extracted."""
+        segments = [
+            {"index": 0, "text": "The big red chart.", "word_count": 25, "intensity": "low"},
+        ]
+        results = generate_prompts_for_segments(segments, clip_duration=10)
+        assert results[0]["verb_source"] == "none"
+
+
+class TestVerblessStreakDetection:
+    """Warning when 3+ consecutive clips have no extracted verb."""
+
+    def test_no_streak_when_verbs_present(self):
+        results = [
+            {"segment_index": i, "core_verb": "surge" if i % 2 == 0 else ""}
+            for i in range(6)
+        ]
+        streaks = detect_verbless_streaks(results)
+        assert len(streaks) == 0
+
+    def test_detects_streak_of_3(self):
+        results = [
+            {"segment_index": 0, "core_verb": "surge"},
+            {"segment_index": 1, "core_verb": ""},
+            {"segment_index": 2, "core_verb": ""},
+            {"segment_index": 3, "core_verb": ""},
+            {"segment_index": 4, "core_verb": "collapse"},
+        ]
+        streaks = detect_verbless_streaks(results)
+        assert len(streaks) == 1
+        assert streaks[0]["start_index"] == 1
+        assert streaks[0]["end_index"] == 3
+        assert streaks[0]["length"] == 3
+
+    def test_detects_streak_at_end(self):
+        results = [
+            {"segment_index": 0, "core_verb": "surge"},
+            {"segment_index": 1, "core_verb": ""},
+            {"segment_index": 2, "core_verb": ""},
+            {"segment_index": 3, "core_verb": ""},
+        ]
+        streaks = detect_verbless_streaks(results)
+        assert len(streaks) == 1
+        assert streaks[0]["end_index"] == 3
+
+    def test_no_streak_with_2_consecutive(self):
+        results = [
+            {"segment_index": 0, "core_verb": ""},
+            {"segment_index": 1, "core_verb": ""},
+            {"segment_index": 2, "core_verb": "surge"},
+        ]
+        streaks = detect_verbless_streaks(results)
+        assert len(streaks) == 0
+
+    def test_detects_multiple_streaks(self):
+        results = [
+            {"segment_index": 0, "core_verb": ""},
+            {"segment_index": 1, "core_verb": ""},
+            {"segment_index": 2, "core_verb": ""},
+            {"segment_index": 3, "core_verb": "surge"},
+            {"segment_index": 4, "core_verb": ""},
+            {"segment_index": 5, "core_verb": ""},
+            {"segment_index": 6, "core_verb": ""},
+            {"segment_index": 7, "core_verb": ""},
+        ]
+        streaks = detect_verbless_streaks(results)
+        assert len(streaks) == 2
+
+    def test_empty_results(self):
+        assert detect_verbless_streaks([]) == []
+
+    def test_threshold_constant(self):
+        assert VERBLESS_STREAK_THRESHOLD == 3
+
+
+class TestHaikuFallback:
+    """Claude Haiku fallback for unknown verbs."""
+
+    def setup_method(self):
+        clear_verb_motion_cache()
+
+    def test_known_verb_returns_from_map(self):
+        """Known verbs should resolve from _VERB_MOTION_MAP without API call."""
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            resolve_verb_motion_async("surge", "Oil prices surge", None)
+        )
+        assert result == _VERB_MOTION_MAP["surge"]
+
+    def test_unknown_verb_without_client_returns_empty(self):
+        """Unknown verbs with no client should return empty string."""
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            resolve_verb_motion_async("hemorrhaging", "hemorrhaging cash", None)
+        )
+        assert result == ""
+
+    def test_cache_clear(self):
+        clear_verb_motion_cache()
+        stats = get_verb_motion_cache_stats()
+        assert stats["cache_size"] == 0
+        assert stats["haiku_calls"] == 0
+
+    def test_cache_stats_structure(self):
+        stats = get_verb_motion_cache_stats()
+        assert "cache_size" in stats
+        assert "haiku_calls" in stats
+        assert "haiku_input_tokens" in stats
+        assert "haiku_output_tokens" in stats
+        assert "estimated_cost_usd" in stats
+
+    def test_unknown_verb_with_mock_client(self):
+        """Mock client should resolve unknown verbs and cache them."""
+        import asyncio
+
+        class MockClient:
+            async def generate(self, **kwargs):
+                return "Values hemorrhage downward, red indicators flooding the chart."
+
+        client = MockClient()
+        result = asyncio.get_event_loop().run_until_complete(
+            resolve_verb_motion_async("hemorrhaging", "hemorrhaging cash", client)
+        )
+        assert "hemorrhage" in result.lower()
+        assert get_verb_motion_cache_stats()["haiku_calls"] == 1
+
+        # Second call should use cache, not API
+        result2 = asyncio.get_event_loop().run_until_complete(
+            resolve_verb_motion_async("hemorrhaging", "hemorrhaging cash", client)
+        )
+        assert result2 == result
+        assert get_verb_motion_cache_stats()["haiku_calls"] == 1  # still 1
+
+    def test_failing_client_returns_empty(self):
+        """A failing API call should return empty string, not crash."""
+        import asyncio
+
+        class FailingClient:
+            async def generate(self, **kwargs):
+                raise ConnectionError("API down")
+
+        client = FailingClient()
+        result = asyncio.get_event_loop().run_until_complete(
+            resolve_verb_motion_async("strangling", "strangling supply lines", client)
+        )
+        assert result == ""
+
+
+class TestAsyncBatchGeneration:
+    """Async batch generation with Haiku fallback."""
+
+    def setup_method(self):
+        clear_verb_motion_cache()
+
+    def test_async_returns_tuple(self):
+        """Async variant returns (results, streaks) tuple."""
+        import asyncio
+
+        segments = [
+            {"index": 0, "text": "Oil prices surge.", "word_count": 25, "intensity": "high"},
+        ]
+        results, streaks = asyncio.get_event_loop().run_until_complete(
+            generate_prompts_for_segments_async(segments, clip_duration=10)
+        )
+        assert len(results) == 1
+        assert isinstance(streaks, list)
+
+    def test_async_detects_verbless_streaks(self):
+        """Async variant should detect and return verbless streaks."""
+        import asyncio
+
+        segments = [
+            {"index": i, "text": "The big red thing.", "word_count": 25, "intensity": "low"}
+            for i in range(5)
+        ]
+        results, streaks = asyncio.get_event_loop().run_until_complete(
+            generate_prompts_for_segments_async(segments, clip_duration=10)
+        )
+        assert len(streaks) == 1
+        assert streaks[0]["length"] == 5
+
+    def test_async_uses_haiku_for_unknown_verbs(self):
+        """Async variant should call Haiku for verbs not in the map."""
+        import asyncio
+
+        class MockClient:
+            call_count = 0
+            async def generate(self, **kwargs):
+                MockClient.call_count += 1
+                return "Supply lines constrict and narrow."
+
+        # "strangling" is not in _VERB_MOTION_MAP but IS an -ing word
+        # We need to use a verb the regex will catch
+        segments = [
+            {"index": 0, "text": "They are strangling the supply lines.", "word_count": 25, "intensity": "medium"},
+        ]
+
+        client = MockClient()
+        results, streaks = asyncio.get_event_loop().run_until_complete(
+            generate_prompts_for_segments_async(
+                segments, clip_duration=10, anthropic_client=client,
+            )
+        )
+        # The verb might be caught by the fallback regex (-ing suffix)
+        # If so, it should have gone to haiku
+        if results[0]["core_verb"]:
+            assert results[0]["verb_source"] in ("map", "haiku", "extracted")

--- a/skills/video-pipeline/tests/test_animation_prompt_engine.py
+++ b/skills/video-pipeline/tests/test_animation_prompt_engine.py
@@ -239,11 +239,14 @@ class TestGenerateAnimationPrompt:
             prompt = generate_animation_prompt(seg, ct, 10)
             assert len(prompt) > 50, f"Empty prompt for {ct}"
 
-    def test_verb_extracted_in_prompt(self):
-        """Rule 1: Verb from sentence text should appear in the prompt."""
+    def test_verb_drives_motion_in_prompt(self):
+        """Rule 1: Verb from sentence text should drive the motion description."""
         seg = self._make_segment("medium", text="Oil prices surge past $200")
         prompt = generate_animation_prompt(seg, "B_data_terminal", 10)
-        assert "surge" in prompt.lower()
+        # The verb "surge" maps to spike/rockets motion, NOT the generic template
+        assert "spike" in prompt.lower() or "rocket" in prompt.lower()
+        # Should NOT contain the generic medium/B_data_terminal template text
+        assert "draws itself from left to right" not in prompt.lower()
 
     def test_static_camera_default(self):
         """Rule 2: Default prompt should have static camera."""
@@ -263,6 +266,34 @@ class TestGenerateAnimationPrompt:
         seg = self._make_segment("medium", text="Thousands of missiles across the entire globe")
         prompt = generate_animation_prompt(seg, "A_geographic_map", 10)
         assert "pull-back" in prompt.lower() or "scale" in prompt.lower()
+
+    def test_verb_motion_overrides_generic_template(self):
+        """Rule 1: Verb-driven motion replaces the generic content-type template."""
+        seg = self._make_segment("high", text="The network collapses overnight")
+        prompt = generate_animation_prompt(seg, "E_network_diagram", 10)
+        # Should use verb motion ("buckles inward") not generic HIGH/E template
+        assert "buckles" in prompt.lower() or "flatline" in prompt.lower()
+        # Should NOT contain the generic high/E_network_diagram text
+        assert "explosion of particles" not in prompt.lower()
+
+    def test_going_dark_produces_extinguish_motion(self):
+        """Rule 1: 'going dark' = lights extinguishing, not generic satellite template."""
+        seg = self._make_segment("high", text="Launch site after launch site going dark")
+        prompt = generate_animation_prompt(seg, "G_satellite", 10)
+        assert "extinguish" in prompt.lower()
+
+    def test_dont_matter_produces_dissolve_motion(self):
+        """Rule 1: 'don't matter' = dissolving to nothing, not generic comparison."""
+        seg = self._make_segment("high", text="Your missiles don't matter")
+        prompt = generate_animation_prompt(seg, "C_object_comparison", 10)
+        assert "dissolve" in prompt.lower() or "fade" in prompt.lower()
+
+    def test_no_verb_uses_content_type_template(self):
+        """Rule 1 fallback: when no verb found, generic template is used."""
+        seg = self._make_segment("medium", text="The big red chart.")
+        prompt = generate_animation_prompt(seg, "B_data_terminal", 10)
+        # Should use the generic medium/B_data_terminal template
+        assert "chart line draws itself" in prompt.lower() or "draws itself" in prompt.lower()
 
 
 class TestGeneratePromptsForSegments:


### PR DESCRIPTION
## Summary

Refactored animation prompt generation to enforce three core animation rules established in March 2026:
1. **Verb-first motion design** — animation derives from the sentence's core verb, not generic templates
2. **Static camera default** — camera only moves when justified by REVEAL, SCALE, or ISOLATION purposes
3. **Maximum 2 animated elements** — each prompt contains at most 2 distinct animated elements

## Key Changes

### animation_prompt_engine.py
- **Added verb extraction system** (`extract_core_verb()`) with:
  - Phrasal verb patterns (e.g., "going dark", "shutting down", "breaking apart")
  - Single-word action verb regex patterns
  - Stop-verb filtering to exclude generic auxiliaries
  - Fallback suffix-based detection for unknown verbs

- **Added camera purpose classification** (`classify_camera_purpose()`) that returns:
  - `REVEAL` — motion uncovers something new
  - `SCALE` — motion communicates size/quantity
  - `ISOLATION` — motion narrows focus on critical element
  - `STATIC` — default, no camera motion

- **Added animated element counting** (`count_animated_elements()`, `validate_max_actions()`) to enforce Rule 3

- **Created verb-to-motion mapping** (`_VERB_MOTION_MAP`) with 50+ verbs mapped to concrete motion descriptions that literally enact the verb (e.g., "going dark" → "lights extinguish one by one")

- **Refactored motion templates** to:
  - Start all templates with "Static wide shot"
  - Remove camera motion from default templates
  - Add camera motion only when `classify_camera_purpose()` justifies it
  - Simplify descriptions to focus on subject actions only

- **Updated `generate_animation_prompt()`** to:
  - Extract core verb from segment text
  - Look up verb in `_VERB_MOTION_MAP` to override generic template
  - Classify camera purpose and add motion only when justified
  - Return results with `core_verb` and `camera_purpose` fields

- **Updated `generate_prompts_for_segments()`** to include `camera_purpose` and `core_verb` in output

### anthropic_client.py
- Updated `generate_video_prompt()` system prompt to enforce the three animation rules
- Changed camera motion logic to use `classify_camera_purpose()` instead of always requesting motion
- Replaced narrative beat method with verb-first motion design instructions
- Clarified that camera is static by default

### prompt_builder.py
- Enhanced `validate_video_prompt()` to:
  - Import and use `classify_camera_purpose()` and `count_animated_elements()`
  - Return `camera_purpose` and `animated_element_count` in validation results
  - Validate against Rule 3 (max 2 animated elements)

### test_animation_prompt_engine.py
- Added comprehensive test coverage for all three rules:
  - `TestVerbExtraction` — 10 tests for verb extraction accuracy
  - `TestCameraPurpose` — 7 tests for camera purpose classification
  - `TestAnimatedElementCount` — 5 tests for element counting and validation
  - Updated existing tests to verify static camera default and verb-driven motion
  - Added tests for verb motion overriding generic templates
  - Added tests for specific verb behaviors (e.g., "going dark" → extinguish, "don't matter" → dissolve)

## Notable Implementation Details

- **Phrasal verbs take priority** over single-word verbs in extraction to capture multi-word actions accurately
- **Stop-verb filtering** prevents generic auxiliaries (is, are, do, get, etc.) from driving animation
- **Verb motion map** contains 50+ hand-crafted verb→motion mappings that literally enact the verb
- **Camera purpose keywords** are checked in order (REVEAL → SCALE → ISOLATION → STATIC) to classify intent
- **All motion templates** now explicitly start with "Static wide shot" to enforce the default
- **Backward compatible** — segments without extracted verbs fall back to generic content-type templates

https://claude.ai/code/session_01CUoQAPN2UNWuaEc6jTCt58