### PR TITLE
Fix render pipeline ignoring video clips — patch render_config with mp4 data

### DIFF
--- a/remotion-video/src/Main.tsx
+++ b/remotion-video/src/Main.tsx
@@ -3,7 +3,7 @@ import { Audio } from "@remotion/media";
 import { Scene } from "./Scene";
 import { useMemo } from "react";
 import { getWordsForScene } from "./transcripts";
-import { getSceneNumbers, getImageCountForScene, getSceneDurationFromConfig } from "./renderConfig";
+import { getSceneNumbers, getImageCountForScene, getSceneDurationFromConfig, getRenderScenesForScene } from "./renderConfig";
 
 interface MainProps {
     totalScenes?: number;
@@ -86,15 +86,25 @@ export const Main: React.FC<MainProps> = ({ totalScenes }) => {
             const imageCount = getImageCountForScene(sceneNumber) || 6;
             const sceneSfx = sfxByScene[sceneNumber] ?? {};
 
+            // Get render_config entries for this scene to detect video clips
+            const renderScenes = getRenderScenesForScene(sceneNumber);
+
             return {
                 sceneNumber,
                 audioFile: `Scene ${sceneNumber}.mp3`,
                 images: Array.from({ length: imageCount }, (_, j) => {
                     const imgIndex = j + 1;
                     const sfxData = sceneSfx[imgIndex];
+                    const padScene = String(sceneNumber).padStart(2, "0");
+                    const padIndex = String(imgIndex).padStart(2, "0");
+                    // Use .mp4 extension if render_config marks this entry as a video clip
+                    const rs = renderScenes.find(
+                        (s) => s.scene_number === sceneNumber && s.image_index === imgIndex,
+                    );
+                    const ext = rs?.type === "video" && rs.video_clip_path ? "mp4" : "png";
                     return {
                         index: imgIndex,
-                        file: `Scene_${String(sceneNumber).padStart(2, "0")}_${String(imgIndex).padStart(2, "0")}.png`,
+                        file: `Scene_${padScene}_${padIndex}.${ext}`,
                         sfx: sfxData?.sfx,
                         sfxVolume: sfxData?.sfxVolume,
                     };

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2790,6 +2790,41 @@ class VideoPipeline:
 
         print(f"  ✅ Assets downloaded: {audio_count} audio, {image_count} images, {video_clip_count} video clips")
 
+        # ── Patch render_config with video clip data ──────────────────
+        # The render_config from audio_sync marks all entries as type="image".
+        # For any downloaded .mp4 files, patch the matching render_config entry
+        # to type="video" so Remotion uses <OffthreadVideo> instead of <Img>.
+        if video_clip_count > 0 and "renderConfig" in props:
+            rc_data = props["renderConfig"]
+            import glob as _glob_mod
+            downloaded_mp4s = _glob_mod.glob(str(public_dir / "Scene_*.mp4"))
+            # Build set of (scene_number, image_index) from downloaded mp4 filenames
+            mp4_lookup: dict[tuple[int, int], str] = {}
+            for mp4_path in downloaded_mp4s:
+                mp4_name = os.path.basename(mp4_path)
+                # Parse Scene_XX_YY.mp4
+                match = re.match(r"Scene_(\d+)_(\d+)\.mp4", mp4_name)
+                if match:
+                    mp4_lookup[(int(match.group(1)), int(match.group(2)))] = mp4_name
+
+            patched = 0
+            for rc_entry in rc_data.get("scenes", []):
+                sn = rc_entry.get("scene_number", 0)
+                ii = rc_entry.get("image_index", 0)
+                mp4_name = mp4_lookup.get((sn, ii))
+                if mp4_name:
+                    rc_entry["type"] = "video"
+                    rc_entry["video_clip_path"] = mp4_name
+                    patched += 1
+
+            if patched:
+                # Rewrite render_config.json on disk and re-embed in props
+                rc_path = public_dir / "render_config.json"
+                with open(rc_path, "w") as f:
+                    json.dump(rc_data, f, indent=2)
+                props["renderConfig"] = rc_data
+                print(f"  🎬 Patched render_config: {patched} entries marked as video clips")
+
         # Build a map of SFX files already in Drive (sfx_*.mp3)
         # so we can download them directly instead of relying on
         # Airtable CDN URLs which expire after 2 hours.


### PR DESCRIPTION
AUDIT FINDINGS:
1. BLOCKER: pipeline.py downloads .mp4 video clips from Drive but never
   patches render_config.json to mark them as type="video". Audio sync
   generates all entries as type="image", so Remotion always renders
   static PNGs with Ken Burns — ignoring available video clips entirely.

2. BLOCKER: Main.tsx hardcodes .png extensions for all image filenames.
   Even when segments.ts has logic to return .mp4 filenames for video
   entries, the no-transcript fallback path always uses .png from the
   images prop built by Main.tsx.

FIXES:
- pipeline.py: After downloading assets from Drive, scan public/ for
  downloaded Scene_XX_YY.mp4 files and patch matching render_config
  entries with type="video" and video_clip_path. Rewrite both the
  on-disk render_config.json and the embedded props copy.

- Main.tsx: Check render_config entries when building the images array.
  Use .mp4 extension when the entry has type="video", ensuring both
  the transcript and no-transcript code paths receive correct filenames.

Note: render_video.py (standalone) already had this patching logic
(lines 438-501). The automated pipeline.py path was missing it.

All 249 tests pass (141 image_prompt_engine + 82 brief_translator + 26 integration).

https://claude.ai/code/session_01Rgqa7KgBy5xFcFDoRXjV8b