### PR TITLE
Add pluggable visual profile system for channel aesthetic swapping

### DIFF
--- a/skills/video-pipeline/animation_prompt_engine.py
+++ b/skills/video-pipeline/animation_prompt_engine.py
@@ -50,6 +50,54 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Profile integration — thin adapter with hardcoded fallbacks
+# ---------------------------------------------------------------------------
+
+def _get_profile():
+    """Return the active visual profile, or None."""
+    try:
+        from visual_profiles import load_profile
+        return load_profile()
+    except Exception:
+        return None
+
+
+def get_universal_rules() -> str:
+    """Get universal rules from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile and profile.animation.universal_rules:
+        return " ".join(profile.animation.universal_rules)
+    # Defer to module-level UNIVERSAL_RULES (defined below)
+    return UNIVERSAL_RULES
+
+
+def get_animation_templates() -> dict:
+    """Get animation templates from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile and profile.animation.motion_templates:
+        # Reconstruct the template dict from profile's flat motion_templates
+        templates = {}
+        for intensity in ("low", "medium", "high"):
+            desc = profile.animation.intensity_levels.get(intensity, "")
+            motion_by_type = {}
+            for key, val in profile.animation.motion_templates.items():
+                if key.startswith(f"{intensity}_"):
+                    content_key = key[len(f"{intensity}_"):]
+                    motion_by_type[content_key] = val
+            if motion_by_type:
+                templates[intensity] = {
+                    "description": desc,
+                    "prefix": "Static shot.",
+                    "suffix": "No camera movement.",
+                    "motion_by_type": motion_by_type,
+                }
+        if templates:
+            return templates
+    # Defer to module-level ANIMATION_TEMPLATES (defined below)
+    return ANIMATION_TEMPLATES
+
+
+# ---------------------------------------------------------------------------
 # Verb extraction — Rule 1 support
 # ---------------------------------------------------------------------------
 

--- a/skills/video-pipeline/audio_sync/config.py
+++ b/skills/video-pipeline/audio_sync/config.py
@@ -3,7 +3,23 @@ Configuration constants for the audio sync pipeline.
 
 Timing rules, thresholds, and Ken Burns defaults used across
 all audio_sync submodules.
+
+When a visual profile is loaded, Ken Burns config reads from the profile.
+Falls back to hardcoded defaults when no profile is available.
 """
+
+
+# ---------------------------------------------------------------------------
+# Profile integration — thin adapter with hardcoded fallbacks
+# ---------------------------------------------------------------------------
+
+def _get_profile():
+    """Return the active visual profile, or None."""
+    try:
+        from visual_profiles import load_profile
+        return load_profile()
+    except Exception:
+        return None
 
 # ---------------------------------------------------------------------------
 # Timing rules (seconds)
@@ -63,6 +79,31 @@ COMPOSITION_DIRECTION_MAP: dict[str, str] = {
     "overhead":      "slow_zoom_in",
     "low_angle":     "slow_tilt_up",
 }
+
+
+def get_ken_burns_presets() -> dict[str, dict]:
+    """Get Ken Burns presets from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile:
+        return profile.ken_burns.presets
+    return KEN_BURNS_PRESETS
+
+
+def get_composition_direction_map() -> dict[str, str]:
+    """Get composition direction map from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile:
+        return profile.ken_burns.direction_map
+    return COMPOSITION_DIRECTION_MAP
+
+
+def get_ken_burns_base_duration() -> float:
+    """Get Ken Burns base duration from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile:
+        return profile.ken_burns.base_duration
+    return KEN_BURNS_BASE_DURATION
+
 
 # ---------------------------------------------------------------------------
 # Render defaults

--- a/skills/video-pipeline/audio_sync/ken_burns_calculator.py
+++ b/skills/video-pipeline/audio_sync/ken_burns_calculator.py
@@ -14,6 +14,9 @@ from .config import (
     KEN_BURNS_PRESETS,
     COMPOSITION_DIRECTION_MAP,
     MIN_DISPLAY_SECONDS,
+    get_ken_burns_presets,
+    get_composition_direction_map,
+    get_ken_burns_base_duration,
 )
 
 
@@ -36,7 +39,12 @@ def calculate_ken_burns(
         Dict with ``direction``, ``speed_multiplier``, and the
         scale/offset keys from :data:`KEN_BURNS_PRESETS`.
     """
-    direction = COMPOSITION_DIRECTION_MAP.get(
+    # Use profile-aware getters (falls back to hardcoded defaults)
+    direction_map = get_composition_direction_map()
+    presets = get_ken_burns_presets()
+    base_duration = get_ken_burns_base_duration()
+
+    direction = direction_map.get(
         composition.lower() if composition else "",
         "slow_zoom_in",
     )
@@ -49,9 +57,9 @@ def calculate_ken_burns(
 
     # Speed multiplier — slower zoom for longer scenes
     safe_duration = max(display_duration, MIN_DISPLAY_SECONDS)
-    speed_multiplier = round(KEN_BURNS_BASE_DURATION / safe_duration, 3)
+    speed_multiplier = round(base_duration / safe_duration, 3)
 
-    config = KEN_BURNS_PRESETS.get(direction, KEN_BURNS_PRESETS["slow_zoom_in"]).copy()
+    config = presets.get(direction, presets.get("slow_zoom_in", {})).copy()
     config["direction"] = direction
     config["speed_multiplier"] = speed_multiplier
 
@@ -65,13 +73,14 @@ def assign_ken_burns(scenes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     Reads ``composition`` (or ``composition_hint``) and
     ``display_duration`` from each scene dict.
     """
+    base_duration = get_ken_burns_base_duration()
     for i, scene in enumerate(scenes):
         composition = (
             scene.get("composition")
             or scene.get("composition_hint")
             or "wide"
         )
-        display_duration = scene.get("display_duration", KEN_BURNS_BASE_DURATION)
+        display_duration = scene.get("display_duration", base_duration)
 
         scene["ken_burns"] = calculate_ken_burns(
             composition=composition,

--- a/skills/video-pipeline/clients/image_client.py
+++ b/skills/video-pipeline/clients/image_client.py
@@ -1,9 +1,49 @@
-"""Image generation client using Kie.ai API."""
+"""Image generation client using Kie.ai API.
+
+When a visual profile is loaded, model selection reads from the profile.
+Falls back to hardcoded defaults when no profile is available.
+"""
 
 import os
 import httpx
 from typing import Optional
 import asyncio
+
+
+def _get_profile():
+    """Return the active visual profile, or None."""
+    try:
+        from visual_profiles import load_profile
+        return load_profile()
+    except Exception:
+        return None
+
+
+def _scene_model_from_profile() -> str:
+    """Get scene model from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile:
+        return profile.image_gen.scene_model
+    return "z-image"
+
+
+def _thumbnail_model_from_profile() -> str:
+    """Get thumbnail model from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile:
+        return profile.image_gen.thumbnail_model
+    return "nano-banana-pro"
+
+
+def _valid_scene_models_from_profile() -> dict:
+    """Get valid scene models from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile and profile.raw.get("valid_scene_models"):
+        return profile.raw["valid_scene_models"]
+    return {
+        "z-image": "Z Image (default — holographic display, $0.004/img)",
+        "nano-banana-2": "Nano Banana 2 (legacy — reference support, $0.025/img)",
+    }
 
 
 class ImageClient:
@@ -18,19 +58,16 @@ class ImageClient:
     VEO_RECORD_INFO_URL = "https://api.kie.ai/api/v1/veo/record-info"
     VEO_1080P_URL = "https://api.kie.ai/api/v1/veo/get-1080p-video"
 
-    # Model routing (v4 — Holographic Intelligence Display)
-    SCENE_MODEL = "z-image"  # Z Image — primary scene images ($0.004/img)
-    THUMBNAIL_MODEL = "nano-banana-pro"  # Nano Banana Pro for thumbnails - text rendering
+    # Model routing — reads from profile with hardcoded fallbacks
+    SCENE_MODEL = _scene_model_from_profile()
+    THUMBNAIL_MODEL = _thumbnail_model_from_profile()
 
     # Alternative scene image models (hot-swappable via Slack !model command)
     ZIMAGE_MODEL = "z-image"  # Z Image — high-quality image generation
     NANO_BANANA_MODEL = "nano-banana-2"  # Nano Banana 2 — legacy/reference support
 
     # Valid scene image models for hot-swap validation
-    VALID_SCENE_MODELS = {
-        "z-image": "Z Image (default — holographic display, $0.004/img)",
-        "nano-banana-2": "Nano Banana 2 (legacy — reference support, $0.025/img)",
-    }
+    VALID_SCENE_MODELS = _valid_scene_models_from_profile()
 
     # Veo 3.1 models
     VEO_MODEL_FAST = "veo3_fast"  # Faster, lower cost

--- a/skills/video-pipeline/clients/style_engine.py
+++ b/skills/video-pipeline/clients/style_engine.py
@@ -3,10 +3,26 @@
 Re-exports all constants from image_prompt_engine.style_config and adds
 legacy compatibility constants for the animation pipeline.
 
+When a visual profile is loaded, style constants are read from the profile.
+Falls back to hardcoded defaults when no profile is available.
+
 Version: 4.0 (Mar 2026) — Holographic Intelligence Display system
 """
 
 from typing import List, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Profile integration — thin adapter with hardcoded fallbacks
+# ---------------------------------------------------------------------------
+
+def _get_profile():
+    """Return the active visual profile, or None."""
+    try:
+        from visual_profiles import load_profile
+        return load_profile()
+    except Exception:
+        return None
 
 # Import all holographic constants from the canonical source
 from image_prompt_engine.style_config import (
@@ -142,6 +158,22 @@ STYLE_ENGINE_SUFFIX = (
 )
 
 STYLE_ENGINE = f"{STYLE_ENGINE_PREFIX} {STYLE_ENGINE_SUFFIX}"
+
+
+def get_style_engine_prefix() -> str:
+    """Get style prefix from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile and profile.raw.get("style_engine_prefix"):
+        return profile.raw["style_engine_prefix"]
+    return STYLE_ENGINE_PREFIX
+
+
+def get_style_engine_suffix() -> str:
+    """Get style suffix from active profile or hardcoded default."""
+    profile = _get_profile()
+    if profile and profile.raw.get("style_engine_suffix"):
+        return profile.raw["style_engine_suffix"]
+    return STYLE_ENGINE_SUFFIX
 
 ANONYMOUS_FIGURE_STYLE = (
     "No human figures allowed. Use measurement icons or labeled silhouette "

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -4,6 +4,9 @@ Prompt builder for the Holographic Intelligence Display system.
 Takes scene descriptions and sequencing metadata, produces fully constructed
 image generation prompts for the holographic intelligence display aesthetic.
 
+When a visual profile is loaded, reads prefix/suffix/figure rules from the
+profile. Falls back to hardcoded defaults when no profile is available.
+
 Version: 4.0 (Mar 2026) — Holographic Intelligence Display system
 """
 
@@ -11,6 +14,19 @@ from __future__ import annotations
 
 import re
 from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Profile integration — thin adapter with hardcoded fallbacks
+# ---------------------------------------------------------------------------
+
+def _get_profile():
+    """Return the active visual profile, or None."""
+    try:
+        from visual_profiles import load_profile
+        return load_profile()
+    except Exception:
+        return None
 
 from .style_config import (
     ColorMood,
@@ -203,7 +219,10 @@ def build_prompt(
         mood_language = _apply_style_override(mood_language, image_style_override)
 
     # Assemble: [Framing] [Content] [Color Mood] [Suffix]
-    return f"{framing} {clean_desc}, {mood_language}{HOLOGRAPHIC_SUFFIX}"
+    # Use profile suffix if available, otherwise hardcoded default
+    profile = _get_profile()
+    suffix = profile.style_system.style_suffix if profile else HOLOGRAPHIC_SUFFIX
+    return f"{framing} {clean_desc}, {mood_language}{suffix}"
 
 
 def _format_from_value(value: str) -> DisplayFormat:

--- a/skills/video-pipeline/image_prompt_engine/style_config.py
+++ b/skills/video-pipeline/image_prompt_engine/style_config.py
@@ -4,10 +4,27 @@ Holographic Intelligence Display style configuration.
 Self-contained module defining all visual identity constants for the
 holographic intelligence display system. No cross-package imports.
 
+When a visual profile is loaded, constants are read from the profile.
+When no profile is available, hardcoded defaults are used (zero risk
+to production).
+
 Version: 4.0 (Mar 2026) — Holographic Intelligence Display system
 """
 
 from enum import Enum
+
+
+# ---------------------------------------------------------------------------
+# Profile integration — thin adapter with hardcoded fallbacks
+# ---------------------------------------------------------------------------
+
+def _get_profile():
+    """Return the active visual profile, or None."""
+    try:
+        from visual_profiles import load_profile
+        return load_profile()
+    except Exception:
+        return None
 
 
 # =============================================================================

--- a/skills/video-pipeline/visual_profiles/README.md
+++ b/skills/video-pipeline/visual_profiles/README.md
@@ -2,7 +2,8 @@
 
 Pluggable visual identity system for Economy FastForward. Each profile
 is a self-contained config that captures every aspect of the channel's
-visual identity.
+visual identity. Think of each profile as a "theme" a customer picks
+during onboarding on StoryEngine.
 
 ## Quick Start — Swap the Channel Aesthetic
 
@@ -16,11 +17,30 @@ export VISUAL_PROFILE=holographic_hud
 
 ## Available Profiles
 
-| Profile | Status | Aesthetic |
-|---------|--------|-----------|
-| `holographic_hud` | **Active (production)** | Dark ops center, holographic projections, zero humans |
-| `cinematic_dossier` | Reference | Prestige documentary, Rembrandt lighting, anonymous figures |
-| `clay_mannequin` | Reference | 3D clay mannequin dioramas, golden chest glow protagonist |
+| Profile | Status | Aesthetic | Cost Tier | Model |
+|---------|--------|-----------|-----------|-------|
+| `holographic_hud` | **Active (production)** | Dark ops center, holographic projections, zero humans | Low ($2-10) | Z Image |
+| `cinematic_dossier` | Standalone template | Prestige documentary, Rembrandt lighting, anonymous figures, 3-substyle system | Mid ($8-20) | Seed Dream 4.0 |
+| `clay_mannequin` | Standalone template | 3D clay mannequin dioramas, golden chest glow protagonist | Mid ($8-15) | Seed Dream 4.0 |
+
+### Holographic Intelligence Display
+- **3-variable system**: 8 content types x 5 display formats x 6 color moods
+- **Figures**: Zero human figures — only data displays and projections
+- **Animation**: Full 24-template motion system (low/medium/high x 8 content types)
+- **Best for**: Geopolitics, military analysis, economic data, investigative journalism
+
+### Cinematic Photorealistic Dossier
+- **3-substyle system**: Dossier (60%), Schema (22%), Echo (18%)
+- **Figures**: Anonymous humans with faces obscured by shadow/silhouette/backlighting
+- **Animation**: Disabled (static stills only)
+- **Rotation**: Echo only in acts 3-5, clusters of 2-3, post-echo returns to Dossier
+- **Best for**: Geopolitics, finance, corporate power, historical analysis
+
+### 3D Clay Mannequin Render
+- **Single style**: Composition cycling only, no substyles
+- **Figures**: Faceless ceramic mannequins, protagonist has golden amber chest glow
+- **Animation**: Selective (hero shots), glow intensity tracks narrative arc
+- **Best for**: Explainers, personal finance, social commentary, philosophy
 
 ## Creating a New Profile (< 5 minutes)
 
@@ -28,29 +48,60 @@ export VISUAL_PROFILE=holographic_hud
 2. Change the `profile_id`, `profile_name`, and `description`
 3. Update each section to match your new aesthetic:
    - `image_gen` — model selection and costs
-   - `style_system` — prefix/suffix/accent colors
+   - `style_system` — prefix/suffix/accent colors/substyles
    - `rotation` — composition constraints and act weights
-   - `figure_rules` — human presence rules
-   - `scene_description` — system prompt for LLM image descriptions
-   - `animation` — motion templates and intensity levels
+   - `figure_rules` — human presence rules, people word filters
+   - `scene_description` — system prompt + metaphor translation table
+   - `animation` — motion templates and intensity levels (or set to disabled)
    - `thumbnail` — thumbnail visual identity
    - `ken_burns` — camera motion defaults
-   - `raw` — enum-based configs (content types, display formats, color moods)
+   - `template_metadata` — StoryEngine display info, costs, preview prompts
+   - `raw` — enum-based configs, material vocabulary, valid models
 4. Register in `__init__.py`:
    ```python
    _PROFILE_MODULES["my_new_style"] = "visual_profiles.my_new_style"
    ```
 5. Test: `VISUAL_PROFILE=my_new_style python -m pytest image_prompt_engine/tests/`
 
+### Completeness Checklist
+
+Every section must be explicitly populated — no `None` values that cause
+fallback to another profile's defaults. If a section doesn't apply
+(e.g., animation disabled), set it explicitly:
+
+```python
+animation=AnimationConfig(
+    animation_model="disabled",
+    animation_cost_per_clip=0.0,
+    motion_templates={},
+    ...
+)
+```
+
+## Schema Sections
+
+| Section | Dataclass | What It Controls |
+|---------|-----------|------------------|
+| `image_gen` | `ImageGenConfig` | Scene/thumbnail model, resolution, cost |
+| `style_system` | `StyleSystemConfig` | Prefix, suffix, substyles, accent colors |
+| `rotation` | `RotationConfig` | Compositions, max consecutive rules, act weights |
+| `figure_rules` | `FigureRulesConfig` | Human/mannequin rules, people word filters |
+| `scene_description` | `SceneDescriptionConfig` | LLM system prompt, metaphor table |
+| `animation` | `AnimationConfig` | Motion templates, intensity levels, rules |
+| `thumbnail` | `ThumbnailConfig` | Thumbnail style, text rules, color presets |
+| `ken_burns` | `KenBurnsConfig` | Direction map, presets, base duration |
+| `template_metadata` | `TemplateMetadata` | StoryEngine display name, tags, costs |
+| `raw` | `dict` | Enum configs, material vocabulary, valid models |
+
 ## Architecture
 
 ```
 visual_profiles/
 ├── __init__.py              # Profile loader, registry, caching
-├── schema.py                # VisualProfile dataclass definition
-├── holographic_hud.py       # Current production profile
-├── cinematic_dossier.py     # Legacy: Dossier/Schema/Echo system
-├── clay_mannequin.py        # Legacy: 3D mannequin style
+├── schema.py                # VisualProfile + section dataclasses
+├── holographic_hud.py       # Current production profile (750+ lines)
+├── cinematic_dossier.py     # Standalone: Dossier/Schema/Echo system
+├── clay_mannequin.py        # Standalone: 3D mannequin dioramas
 └── README.md                # This file
 ```
 
@@ -79,3 +130,9 @@ hardcoded fallbacks for backward compatibility:
 
 **Backward compatibility**: If `load_profile()` returns `None`, every
 consumer falls back to its current hardcoded values. Zero risk to production.
+
+## Isolation Guarantee
+
+Each profile is 100% self-contained. Loading `cinematic_dossier` produces
+completely different visual output with zero references to holographic or
+clay styles leaking through. Verified by automated isolation tests.

--- a/skills/video-pipeline/visual_profiles/README.md
+++ b/skills/video-pipeline/visual_profiles/README.md
@@ -1,0 +1,81 @@
+# Visual Profiles
+
+Pluggable visual identity system for Economy FastForward. Each profile
+is a self-contained config that captures every aspect of the channel's
+visual identity.
+
+## Quick Start — Swap the Channel Aesthetic
+
+```bash
+# Option 1: Environment variable (per-channel default)
+export VISUAL_PROFILE=holographic_hud
+
+# Option 2: Airtable field (per-video override)
+# Set "Visual Profile" field on an Idea Concepts record
+```
+
+## Available Profiles
+
+| Profile | Status | Aesthetic |
+|---------|--------|-----------|
+| `holographic_hud` | **Active (production)** | Dark ops center, holographic projections, zero humans |
+| `cinematic_dossier` | Reference | Prestige documentary, Rembrandt lighting, anonymous figures |
+| `clay_mannequin` | Reference | 3D clay mannequin dioramas, golden chest glow protagonist |
+
+## Creating a New Profile (< 5 minutes)
+
+1. Copy `holographic_hud.py` as a starting template
+2. Change the `profile_id`, `profile_name`, and `description`
+3. Update each section to match your new aesthetic:
+   - `image_gen` — model selection and costs
+   - `style_system` — prefix/suffix/accent colors
+   - `rotation` — composition constraints and act weights
+   - `figure_rules` — human presence rules
+   - `scene_description` — system prompt for LLM image descriptions
+   - `animation` — motion templates and intensity levels
+   - `thumbnail` — thumbnail visual identity
+   - `ken_burns` — camera motion defaults
+   - `raw` — enum-based configs (content types, display formats, color moods)
+4. Register in `__init__.py`:
+   ```python
+   _PROFILE_MODULES["my_new_style"] = "visual_profiles.my_new_style"
+   ```
+5. Test: `VISUAL_PROFILE=my_new_style python -m pytest image_prompt_engine/tests/`
+
+## Architecture
+
+```
+visual_profiles/
+├── __init__.py              # Profile loader, registry, caching
+├── schema.py                # VisualProfile dataclass definition
+├── holographic_hud.py       # Current production profile
+├── cinematic_dossier.py     # Legacy: Dossier/Schema/Echo system
+├── clay_mannequin.py        # Legacy: 3D mannequin style
+└── README.md                # This file
+```
+
+## Profile Selection Order
+
+1. **Explicit argument** — `load_profile("cinematic_dossier")`
+2. **Airtable field** — `Visual Profile` on Idea Concepts record
+3. **Environment variable** — `VISUAL_PROFILE=holographic_hud`
+4. **Default** — `holographic_hud`
+
+## How Existing Code Uses Profiles
+
+Each existing file has a thin adapter that reads from the profile with
+hardcoded fallbacks for backward compatibility:
+
+| File | Reads From Profile |
+|------|--------------------|
+| `style_config.py` | `profile.style_system`, `profile.raw` |
+| `sequencer.py` | `profile.rotation` |
+| `prompt_builder.py` | `profile.style_system`, `profile.figure_rules` |
+| `style_engine.py` | `profile.raw` (legacy re-exports) |
+| `anthropic_client.py` | `profile.scene_description`, `profile.figure_rules` |
+| `image_client.py` | `profile.image_gen` |
+| `ken_burns_calculator.py` | `profile.ken_burns` |
+| `animation_prompt_engine.py` | `profile.animation` |
+
+**Backward compatibility**: If `load_profile()` returns `None`, every
+consumer falls back to its current hardcoded values. Zero risk to production.

--- a/skills/video-pipeline/visual_profiles/__init__.py
+++ b/skills/video-pipeline/visual_profiles/__init__.py
@@ -1,0 +1,124 @@
+"""Visual Profile loader and registry.
+
+Provides ``load_profile()`` — the single entry point for getting the
+active visual identity profile at runtime.
+
+Profile selection order:
+1. Explicit ``profile_id`` argument (per-video override from Airtable)
+2. ``VISUAL_PROFILE`` environment variable (per-channel default)
+3. Fallback: ``"holographic_hud"`` (current production style)
+
+Usage::
+
+    from visual_profiles import load_profile
+
+    profile = load_profile()              # uses env var or default
+    profile = load_profile("clay_mannequin")  # explicit override
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Optional
+
+from .schema import VisualProfile
+
+# Registry of known profile module names
+_PROFILE_MODULES: dict[str, str] = {
+    "holographic_hud": "visual_profiles.holographic_hud",
+    "cinematic_dossier": "visual_profiles.cinematic_dossier",
+    "clay_mannequin": "visual_profiles.clay_mannequin",
+}
+
+DEFAULT_PROFILE_ID = "holographic_hud"
+
+# Module-level cache — one profile loaded per pipeline run
+_profile_cache: dict[str, VisualProfile] = {}
+
+
+def load_profile(profile_id: Optional[str] = None) -> Optional[VisualProfile]:
+    """Load a visual profile by ID.
+
+    Args:
+        profile_id: Profile to load. If None, reads ``VISUAL_PROFILE``
+            env var, then falls back to ``"holographic_hud"``.
+
+    Returns:
+        The loaded ``VisualProfile``, or ``None`` if loading fails
+        (callers should fall back to hardcoded defaults).
+    """
+    resolved_id = (
+        profile_id
+        or os.getenv("VISUAL_PROFILE", "").strip()
+        or DEFAULT_PROFILE_ID
+    )
+
+    # Check cache first
+    if resolved_id in _profile_cache:
+        return _profile_cache[resolved_id]
+
+    try:
+        module_path = _PROFILE_MODULES.get(resolved_id)
+        if not module_path:
+            print(f"[visual_profiles] Unknown profile: {resolved_id}")
+            return None
+
+        mod = importlib.import_module(module_path)
+        profile: VisualProfile = getattr(mod, "PROFILE", None)
+
+        if profile is None:
+            print(f"[visual_profiles] Module {module_path} has no PROFILE attribute")
+            return None
+
+        _profile_cache[resolved_id] = profile
+        return profile
+
+    except Exception as exc:
+        print(f"[visual_profiles] Failed to load profile '{resolved_id}': {exc}")
+        return None
+
+
+def get_profile_or_default(profile_id: Optional[str] = None) -> Optional[VisualProfile]:
+    """Load a profile, trying default if the requested one fails.
+
+    Unlike ``load_profile()``, this tries the default profile as a
+    secondary fallback when a specific profile_id fails to load.
+    """
+    profile = load_profile(profile_id)
+    if profile is not None:
+        return profile
+
+    # If a specific profile was requested and failed, try default
+    if profile_id and profile_id != DEFAULT_PROFILE_ID:
+        return load_profile(DEFAULT_PROFILE_ID)
+
+    return None
+
+
+def clear_cache() -> None:
+    """Clear the profile cache (useful for testing)."""
+    _profile_cache.clear()
+
+
+def list_profiles() -> list[str]:
+    """Return all registered profile IDs."""
+    return list(_PROFILE_MODULES.keys())
+
+
+def register_profile(profile_id: str, module_path: str) -> None:
+    """Register a new profile module at runtime."""
+    _PROFILE_MODULES[profile_id] = module_path
+    # Invalidate cache for this profile
+    _profile_cache.pop(profile_id, None)
+
+
+__all__ = [
+    "load_profile",
+    "get_profile_or_default",
+    "clear_cache",
+    "list_profiles",
+    "register_profile",
+    "VisualProfile",
+    "DEFAULT_PROFILE_ID",
+]

--- a/skills/video-pipeline/visual_profiles/cinematic_dossier.py
+++ b/skills/video-pipeline/visual_profiles/cinematic_dossier.py
@@ -1,11 +1,16 @@
-"""Cinematic Dossier — Legacy reference profile (pre-Mar 2026).
+"""Cinematic Dossier — The original 3-style documentary system.
 
-The original 3-style system (Dossier/Schema/Echo) used for the Economy
-FastForward YouTube channel. Preserved for reference and potential reuse.
+The Dossier/Schema/Echo visual system that defined Economy FastForward's
+first era. Prestige documentary photography with three visual substyles
+rotating across a 6-act narrative structure.
 
-Aesthetic: Prestige documentary photography with Rembrandt lighting,
-anonymous human figures with faces obscured by shadow/silhouette/backlighting,
-desaturated palette with accent colors.
+Aesthetic: Dark moody photorealism. Rembrandt lighting, desaturated palette,
+accent color pops. Anonymous human figures with faces obscured by shadow,
+silhouette, or backlighting. Body language conveys emotion.
+
+This is a COMPLETE, STANDALONE profile. Loading it as the active profile
+produces a fully different visual output with zero holographic or clay
+style leakage.
 """
 
 from visual_profiles.schema import (
@@ -17,13 +22,54 @@ from visual_profiles.schema import (
     SceneDescriptionConfig,
     StyleSystemConfig,
     SubstyleConfig,
+    TemplateMetadata,
     ThumbnailConfig,
     VisualProfile,
 )
 
 
 # =============================================================================
-# Style Prefix / Suffix (the Dossier era)
+# Section 1: Identity
+# =============================================================================
+
+_IDENTITY = dict(
+    profile_id="cinematic_dossier",
+    profile_name="Cinematic Photorealistic Dossier",
+    description=(
+        "Prestige documentary photography. Rembrandt lighting, anonymous "
+        "human figures with faces obscured by shadow/silhouette/backlighting. "
+        "3-style system: Dossier (60%), Schema (22%), Echo (18%). "
+        "Best for geopolitics, finance, corporate power, historical analysis."
+    ),
+    version="3.0",
+    channel="economy_fastforward",
+)
+
+
+# =============================================================================
+# Section 2: Image Generation Config
+# =============================================================================
+
+_IMAGE_GEN = ImageGenConfig(
+    scene_model="seedream-v4",
+    scene_model_params={
+        "aspect_ratio": "16:9",
+        "resolution": "1K",
+        "output_format": "png",
+    },
+    scene_cost_per_image=0.025,
+    thumbnail_model="nano-banana-pro",
+    thumbnail_model_params={
+        "aspect_ratio": "16:9",
+        "resolution": "2K",
+        "output_format": "png",
+    },
+    thumbnail_cost_per_image=0.04,
+)
+
+
+# =============================================================================
+# Section 3: Style System — Dossier / Schema / Echo
 # =============================================================================
 
 _DOSSIER_PREFIX = (
@@ -32,190 +78,410 @@ _DOSSIER_PREFIX = (
     "film stock, 16:9 cinematic composition."
 )
 
-_DOSSIER_SUFFIX = (
-    "Anonymous human figures with faces obscured by shadow silhouette or "
+# Per-substyle suffixes — appended AFTER scene description
+_DOSSIER_SUBSTYLE_SUFFIX = (
+    "cinematic photorealistic, single dramatic light source, Rembrandt lighting, "
+    "deep shadows, desaturated color palette with {accent_color} accent, "
+    "shallow depth of field, subtle film grain, dark moody atmosphere, "
+    "documentary photography style, shot on Arri Alexa, 16:9"
+)
+
+_SCHEMA_SUBSTYLE_SUFFIX = (
+    "cinematic photorealistic background with translucent glowing data overlay, "
+    "thin luminous {accent_color} connection lines and node points, "
+    "Bloomberg terminal meets surveillance system aesthetic, dark atmosphere, "
+    "minimal and elegant, deep blacks with light-emitting data elements, "
+    "subtle film grain, 16:9"
+)
+
+_ECHO_SUBSTYLE_SUFFIX = (
+    "photorealistic with subtle oil painting texture, dramatic chiaroscuro "
+    "period-appropriate lighting, {accent_color} tones, "
+    "period-accurate costume and architecture detail, deep shadows, "
+    "slightly soft focus with painterly grain, historical documentary style, "
+    "heavy film grain, atmospheric and evocative, 16:9"
+)
+
+_DOSSIER_GENERAL_SUFFIX = (
+    ", anonymous human figures with faces obscured by shadow silhouette or "
     "backlighting, cinematic depth of field, no text overlays, "
     "subtle ambient light, photorealistic rendering, 16:9 aspect ratio"
 )
 
+_STYLE_SYSTEM = StyleSystemConfig(
+    style_prefix=_DOSSIER_PREFIX,
+    style_suffix=_DOSSIER_GENERAL_SUFFIX,
+    substyles={
+        "dossier": SubstyleConfig(
+            name="Dossier",
+            weight=0.60,
+            suffix=_DOSSIER_SUBSTYLE_SUFFIX,
+            description=(
+                "Investigation, corporate, power. Photorealistic with Rembrandt "
+                "lighting and accent color highlights. The workhorse style — "
+                "60% of all images."
+            ),
+        ),
+        "schema": SubstyleConfig(
+            name="Schema",
+            weight=0.22,
+            suffix=_SCHEMA_SUBSTYLE_SUFFIX,
+            description=(
+                "Systems, networks, data. Glowing translucent data overlays on "
+                "dark photorealistic backgrounds. Bloomberg terminal aesthetic."
+            ),
+        ),
+        "echo": SubstyleConfig(
+            name="Echo",
+            weight=0.18,
+            suffix=_ECHO_SUBSTYLE_SUFFIX,
+            description=(
+                "Backstory, historical context. Painterly texture over photorealism, "
+                "candlelit warm tones, period-accurate detail. Only in acts 3-5."
+            ),
+        ),
+    },
+    accent_colors={
+        "geopolitical": "cold teal",
+        "ai_tech": "cold teal",
+        "corporate_power": "cold teal",
+        "surveillance": "cold teal",
+        "financial": "warm amber",
+        "economic": "warm amber",
+        "historical_power": "warm amber",
+        "old_money": "warm amber",
+        "conflict": "muted crimson",
+        "warfare": "muted crimson",
+        "political_violence": "muted crimson",
+        "military": "muted crimson",
+        "default": "cold teal",
+    },
+    accent_color_to_mood={
+        "cold teal": "cold teal",
+        "warm amber": "warm amber",
+        "muted crimson": "muted crimson",
+        "muted green": "muted green",
+    },
+    category_to_mood={
+        "geopolitical": "cold teal",
+        "ai_tech": "cold teal",
+        "corporate_power": "warm amber",
+        "surveillance": "cold teal",
+        "economic": "warm amber",
+        "financial": "warm amber",
+        "historical_power": "warm amber",
+        "old_money": "warm amber",
+        "conflict": "muted crimson",
+        "warfare": "muted crimson",
+        "political_violence": "muted crimson",
+        "military": "muted crimson",
+        "markets": "warm amber",
+        "growth": "warm amber",
+        "trade": "cold teal",
+    },
+)
+
+
+# =============================================================================
+# Section 4: Rotation & Composition
+# =============================================================================
+
+_ROTATION = RotationConfig(
+    compositions=[
+        "wide", "medium", "closeup", "environmental",
+        "portrait", "overhead", "low_angle",
+    ],
+    # Dossier uses max_consecutive_same_style (mapped to content_type field)
+    max_consecutive_same_content_type=4,
+    max_consecutive_same_format=2,
+    max_consecutive_same_palette=3,
+    max_consecutive_close_up=1,
+    act_weights={
+        "act1": {"dossier": 0.80, "schema": 0.20, "echo": 0.00},
+        "act2": {"dossier": 0.65, "schema": 0.30, "echo": 0.05},
+        "act3": {"dossier": 0.55, "schema": 0.20, "echo": 0.25},
+        "act4": {"dossier": 0.50, "schema": 0.20, "echo": 0.30},
+        "act5": {"dossier": 0.45, "schema": 0.35, "echo": 0.20},
+        "act6": {"dossier": 0.75, "schema": 0.25, "echo": 0.00},
+    },
+    scene_expander_style_distribution={
+        1: {"dossier": 90, "schema": 10, "echo": 0},
+        2: {"dossier": 70, "schema": 30, "echo": 0},
+        3: {"dossier": 45, "schema": 20, "echo": 35},
+        4: {"dossier": 35, "schema": 20, "echo": 45},
+        5: {"dossier": 50, "schema": 35, "echo": 15},
+        6: {"dossier": 65, "schema": 35, "echo": 0},
+    },
+)
+
+
+# =============================================================================
+# Section 5: Figure Rules — anonymous human figures
+# =============================================================================
+
+_FIGURE_RULES = FigureRulesConfig(
+    allow_human_figures=True,
+    allow_silhouettes=True,
+    allow_mannequins=False,
+    protagonist_config=None,
+    negative_prompt_suffix=(
+        "no visible recognizable faces of real named public figures, "
+        "faces always obscured by shadow silhouette or backlighting, "
+        "body language conveys emotion instead of facial expression"
+    ),
+    people_words=[],  # People are ALLOWED in dossier — no filtering needed
+    people_replacements=[],  # No auto-replacement — people stay in prompts
+)
+
+
+# =============================================================================
+# Section 6: Scene Description Rules
+# =============================================================================
+
+_SCENE_DESCRIPTION = SceneDescriptionConfig(
+    system_prompt=(
+        "You are a visual director creating cinematic photorealistic documentary "
+        "image prompts for a YouTube documentary channel.\n\n"
+        "Every prompt should feel like a still from a prestige documentary — "
+        "dark moody atmosphere, desaturated palette, Rembrandt lighting with "
+        "deep shadows.\n\n"
+        "HUMAN FIGURES: Show real people, real places, real objects. Anonymous "
+        "figures with faces obscured by shadow, silhouette, or backlighting. "
+        "Body language and posture convey emotion — not facial expressions.\n\n"
+        "NEVER visualize metaphors literally. When the script says 'markets "
+        "are bleeding' — show a trader at a terminal with red screens, NOT "
+        "literal blood. When it says 'empire crumbling' — show the actual "
+        "institution under pressure, NOT rubble.\n\n"
+        "FILMABLE SCENE RULE: Every image must depict a scene a documentary "
+        "crew could actually photograph. Real locations, real lighting, real "
+        "people in real situations. No fantasy, no sci-fi, no impossible physics.\n\n"
+        "VISUAL STORYTELLING TABLE:\n"
+        "| Abstract Concept | DO Show | DON'T Show |\n"
+        "| Money flowing | Trading floor, vault, wire transfer screen | Literal river of money |\n"
+        "| Power consolidation | Corporate HQ, signing ceremony, closed doors | Giant hand crushing things |\n"
+        "| Economic pressure | Empty store shelves, price tags, long queues | Abstract pressure waves |\n"
+        "| Military force | Fleet at sea, weapon systems, command center | Abstract force arrows |\n"
+        "| Political tension | Diplomatic table, embassy exterior, protests | Lightning bolts between leaders |\n"
+        "| Surveillance state | CCTV cameras, server rooms, data centers | Giant eye in the sky |\n"
+        "| Market crash | Trading floor chaos, red screens, empty desks | Literal falling graph |\n"
+        "| Historical parallel | Period architecture, vintage documents, old photos | Time portal |\n"
+    ),
+    metaphor_translation_table={
+        "money_flow": "Show the institution: central bank vault, trading floor terminals, wire transfer screens",
+        "power_consolidation": "Show the person/building: corporate HQ, signing ceremony, closed-door meeting",
+        "economic_pressure": "Show the evidence: empty shelves, price tags, queues, shuttered storefronts",
+        "military_force": "Show the hardware: fleet at sea, command center, satellite imagery",
+        "political_tension": "Show the setting: diplomatic table, embassy exterior, protest crowds from behind",
+        "surveillance_state": "Show the infrastructure: CCTV arrays, server rooms, data center corridors",
+        "market_crash": "Show the aftermath: trading floor chaos, red terminal screens, empty desks",
+        "historical_parallel": "Show the period: vintage architecture, aged documents, sepia-toned locations",
+        "corruption": "Show the setting: luxury office, offshore bank exterior, document shredder",
+        "inequality": "Show the contrast: penthouse vs slum, private jet vs bus stop, boardroom vs factory floor",
+    },
+    quantitative_requirement=False,
+    text_in_image_rules=(
+        "no narrative text in images — only naturally occurring text visible in "
+        "the scene (street signs, terminal displays, document headers)"
+    ),
+)
+
+
+# =============================================================================
+# Section 7: Animation — DISABLED for Dossier style
+# =============================================================================
+
+_ANIMATION = AnimationConfig(
+    animation_model="disabled",
+    animation_cost_per_clip=0.0,
+    motion_templates={},
+    motion_base_rule="Animation not used with cinematic dossier style",
+    intensity_levels={},
+    universal_rules=[],
+    banned_motion_words=[],
+    emotional_motion_dict={},
+)
+
+
+# =============================================================================
+# Section 8: Thumbnail Identity
+# =============================================================================
+
+_THUMBNAIL = ThumbnailConfig(
+    thumbnail_style="bright_editorial_illustration",
+    thumbnail_text_color="#FFD700",
+    thumbnail_text_style="bold block capitals, thick black outline",
+    thumbnail_max_words_per_line=4,
+    thumbnail_max_lines=2,
+    thumbnail_background="simple, recognizable, reads at 160x90px",
+    thumbnail_palette_max_colors=4,
+    thumbnail_prompt_templates={},  # Templates in thumbnail_generator/templates.py
+    thumbnail_color_presets={
+        "geopolitics": ["#1a5c6b", "#FFD700", "#333", "#fff"],
+        "finance": ["#b8860b", "#FFD700", "#333", "#fff"],
+        "conflict": ["#8b1a1a", "#FFD700", "#333", "#fff"],
+    },
+    thumbnail_system_prompt="",  # Full prompt in anthropic_client.py
+    thumbnail_figure_rules=(
+        "Generic building silhouette or symbolic hand gesture. "
+        "No named political figures — no recognizable faces."
+    ),
+)
+
+
+# =============================================================================
+# Section 9: Ken Burns Config
+# =============================================================================
+
+_KEN_BURNS = KenBurnsConfig(
+    direction_map={
+        "wide": "slow_zoom_in",
+        "medium": "slow_pan_right",
+        "closeup": "slow_zoom_out",
+        "environmental": "slow_pan_left",
+        "portrait": "slow_zoom_in",
+        "overhead": "slow_zoom_in",
+        "low_angle": "slow_tilt_up",
+    },
+    presets={
+        "slow_zoom_in": {"start_scale": 1.0, "end_scale": 1.15},
+        "slow_zoom_out": {"start_scale": 1.15, "end_scale": 1.0},
+        "slow_pan_right": {"start_x_offset": -40, "end_x_offset": 40},
+        "slow_pan_left": {"start_x_offset": 40, "end_x_offset": -40},
+        "slow_tilt_up": {"start_y_offset": 30, "end_y_offset": -30},
+    },
+    base_duration=11.0,
+    pan_alternates={
+        "slow_pan_right": "slow_pan_left",
+        "slow_pan_left": "slow_pan_right",
+    },
+)
+
+
+# =============================================================================
+# Section 10: Template Metadata (StoryEngine)
+# =============================================================================
+
+_TEMPLATE_METADATA = TemplateMetadata(
+    display_name="Cinematic Intelligence Briefing",
+    category="documentary",
+    tags=["dark", "cinematic", "geopolitics", "finance", "thriller", "documentary", "Rembrandt"],
+    description=(
+        "Dark, moody photorealistic stills with Rembrandt lighting. Three visual "
+        "substyles (Dossier, Schema, Echo) create a documentary thriller aesthetic. "
+        "Anonymous human figures with obscured faces convey emotion through body "
+        "language. Best for: geopolitics, finance, corporate power, historical analysis."
+    ),
+    preview_prompts=[
+        (
+            "A lone figure in a dark tailored suit standing at the end of a "
+            "rain-slicked corridor in a government building, single overhead "
+            "light casting Rembrandt shadows, cold teal accent on the wet floor "
+            "reflections, cinematic depth of field, shot on Arri Alexa, 16:9"
+        ),
+        (
+            "Dark photorealistic aerial view of a sprawling financial district "
+            "at night, overlaid with translucent glowing cold teal connection "
+            "lines linking major bank towers, Bloomberg terminal meets "
+            "surveillance aesthetic, subtle film grain, 16:9"
+        ),
+        (
+            "A Renaissance-era council chamber, heavy wooden table covered in "
+            "maps and wax-sealed correspondence, dramatic chiaroscuro candlelight, "
+            "warm amber tones, period-accurate costume detail on anonymous "
+            "robed figures, oil painting texture, heavy film grain, 16:9"
+        ),
+    ],
+    best_for=["geopolitics", "finance", "corporate power", "historical analysis"],
+    cost_tier="mid",
+    estimated_cost_per_video={
+        "10min_no_animation": 4.50,
+        "10min_with_animation": 12.00,
+        "20min_no_animation": 8.00,
+        "20min_with_animation": 20.00,
+    },
+)
+
+
+# =============================================================================
+# Section 11: Raw data
+# =============================================================================
+
+_RAW = {
+    "style_engine_prefix": _DOSSIER_PREFIX,
+    "style_engine_suffix": _DOSSIER_GENERAL_SUFFIX,
+    # Dossier rotation rules (for sequencer compatibility)
+    "substyle_rotation_rules": {
+        "max_consecutive_same_style": 4,
+        "echo_allowed_acts": [3, 4, 5],
+        "echo_cluster_min": 2,
+        "echo_cluster_max": 3,
+        "post_echo_must_be": "dossier",
+        "schema_max_consecutive": 1,
+        "schema_max_consecutive_act5": 2,
+        "first_image_must_be": "dossier",
+        "last_image_must_be": "dossier",
+    },
+    # Accent color hex values
+    "accent_color_hex": {
+        "cold teal": "#1a5c6b",
+        "warm amber": "#b8860b",
+        "muted crimson": "#8b1a1a",
+        "muted green": "#2d5a27",
+    },
+    # Valid scene models
+    "valid_scene_models": {
+        "seedream-v4": "Seed Dream 4.0 (default — cinematic dossier, $0.025/img)",
+        "nano-banana-2": "Nano Banana 2 (alternative — reference support, $0.025/img)",
+    },
+    # Material vocabulary for dossier style
+    "material_vocabulary": {
+        "premium": [
+            "mahogany desk", "leather briefcase", "gold cufflinks",
+            "crystal decanter", "silk tie", "brass desk lamp",
+        ],
+        "institutional": [
+            "concrete government building", "steel filing cabinets",
+            "fluorescent-lit corridor", "security checkpoint",
+            "reinforced vault door", "diplomatic conference table",
+        ],
+        "historical": [
+            "aged parchment", "wax seal", "oil painting frame",
+            "iron chandelier", "stone archway", "wooden ship hull",
+        ],
+        "data": [
+            "Bloomberg terminal", "surveillance monitor wall",
+            "fiber optic cables", "server rack LEDs",
+            "radar display", "encrypted communication device",
+        ],
+    },
+    # Prompt word budget
+    "prompt_min_words": 62,
+    "prompt_max_words": 84,
+    # Default config values
+    "default_config": {
+        "image_duration_seconds": 11,
+        "video_duration_seconds": 1500,
+        "total_images": 120,
+        "images_per_scene": 6,
+        "scenes_per_video": 20,
+    },
+}
+
+
+# =============================================================================
+# PROFILE — the single export
+# =============================================================================
 
 PROFILE = VisualProfile(
-    # Identity
-    profile_id="cinematic_dossier",
-    profile_name="Cinematic Photorealistic Dossier",
-    description=(
-        "Prestige documentary photography. Rembrandt lighting, anonymous "
-        "human figures with faces obscured by shadow/silhouette/backlighting. "
-        "3-style system: Dossier (60%), Schema (22%), Echo (18%)."
-    ),
-    version="3.0",
-    channel="economy_fastforward",
-
-    # Image generation
-    image_gen=ImageGenConfig(
-        scene_model="nano-banana-2",
-        scene_model_params={
-            "aspect_ratio": "16:9",
-            "resolution": "1K",
-            "output_format": "png",
-        },
-        scene_cost_per_image=0.025,
-        thumbnail_model="nano-banana-pro",
-        thumbnail_model_params={
-            "aspect_ratio": "16:9",
-            "resolution": "2K",
-            "output_format": "png",
-        },
-        thumbnail_cost_per_image=0.09,
-    ),
-
-    # Style system
-    style_system=StyleSystemConfig(
-        style_prefix=_DOSSIER_PREFIX,
-        style_suffix=_DOSSIER_SUFFIX,
-        substyles={
-            "dossier": SubstyleConfig(
-                name="Dossier",
-                weight=0.60,
-                suffix=(
-                    "Rembrandt lighting, cinematic photorealism, "
-                    "deep shadows and warm accent color highlights"
-                ),
-                description="Investigation, corporate, power. Photorealistic with accent colors.",
-            ),
-            "schema": SubstyleConfig(
-                name="Schema",
-                weight=0.22,
-                suffix=(
-                    "Data overlay aesthetic, glowing nodes on dark background, "
-                    "HUD elements and wireframe overlays"
-                ),
-                description="Systems, networks, data. Glowing data overlays on dark backgrounds.",
-            ),
-            "echo": SubstyleConfig(
-                name="Echo",
-                weight=0.18,
-                suffix=(
-                    "Painterly historical texture, candlelit warm tones, "
-                    "oil painting meets documentary photography"
-                ),
-                description="Backstory, historical context. Painterly, candlelit aesthetic.",
-            ),
-        },
-        accent_colors={
-            "geopolitical": "cold teal",
-            "financial": "warm amber",
-            "conflict": "muted crimson",
-            "default": "cold teal",
-        },
-        accent_color_to_mood={
-            "cold teal": "cold teal",
-            "warm amber": "warm amber",
-            "muted crimson": "muted crimson",
-            "muted green": "muted green",
-        },
-        category_to_mood={
-            "geopolitical": "cold teal",
-            "ai_tech": "cold teal",
-            "corporate_power": "warm amber",
-            "surveillance": "cold teal",
-            "economic": "warm amber",
-            "financial": "warm amber",
-            "historical_power": "warm amber",
-            "conflict": "muted crimson",
-            "warfare": "muted crimson",
-            "military": "muted crimson",
-        },
-    ),
-
-    # Rotation
-    rotation=RotationConfig(
-        compositions=[
-            "wide", "medium", "closeup", "environmental",
-            "portrait", "overhead", "low_angle",
-        ],
-        max_consecutive_same_content_type=4,  # Original: max 4 consecutive same style
-        max_consecutive_same_format=2,
-        max_consecutive_same_palette=3,
-        max_consecutive_close_up=1,
-        act_weights={
-            "act1": {"dossier": 0.75, "schema": 0.25, "echo": 0.00},
-            "act2": {"dossier": 0.65, "schema": 0.30, "echo": 0.05},
-            "act3": {"dossier": 0.40, "schema": 0.20, "echo": 0.40},
-            "act4": {"dossier": 0.35, "schema": 0.20, "echo": 0.45},
-            "act5": {"dossier": 0.50, "schema": 0.35, "echo": 0.15},
-            "act6": {"dossier": 0.65, "schema": 0.35, "echo": 0.00},
-        },
-        scene_expander_style_distribution={
-            1: {"dossier": 90, "schema": 10, "echo": 0},
-            2: {"dossier": 70, "schema": 30, "echo": 0},
-            3: {"dossier": 45, "schema": 20, "echo": 35},
-            4: {"dossier": 35, "schema": 20, "echo": 45},
-            5: {"dossier": 50, "schema": 35, "echo": 15},
-            6: {"dossier": 65, "schema": 35, "echo": 0},
-        },
-    ),
-
-    # Figure rules — anonymous figures allowed (faces obscured)
-    figure_rules=FigureRulesConfig(
-        allow_human_figures=True,
-        allow_silhouettes=True,
-        allow_mannequins=False,
-        protagonist_config=None,
-        negative_prompt_suffix=(
-            "no visible faces, faces obscured by shadow or backlighting"
-        ),
-        people_words=[],
-        people_replacements=[],
-    ),
-
-    # Scene description
-    scene_description=SceneDescriptionConfig(
-        system_prompt=(
-            "You are a visual director creating cinematic photorealistic "
-            "documentary image prompts for a YouTube documentary channel.\n\n"
-            "Every prompt should feel like a still from a prestige documentary. "
-            "Dark moody atmosphere, desaturated palette, Rembrandt lighting.\n\n"
-            "Anonymous human figures with faces obscured by shadow, silhouette, "
-            "or backlighting. Body language conveys emotion."
-        ),
-        metaphor_translation_table={
-            "money_flow": "Show the institution: central bank, trading floor, vault",
-            "power_consolidation": "Show the person/building: corporate HQ, signing ceremony",
-        },
-        quantitative_requirement=False,
-        text_in_image_rules="no narrative text, only analytical data labels and readouts",
-    ),
-
-    # Animation
-    animation=AnimationConfig(
-        animation_model="grok-imagine/image-to-video",
-        animation_cost_per_clip=0.10,
-    ),
-
-    # Thumbnail
-    thumbnail=ThumbnailConfig(
-        thumbnail_style="bright_editorial_illustration",
-        thumbnail_text_color="#FFD700",
-        thumbnail_text_style="bold block capitals, thick black outline",
-    ),
-
-    # Ken Burns
-    ken_burns=KenBurnsConfig(
-        direction_map={
-            "wide": "slow_zoom_in",
-            "medium": "slow_pan_right",
-            "closeup": "slow_zoom_out",
-            "environmental": "slow_pan_left",
-            "portrait": "slow_zoom_in",
-            "overhead": "slow_zoom_in",
-            "low_angle": "slow_tilt_up",
-        },
-    ),
-
-    # Raw data
-    raw={
-        "style_engine_prefix": _DOSSIER_PREFIX,
-        "style_engine_suffix": _DOSSIER_SUFFIX,
-    },
+    **_IDENTITY,
+    image_gen=_IMAGE_GEN,
+    style_system=_STYLE_SYSTEM,
+    rotation=_ROTATION,
+    figure_rules=_FIGURE_RULES,
+    scene_description=_SCENE_DESCRIPTION,
+    animation=_ANIMATION,
+    thumbnail=_THUMBNAIL,
+    ken_burns=_KEN_BURNS,
+    template_metadata=_TEMPLATE_METADATA,
+    raw=_RAW,
 )

--- a/skills/video-pipeline/visual_profiles/cinematic_dossier.py
+++ b/skills/video-pipeline/visual_profiles/cinematic_dossier.py
@@ -1,0 +1,221 @@
+"""Cinematic Dossier — Legacy reference profile (pre-Mar 2026).
+
+The original 3-style system (Dossier/Schema/Echo) used for the Economy
+FastForward YouTube channel. Preserved for reference and potential reuse.
+
+Aesthetic: Prestige documentary photography with Rembrandt lighting,
+anonymous human figures with faces obscured by shadow/silhouette/backlighting,
+desaturated palette with accent colors.
+"""
+
+from visual_profiles.schema import (
+    AnimationConfig,
+    FigureRulesConfig,
+    ImageGenConfig,
+    KenBurnsConfig,
+    RotationConfig,
+    SceneDescriptionConfig,
+    StyleSystemConfig,
+    SubstyleConfig,
+    ThumbnailConfig,
+    VisualProfile,
+)
+
+
+# =============================================================================
+# Style Prefix / Suffix (the Dossier era)
+# =============================================================================
+
+_DOSSIER_PREFIX = (
+    "Cinematic photorealistic still, dark moody atmosphere, desaturated palette, "
+    "Rembrandt lighting with deep shadows, shot on Arri Alexa with Kodak Vision "
+    "film stock, 16:9 cinematic composition."
+)
+
+_DOSSIER_SUFFIX = (
+    "Anonymous human figures with faces obscured by shadow silhouette or "
+    "backlighting, cinematic depth of field, no text overlays, "
+    "subtle ambient light, photorealistic rendering, 16:9 aspect ratio"
+)
+
+
+PROFILE = VisualProfile(
+    # Identity
+    profile_id="cinematic_dossier",
+    profile_name="Cinematic Photorealistic Dossier",
+    description=(
+        "Prestige documentary photography. Rembrandt lighting, anonymous "
+        "human figures with faces obscured by shadow/silhouette/backlighting. "
+        "3-style system: Dossier (60%), Schema (22%), Echo (18%)."
+    ),
+    version="3.0",
+    channel="economy_fastforward",
+
+    # Image generation
+    image_gen=ImageGenConfig(
+        scene_model="nano-banana-2",
+        scene_model_params={
+            "aspect_ratio": "16:9",
+            "resolution": "1K",
+            "output_format": "png",
+        },
+        scene_cost_per_image=0.025,
+        thumbnail_model="nano-banana-pro",
+        thumbnail_model_params={
+            "aspect_ratio": "16:9",
+            "resolution": "2K",
+            "output_format": "png",
+        },
+        thumbnail_cost_per_image=0.09,
+    ),
+
+    # Style system
+    style_system=StyleSystemConfig(
+        style_prefix=_DOSSIER_PREFIX,
+        style_suffix=_DOSSIER_SUFFIX,
+        substyles={
+            "dossier": SubstyleConfig(
+                name="Dossier",
+                weight=0.60,
+                suffix=(
+                    "Rembrandt lighting, cinematic photorealism, "
+                    "deep shadows and warm accent color highlights"
+                ),
+                description="Investigation, corporate, power. Photorealistic with accent colors.",
+            ),
+            "schema": SubstyleConfig(
+                name="Schema",
+                weight=0.22,
+                suffix=(
+                    "Data overlay aesthetic, glowing nodes on dark background, "
+                    "HUD elements and wireframe overlays"
+                ),
+                description="Systems, networks, data. Glowing data overlays on dark backgrounds.",
+            ),
+            "echo": SubstyleConfig(
+                name="Echo",
+                weight=0.18,
+                suffix=(
+                    "Painterly historical texture, candlelit warm tones, "
+                    "oil painting meets documentary photography"
+                ),
+                description="Backstory, historical context. Painterly, candlelit aesthetic.",
+            ),
+        },
+        accent_colors={
+            "geopolitical": "cold teal",
+            "financial": "warm amber",
+            "conflict": "muted crimson",
+            "default": "cold teal",
+        },
+        accent_color_to_mood={
+            "cold teal": "cold teal",
+            "warm amber": "warm amber",
+            "muted crimson": "muted crimson",
+            "muted green": "muted green",
+        },
+        category_to_mood={
+            "geopolitical": "cold teal",
+            "ai_tech": "cold teal",
+            "corporate_power": "warm amber",
+            "surveillance": "cold teal",
+            "economic": "warm amber",
+            "financial": "warm amber",
+            "historical_power": "warm amber",
+            "conflict": "muted crimson",
+            "warfare": "muted crimson",
+            "military": "muted crimson",
+        },
+    ),
+
+    # Rotation
+    rotation=RotationConfig(
+        compositions=[
+            "wide", "medium", "closeup", "environmental",
+            "portrait", "overhead", "low_angle",
+        ],
+        max_consecutive_same_content_type=4,  # Original: max 4 consecutive same style
+        max_consecutive_same_format=2,
+        max_consecutive_same_palette=3,
+        max_consecutive_close_up=1,
+        act_weights={
+            "act1": {"dossier": 0.75, "schema": 0.25, "echo": 0.00},
+            "act2": {"dossier": 0.65, "schema": 0.30, "echo": 0.05},
+            "act3": {"dossier": 0.40, "schema": 0.20, "echo": 0.40},
+            "act4": {"dossier": 0.35, "schema": 0.20, "echo": 0.45},
+            "act5": {"dossier": 0.50, "schema": 0.35, "echo": 0.15},
+            "act6": {"dossier": 0.65, "schema": 0.35, "echo": 0.00},
+        },
+        scene_expander_style_distribution={
+            1: {"dossier": 90, "schema": 10, "echo": 0},
+            2: {"dossier": 70, "schema": 30, "echo": 0},
+            3: {"dossier": 45, "schema": 20, "echo": 35},
+            4: {"dossier": 35, "schema": 20, "echo": 45},
+            5: {"dossier": 50, "schema": 35, "echo": 15},
+            6: {"dossier": 65, "schema": 35, "echo": 0},
+        },
+    ),
+
+    # Figure rules — anonymous figures allowed (faces obscured)
+    figure_rules=FigureRulesConfig(
+        allow_human_figures=True,
+        allow_silhouettes=True,
+        allow_mannequins=False,
+        protagonist_config=None,
+        negative_prompt_suffix=(
+            "no visible faces, faces obscured by shadow or backlighting"
+        ),
+        people_words=[],
+        people_replacements=[],
+    ),
+
+    # Scene description
+    scene_description=SceneDescriptionConfig(
+        system_prompt=(
+            "You are a visual director creating cinematic photorealistic "
+            "documentary image prompts for a YouTube documentary channel.\n\n"
+            "Every prompt should feel like a still from a prestige documentary. "
+            "Dark moody atmosphere, desaturated palette, Rembrandt lighting.\n\n"
+            "Anonymous human figures with faces obscured by shadow, silhouette, "
+            "or backlighting. Body language conveys emotion."
+        ),
+        metaphor_translation_table={
+            "money_flow": "Show the institution: central bank, trading floor, vault",
+            "power_consolidation": "Show the person/building: corporate HQ, signing ceremony",
+        },
+        quantitative_requirement=False,
+        text_in_image_rules="no narrative text, only analytical data labels and readouts",
+    ),
+
+    # Animation
+    animation=AnimationConfig(
+        animation_model="grok-imagine/image-to-video",
+        animation_cost_per_clip=0.10,
+    ),
+
+    # Thumbnail
+    thumbnail=ThumbnailConfig(
+        thumbnail_style="bright_editorial_illustration",
+        thumbnail_text_color="#FFD700",
+        thumbnail_text_style="bold block capitals, thick black outline",
+    ),
+
+    # Ken Burns
+    ken_burns=KenBurnsConfig(
+        direction_map={
+            "wide": "slow_zoom_in",
+            "medium": "slow_pan_right",
+            "closeup": "slow_zoom_out",
+            "environmental": "slow_pan_left",
+            "portrait": "slow_zoom_in",
+            "overhead": "slow_zoom_in",
+            "low_angle": "slow_tilt_up",
+        },
+    ),
+
+    # Raw data
+    raw={
+        "style_engine_prefix": _DOSSIER_PREFIX,
+        "style_engine_suffix": _DOSSIER_SUFFIX,
+    },
+)

--- a/skills/video-pipeline/visual_profiles/clay_mannequin.py
+++ b/skills/video-pipeline/visual_profiles/clay_mannequin.py
@@ -1,0 +1,126 @@
+"""Clay Mannequin — Legacy reference profile (earliest style).
+
+The original animation-focused style using 3D clay render mannequins
+with a golden chest glow protagonist. Preserved for reference.
+
+Aesthetic: 3D editorial conceptual render, smooth matte gray ceramic
+mannequin figures, department store display aesthetic, golden amber
+chest glow for the protagonist figure.
+"""
+
+from visual_profiles.schema import (
+    AnimationConfig,
+    FigureRulesConfig,
+    ImageGenConfig,
+    KenBurnsConfig,
+    RotationConfig,
+    SceneDescriptionConfig,
+    StyleSystemConfig,
+    ThumbnailConfig,
+    VisualProfile,
+)
+
+
+_CLAY_PREFIX = (
+    "3D editorial conceptual render, smooth matte gray ceramic mannequin "
+    "figures in a department store display diorama, "
+    "cinematic soft studio lighting, 16:9 composition."
+)
+
+_CLAY_SUFFIX = (
+    "Faceless mannequin figures, no facial features, smooth matte gray "
+    "ceramic material, department store display aesthetic, "
+    "cinematic depth of field, 16:9 aspect ratio"
+)
+
+
+PROFILE = VisualProfile(
+    # Identity
+    profile_id="clay_mannequin",
+    profile_name="3D Clay Mannequin Render",
+    description=(
+        "3D editorial conceptual render with faceless matte gray ceramic "
+        "mannequin figures. Protagonist has golden amber chest glow. "
+        "Department store display diorama aesthetic."
+    ),
+    version="1.0",
+    channel="economy_fastforward",
+
+    # Image generation
+    image_gen=ImageGenConfig(
+        scene_model="nano-banana-2",
+        scene_model_params={
+            "aspect_ratio": "16:9",
+            "resolution": "1K",
+            "output_format": "png",
+        },
+        scene_cost_per_image=0.025,
+    ),
+
+    # Style system
+    style_system=StyleSystemConfig(
+        style_prefix=_CLAY_PREFIX,
+        style_suffix=_CLAY_SUFFIX,
+        substyles={},
+        accent_colors={
+            "default": "cold teal",
+        },
+    ),
+
+    # Rotation
+    rotation=RotationConfig(
+        compositions=[
+            "wide", "medium", "closeup", "environmental",
+            "portrait", "overhead", "low_angle",
+        ],
+    ),
+
+    # Figure rules — mannequins allowed with protagonist glow
+    figure_rules=FigureRulesConfig(
+        allow_human_figures=False,
+        allow_silhouettes=False,
+        allow_mannequins=True,
+        protagonist_config={
+            "glow_color": "gold/amber",
+            "glow_intensity_range": [0, 100],
+            "base_material": "smooth matte gray ceramic",
+            "glow_location": "chest/heart area",
+        },
+        negative_prompt_suffix=(
+            "no facial features, no real human skin, smooth matte gray ceramic"
+        ),
+    ),
+
+    # Scene description
+    scene_description=SceneDescriptionConfig(
+        system_prompt=(
+            "You are a visual director creating 3D clay mannequin render "
+            "image prompts. Every scene is a conceptual diorama with smooth "
+            "matte gray ceramic mannequin figures. The protagonist mannequin "
+            "has a golden amber glow emanating from the chest area."
+        ),
+        quantitative_requirement=False,
+        text_in_image_rules="no text overlays",
+    ),
+
+    # Animation
+    animation=AnimationConfig(
+        animation_model="grok-imagine/image-to-video",
+        animation_cost_per_clip=0.10,
+    ),
+
+    # Thumbnail
+    thumbnail=ThumbnailConfig(
+        thumbnail_style="bright_editorial_illustration",
+        thumbnail_text_color="#FFD700",
+    ),
+
+    # Ken Burns
+    ken_burns=KenBurnsConfig(),
+
+    # Raw data
+    raw={
+        "style_engine_prefix": _CLAY_PREFIX,
+        "style_engine_suffix": _CLAY_SUFFIX,
+    },
+)

--- a/skills/video-pipeline/visual_profiles/clay_mannequin.py
+++ b/skills/video-pipeline/visual_profiles/clay_mannequin.py
@@ -1,11 +1,17 @@
-"""Clay Mannequin — Legacy reference profile (earliest style).
+"""Clay Mannequin — The original 3D editorial conceptual render style.
 
-The original animation-focused style using 3D clay render mannequins
-with a golden chest glow protagonist. Preserved for reference.
+The earliest Economy FastForward visual system using faceless ceramic
+mannequin figures in diorama compositions. The protagonist mannequin has
+a distinctive golden amber chest glow that tracks narrative intensity.
 
-Aesthetic: 3D editorial conceptual render, smooth matte gray ceramic
-mannequin figures, department store display aesthetic, golden amber
-chest glow for the protagonist figure.
+Aesthetic: 3D editorial clay render, matte ceramic surfaces, studio-lit
+diorama composition. Faceless smooth-skinned mannequin figures with subtle
+anatomical indentations. Mixed material contrasts — brushed steel, frosted
+glass, worn leather, polished chrome. Protagonist has warm amber chest glow.
+
+This is a COMPLETE, STANDALONE profile. Loading it as the active profile
+produces a fully different visual output with zero holographic or dossier
+style leakage.
 """
 
 from visual_profiles.schema import (
@@ -16,111 +22,483 @@ from visual_profiles.schema import (
     RotationConfig,
     SceneDescriptionConfig,
     StyleSystemConfig,
+    TemplateMetadata,
     ThumbnailConfig,
     VisualProfile,
 )
 
 
-_CLAY_PREFIX = (
-    "3D editorial conceptual render, smooth matte gray ceramic mannequin "
-    "figures in a department store display diorama, "
-    "cinematic soft studio lighting, 16:9 composition."
-)
+# =============================================================================
+# Section 1: Identity
+# =============================================================================
 
-_CLAY_SUFFIX = (
-    "Faceless mannequin figures, no facial features, smooth matte gray "
-    "ceramic material, department store display aesthetic, "
-    "cinematic depth of field, 16:9 aspect ratio"
-)
-
-
-PROFILE = VisualProfile(
-    # Identity
+_IDENTITY = dict(
     profile_id="clay_mannequin",
     profile_name="3D Clay Mannequin Render",
     description=(
         "3D editorial conceptual render with faceless matte gray ceramic "
-        "mannequin figures. Protagonist has golden amber chest glow. "
-        "Department store display diorama aesthetic."
+        "mannequin figures. Protagonist has golden amber chest glow that "
+        "tracks narrative intensity. Department store display diorama "
+        "aesthetic with mixed material contrasts."
     ),
-    version="1.0",
+    version="2.0",
     channel="economy_fastforward",
+)
 
-    # Image generation
-    image_gen=ImageGenConfig(
-        scene_model="nano-banana-2",
-        scene_model_params={
-            "aspect_ratio": "16:9",
-            "resolution": "1K",
-            "output_format": "png",
-        },
-        scene_cost_per_image=0.025,
-    ),
 
-    # Style system
-    style_system=StyleSystemConfig(
-        style_prefix=_CLAY_PREFIX,
-        style_suffix=_CLAY_SUFFIX,
-        substyles={},
-        accent_colors={
-            "default": "cold teal",
-        },
-    ),
+# =============================================================================
+# Section 2: Image Generation Config
+# =============================================================================
 
-    # Rotation
-    rotation=RotationConfig(
-        compositions=[
-            "wide", "medium", "closeup", "environmental",
-            "portrait", "overhead", "low_angle",
-        ],
-    ),
-
-    # Figure rules — mannequins allowed with protagonist glow
-    figure_rules=FigureRulesConfig(
-        allow_human_figures=False,
-        allow_silhouettes=False,
-        allow_mannequins=True,
-        protagonist_config={
-            "glow_color": "gold/amber",
-            "glow_intensity_range": [0, 100],
-            "base_material": "smooth matte gray ceramic",
-            "glow_location": "chest/heart area",
-        },
-        negative_prompt_suffix=(
-            "no facial features, no real human skin, smooth matte gray ceramic"
-        ),
-    ),
-
-    # Scene description
-    scene_description=SceneDescriptionConfig(
-        system_prompt=(
-            "You are a visual director creating 3D clay mannequin render "
-            "image prompts. Every scene is a conceptual diorama with smooth "
-            "matte gray ceramic mannequin figures. The protagonist mannequin "
-            "has a golden amber glow emanating from the chest area."
-        ),
-        quantitative_requirement=False,
-        text_in_image_rules="no text overlays",
-    ),
-
-    # Animation
-    animation=AnimationConfig(
-        animation_model="grok-imagine/image-to-video",
-        animation_cost_per_clip=0.10,
-    ),
-
-    # Thumbnail
-    thumbnail=ThumbnailConfig(
-        thumbnail_style="bright_editorial_illustration",
-        thumbnail_text_color="#FFD700",
-    ),
-
-    # Ken Burns
-    ken_burns=KenBurnsConfig(),
-
-    # Raw data
-    raw={
-        "style_engine_prefix": _CLAY_PREFIX,
-        "style_engine_suffix": _CLAY_SUFFIX,
+_IMAGE_GEN = ImageGenConfig(
+    scene_model="seedream-v4",
+    scene_model_params={
+        "aspect_ratio": "16:9",
+        "resolution": "1K",
+        "output_format": "png",
     },
+    scene_cost_per_image=0.025,
+    thumbnail_model="nano-banana-pro",
+    thumbnail_model_params={
+        "aspect_ratio": "16:9",
+        "resolution": "2K",
+        "output_format": "png",
+    },
+    thumbnail_cost_per_image=0.04,
+)
+
+
+# =============================================================================
+# Section 3: Style System — single style, no substyles
+# =============================================================================
+
+_CLAY_PREFIX = (
+    "3D editorial clay render, matte ceramic surfaces, studio-lit diorama "
+    "composition, faceless smooth-skinned mannequin figures with subtle "
+    "anatomical indentations, mixed material contrasts — brushed steel, "
+    "frosted glass, worn leather, polished chrome."
+)
+
+_CLAY_SUFFIX = (
+    ", dramatic directional studio lighting, shallow depth of field, "
+    "volumetric atmosphere, cinematic 16:9 composition, "
+    "material surfaces: concrete, chrome, brushed steel, glass, leather, velvet, "
+    "color grade: desaturated with selective warm accent lighting, "
+    "no photorealistic skin, no flat 2D, no anime, no cartoon"
+)
+
+_STYLE_SYSTEM = StyleSystemConfig(
+    style_prefix=_CLAY_PREFIX,
+    style_suffix=_CLAY_SUFFIX,
+    substyles={},  # Clay uses single style — no substyle rotation
+    accent_colors={
+        "geopolitical": "cold teal",
+        "financial": "warm amber",
+        "conflict": "muted crimson",
+        "default": "cold teal",
+    },
+    accent_color_to_mood={
+        "cold teal": "cold teal",
+        "warm amber": "warm amber",
+        "muted crimson": "muted crimson",
+        "muted green": "muted green",
+    },
+    category_to_mood={
+        "geopolitical": "cold teal",
+        "ai_tech": "cold teal",
+        "corporate_power": "warm amber",
+        "surveillance": "cold teal",
+        "economic": "warm amber",
+        "financial": "warm amber",
+        "historical_power": "warm amber",
+        "conflict": "muted crimson",
+        "warfare": "muted crimson",
+        "military": "muted crimson",
+    },
+)
+
+
+# =============================================================================
+# Section 4: Rotation & Composition — cycling only, no substyles
+# =============================================================================
+
+_ROTATION = RotationConfig(
+    compositions=[
+        "wide", "medium", "closeup", "environmental",
+        "portrait", "overhead", "low_angle",
+    ],
+    # Clay uses simple composition cycling — no substyle constraints
+    max_consecutive_same_content_type=3,  # Generic variety rule
+    max_consecutive_same_format=2,
+    max_consecutive_same_palette=3,
+    max_consecutive_close_up=1,
+    act_weights={},  # No substyle weights — single style system
+    scene_expander_style_distribution={},  # Not applicable
+)
+
+
+# =============================================================================
+# Section 5: Figure Rules — mannequins with protagonist glow
+# =============================================================================
+
+_FIGURE_RULES = FigureRulesConfig(
+    allow_human_figures=False,
+    allow_silhouettes=False,
+    allow_mannequins=True,
+    protagonist_config={
+        "glow_color": "gold/amber",
+        "glow_intensity_range": [0, 100],
+        "base_material": "smooth matte gray ceramic",
+        "glow_location": "chest/heart area",
+        "description": (
+            "Faceless mannequin with warm amber glow emanating from chest, "
+            "intensity tracks narrative arc: steady=comfort, flickering=unease, "
+            "dimming=loss, surging=awakening"
+        ),
+        "glow_intensity_mapping": {
+            "comfort": "steady warm glow, 40-60% intensity",
+            "tension": "flickering glow, 50-70% intensity, uneven",
+            "unease": "faint flickering glow, 20-40% intensity",
+            "loss": "dim fading glow, 5-15% intensity",
+            "awakening": "surging bright glow, 80-100% intensity",
+            "neutral": "gentle warm glow, 30-50% intensity",
+        },
+        "background_characters": "neutral gray droids with no glow",
+    },
+    negative_prompt_suffix=(
+        "no photorealistic skin, no flat 2D, no realistic skin texture, "
+        "no anime, no cartoon, no facial features, smooth matte gray ceramic"
+    ),
+    people_words=[
+        "person", "people", "man", "woman", "face", "faces",
+        "smile", "expression", "eyes", "mouth", "hair",
+    ],
+    people_replacements=[
+        (r"\bperson\b", "mannequin figure"),
+        (r"\bpeople\b", "mannequin figures"),
+        (r"\bman\b", "mannequin figure"),
+        (r"\bwoman\b", "mannequin figure"),
+        (r"\bfaces?\b", "smooth featureless head"),
+        (r"\bsmil(?:e|ing)\b", "tilted head posture"),
+        (r"\bexpression\b", "body language"),
+        (r"\beyes\b", "smooth eye indentations"),
+        (r"\bmouth\b", "smooth surface"),
+        (r"\bhair\b", "smooth ceramic head"),
+    ],
+)
+
+
+# =============================================================================
+# Section 6: Scene Description Rules
+# =============================================================================
+
+_SCENE_DESCRIPTION = SceneDescriptionConfig(
+    system_prompt=(
+        "You are a visual director creating 3D CLAY MANNEQUIN RENDER image "
+        "prompts for a YouTube documentary channel.\n\n"
+        "Every image is a conceptual editorial diorama — like a high-end "
+        "department store window display that tells a story. Faceless matte "
+        "gray ceramic mannequin figures with smooth anatomical indentations "
+        "where eyes, nose, and mouth would be.\n\n"
+        "THE PROTAGONIST: One mannequin has a warm golden amber glow "
+        "emanating from its chest/heart area. This is the viewer's avatar. "
+        "The glow intensity tracks the narrative: steady=comfort, "
+        "flickering=unease, dimming=loss, surging=awakening.\n\n"
+        "BACKGROUND CHARACTERS: Neutral gray mannequins with NO glow. "
+        "They are scenery, not protagonists.\n\n"
+        "CAMERA RULES:\n"
+        "- Eye level = neutral observation\n"
+        "- Overhead = vulnerability, being watched\n"
+        "- Low angle = power, authority, intimidation\n"
+        "- Push in = intimacy, focus, revelation\n\n"
+        "MATERIAL PALETTE: Every scene uses mixed material contrasts — "
+        "concrete, chrome, brushed steel, glass, leather, velvet. The "
+        "diorama should feel tactile and three-dimensional.\n\n"
+        "NEVER visualize metaphors literally. When the script says 'economy "
+        "crumbling' — show mannequins in a cracked concrete environment with "
+        "falling debris, NOT a literal crumbling pie chart.\n\n"
+        "FILMABLE DIORAMA RULE: Every image must look like it could be a "
+        "physical department store display you could walk around and photograph."
+    ),
+    metaphor_translation_table={
+        "money_flow": "Show mannequin at bank vault diorama, stacks of prop currency, conveyor belt",
+        "power_consolidation": "Show mannequin in executive chair, others standing below on lower platform",
+        "economic_pressure": "Show mannequin surrounded by shrinking walls, price tags, empty shelves",
+        "military_force": "Show mannequin figures around scale model warships and tanks",
+        "political_tension": "Show mannequins seated opposite each other at long diplomatic table",
+        "surveillance_state": "Show mannequin under spotlight with camera props and glass panels",
+        "market_crash": "Show mannequin amid falling prop stock certificates and broken glass",
+        "corruption": "Show mannequin in luxury setting with hidden compartment props",
+        "inequality": "Show split diorama: gold platform vs concrete pit, mannequins at each level",
+    },
+    quantitative_requirement=False,
+    text_in_image_rules="no text overlays — all storytelling through spatial composition and materials",
+)
+
+
+# =============================================================================
+# Section 7: Animation — selective (hero shots only)
+# =============================================================================
+
+_CLAY_LOW_MOTION = {
+    "wide_establishing": "Static shot. Protagonist's chest glow pulses slowly with gentle warmth.",
+    "medium_scene": "Static shot. One material element shifts slightly — a glass panel catches light.",
+    "closeup_detail": "Static shot. Protagonist's glow flickers once, casting subtle shadow shift.",
+    "environmental": "Static shot. Volumetric atmosphere drifts slowly through the diorama.",
+    "portrait": "Static shot. Protagonist mannequin's glow breathes — slow intensity cycle.",
+    "overhead": "Static shot. One small prop element shifts position on the diorama surface.",
+    "low_angle": "Static shot. Light source shifts subtly, changing shadow angles on ceramic surfaces.",
+}
+
+_CLAY_MEDIUM_MOTION = {
+    "wide_establishing": "Static shot. Protagonist's chest glow intensifies as they step forward. Background mannequins remain frozen.",
+    "medium_scene": "Static shot. A material element transforms — glass cracks, metal bends. Protagonist reacts with glow shift.",
+    "closeup_detail": "Static shot. Protagonist's hand reaches toward an object. Glow light spills onto the surface.",
+    "environmental": "Static shot. Environmental elements shift — walls close in or open up. Lighting changes temperature.",
+    "portrait": "Static shot. Protagonist mannequin turns head slightly. Glow shifts from steady to flickering.",
+    "overhead": "Static shot. Props rearrange on the diorama surface as if moved by invisible force.",
+    "low_angle": "Static shot. Shadow patterns sweep across mannequin as light source moves overhead.",
+}
+
+_CLAY_HIGH_MOTION = {
+    "wide_establishing": "Static shot. Diorama environment fractures — concrete cracks, glass shatters. Protagonist's glow surges bright.",
+    "medium_scene": "Static shot. Background mannequins topple in sequence. Protagonist stands firm, glow blazing.",
+    "closeup_detail": "Static shot. Object in frame disintegrates into particles. Protagonist's glow pulses with each impact.",
+    "environmental": "Static shot. Entire diorama platform tilts. Materials slide and crash. Volumetric dust erupts.",
+    "portrait": "Static shot. Protagonist's glow explodes outward in a burst of amber light, then contracts.",
+    "overhead": "Static shot. Impact crater forms on diorama surface. Debris scatters outward from center.",
+    "low_angle": "Static shot. Towering structure behind mannequin collapses. Protagonist's shadow stretches across frame.",
+}
+
+_ANIMATION = AnimationConfig(
+    animation_model="grok-imagine/image-to-video",
+    animation_cost_per_clip=0.10,
+    motion_templates={
+        **{f"low_{k}": v for k, v in _CLAY_LOW_MOTION.items()},
+        **{f"medium_{k}": v for k, v in _CLAY_MEDIUM_MOTION.items()},
+        **{f"high_{k}": v for k, v in _CLAY_HIGH_MOTION.items()},
+    },
+    motion_base_rule=(
+        "Maintain the full original frame composition. Preserve the protagonist "
+        "mannequin's golden amber chest glow throughout the animation — do not "
+        "let the model wash it out or change its color."
+    ),
+    intensity_levels={
+        "low": "Subtle ambient motion. Glow breathes, one material element shifts.",
+        "medium": "Active reveal. Up to two elements animate, glow reacts to events.",
+        "high": "Dramatic action. Environment fractures, glow surges or dims.",
+    },
+    universal_rules=[
+        "Maintain the full original frame composition.",
+        "Protagonist's golden amber chest glow must remain visible throughout.",
+        "Mannequin surfaces must remain matte ceramic — no skin-like texture.",
+        "Material contrasts (concrete, chrome, glass) must stay consistent.",
+        "No facial features should appear on any mannequin at any point.",
+    ],
+    banned_motion_words=[
+        "realistic skin", "facial expression", "hair movement", "eye movement",
+        "lip movement", "breathing chest", "muscle flex",
+    ],
+    emotional_motion_dict={
+        "comfort_safety": [
+            "glow steadies", "glow warms", "materials smooth",
+            "light softens", "space opens up",
+        ],
+        "tension_unease": [
+            "glow flickers", "materials vibrate", "shadows sharpen",
+            "space constricts", "surfaces crack",
+        ],
+        "loss_absence": [
+            "glow dims", "glow fades", "materials crumble",
+            "surfaces erode", "space empties",
+        ],
+        "awakening_power": [
+            "glow surges", "glow blazes", "glow explodes outward",
+            "materials transform", "space expands",
+        ],
+        "confrontation": [
+            "glow intensifies", "materials shatter", "surfaces fracture",
+            "props scatter", "environment tilts",
+        ],
+    },
+)
+
+
+# =============================================================================
+# Section 8: Thumbnail Identity
+# =============================================================================
+
+_THUMBNAIL = ThumbnailConfig(
+    thumbnail_style="bright_editorial_illustration",
+    thumbnail_text_color="#FFD700",
+    thumbnail_text_style="bold block capitals, thick black outline",
+    thumbnail_max_words_per_line=4,
+    thumbnail_max_lines=2,
+    thumbnail_background="simple, recognizable, reads at 160x90px",
+    thumbnail_palette_max_colors=4,
+    thumbnail_prompt_templates={},  # Templates in thumbnail_generator/templates.py
+    thumbnail_color_presets={
+        "geopolitics": ["#1a5c6b", "#FFD700", "#333", "#fff"],
+        "finance": ["#b8860b", "#FFD700", "#333", "#fff"],
+        "conflict": ["#8b1a1a", "#FFD700", "#333", "#fff"],
+    },
+    thumbnail_system_prompt="",  # Full prompt in anthropic_client.py
+    thumbnail_figure_rules=(
+        "Mannequin figure silhouette or symbolic object. "
+        "No recognizable faces — use featureless ceramic head shape."
+    ),
+)
+
+
+# =============================================================================
+# Section 9: Ken Burns Config
+# =============================================================================
+
+_KEN_BURNS = KenBurnsConfig(
+    direction_map={
+        "wide": "slow_zoom_in",
+        "medium": "slow_pan_right",
+        "closeup": "slow_zoom_out",
+        "environmental": "slow_pan_left",
+        "portrait": "slow_zoom_in",
+        "overhead": "slow_zoom_in",
+        "low_angle": "slow_tilt_up",
+    },
+    presets={
+        "slow_zoom_in": {"start_scale": 1.0, "end_scale": 1.15},
+        "slow_zoom_out": {"start_scale": 1.15, "end_scale": 1.0},
+        "slow_pan_right": {"start_x_offset": -40, "end_x_offset": 40},
+        "slow_pan_left": {"start_x_offset": 40, "end_x_offset": -40},
+        "slow_tilt_up": {"start_y_offset": 30, "end_y_offset": -30},
+    },
+    base_duration=11.0,
+    pan_alternates={
+        "slow_pan_right": "slow_pan_left",
+        "slow_pan_left": "slow_pan_right",
+    },
+)
+
+
+# =============================================================================
+# Section 10: Template Metadata (StoryEngine)
+# =============================================================================
+
+_TEMPLATE_METADATA = TemplateMetadata(
+    display_name="Clay Mannequin Dioramas",
+    category="conceptual",
+    tags=["3D", "clay", "mannequin", "diorama", "conceptual", "editorial", "warm"],
+    description=(
+        "3D editorial conceptual renders using faceless matte ceramic mannequin "
+        "figures in department store diorama compositions. A warm golden protagonist "
+        "glow tracks narrative emotion. Mixed material contrasts create tactile, "
+        "three-dimensional storytelling. Best for: explainers, personal finance, "
+        "social commentary, philosophical content."
+    ),
+    preview_prompts=[
+        (
+            "3D editorial clay render, a faceless matte gray ceramic mannequin "
+            "with warm golden amber chest glow standing alone in a vast concrete "
+            "atrium, surrounded by towering chrome pillars and frosted glass "
+            "walls, dramatic directional studio lighting, shallow depth of field, "
+            "cinematic 16:9 composition"
+        ),
+        (
+            "3D editorial clay render, two faceless ceramic mannequins seated "
+            "at opposite ends of a long brushed steel conference table, the "
+            "protagonist (golden chest glow) on one side, neutral gray figure "
+            "on the other, leather chairs, glass partition between them, "
+            "overhead spotlight, cinematic 16:9 composition"
+        ),
+        (
+            "3D editorial clay render, overhead view of a diorama showing a "
+            "mannequin with amber chest glow walking through a cracked concrete "
+            "maze, velvet-lined dead ends, chrome mirrors reflecting the glow, "
+            "volumetric atmosphere, desaturated with warm accent, 16:9 composition"
+        ),
+    ],
+    best_for=["explainers", "personal finance", "social commentary", "philosophy"],
+    cost_tier="mid",
+    estimated_cost_per_video={
+        "10min_no_animation": 4.50,
+        "10min_with_animation": 8.00,
+        "20min_no_animation": 8.00,
+        "20min_with_animation": 15.00,
+    },
+)
+
+
+# =============================================================================
+# Section 11: Raw data
+# =============================================================================
+
+_RAW = {
+    "style_engine_prefix": _CLAY_PREFIX,
+    "style_engine_suffix": _CLAY_SUFFIX,
+    # Valid scene models
+    "valid_scene_models": {
+        "seedream-v4": "Seed Dream 4.0 (default — clay mannequin, $0.025/img)",
+        "nano-banana-2": "Nano Banana 2 (alternative, $0.025/img)",
+    },
+    # Material vocabulary (unique to clay style)
+    "material_vocabulary": {
+        "premium": [
+            "polished chrome", "brushed gold", "marble", "leather", "velvet",
+        ],
+        "institutional": [
+            "concrete", "steel", "frosted glass", "matte ceramic",
+        ],
+        "decay": [
+            "rusted metal", "cracked concrete", "peeling paint", "oxidized copper",
+        ],
+        "data": [
+            "glowing neon", "holographic surfaces", "digital grids", "fiber optic",
+        ],
+    },
+    # Prompt word budget
+    "prompt_min_words": 62,
+    "prompt_max_words": 84,
+    # Protagonist glow intensity presets (for animation)
+    "glow_intensity_by_act": {
+        "act1": 50,   # Neutral — setting the scene
+        "act2": 40,   # Slight unease — tension building
+        "act3": 25,   # Dimming — complications mount
+        "act4": 60,   # Flickering — conflict peaks
+        "act5": 85,   # Surging — climax/revelation
+        "act6": 70,   # Steady warm — resolution
+    },
+    # Camera meaning vocabulary (for prompt building)
+    "camera_meaning": {
+        "eye_level": "neutral observation — viewer is equal to mannequin",
+        "overhead": "vulnerability — being watched, exposed, small",
+        "low_angle": "power — authority, intimidation, towering presence",
+        "push_in": "intimacy — focus, revelation, emotional close-up",
+        "pull_back": "isolation — loneliness, scale, being overwhelmed",
+    },
+    # Default config values
+    "default_config": {
+        "image_duration_seconds": 11,
+        "video_duration_seconds": 1500,
+        "total_images": 120,
+        "images_per_scene": 6,
+        "scenes_per_video": 20,
+    },
+}
+
+
+# =============================================================================
+# PROFILE — the single export
+# =============================================================================
+
+PROFILE = VisualProfile(
+    **_IDENTITY,
+    image_gen=_IMAGE_GEN,
+    style_system=_STYLE_SYSTEM,
+    rotation=_ROTATION,
+    figure_rules=_FIGURE_RULES,
+    scene_description=_SCENE_DESCRIPTION,
+    animation=_ANIMATION,
+    thumbnail=_THUMBNAIL,
+    ken_burns=_KEN_BURNS,
+    template_metadata=_TEMPLATE_METADATA,
+    raw=_RAW,
 )

--- a/skills/video-pipeline/visual_profiles/holographic_hud.py
+++ b/skills/video-pipeline/visual_profiles/holographic_hud.py
@@ -1,0 +1,710 @@
+"""Holographic Intelligence Display — Active production profile.
+
+Extracted from the current codebase (Mar 2026). When loaded, this profile
+produces IDENTICAL output to the current hardcoded system.
+
+Aesthetic: Dark high-security intelligence operations center with holographic
+projections. War room from Tom Clancy crossed with Bloomberg Terminal crossed
+with Minority Report. Zero human figures. Every frame carries actual
+analytical information.
+"""
+
+from visual_profiles.schema import (
+    AnimationConfig,
+    FigureRulesConfig,
+    ImageGenConfig,
+    KenBurnsConfig,
+    RotationConfig,
+    SceneDescriptionConfig,
+    StyleSystemConfig,
+    ThumbnailConfig,
+    VisualProfile,
+)
+
+
+# =============================================================================
+# Section 1: Identity
+# =============================================================================
+
+_IDENTITY = dict(
+    profile_id="holographic_hud",
+    profile_name="Holographic Intelligence Display",
+    description=(
+        "Dark operations room with projected holographic maps, data terminals, "
+        "and analytical visualizations. War room meets Bloomberg Terminal meets "
+        "Minority Report. Zero human figures — only data displays."
+    ),
+    version="4.0",
+    channel="economy_fastforward",
+)
+
+
+# =============================================================================
+# Section 2: Image Generation Config
+# =============================================================================
+
+_IMAGE_GEN = ImageGenConfig(
+    scene_model="z-image",
+    scene_model_params={
+        "aspect_ratio": "16:9",
+        "resolution": "1K",
+        "output_format": "png",
+    },
+    scene_cost_per_image=0.004,
+    thumbnail_model="nano-banana-pro",
+    thumbnail_model_params={
+        "aspect_ratio": "16:9",
+        "resolution": "2K",
+        "output_format": "png",
+    },
+    thumbnail_cost_per_image=0.09,
+)
+
+
+# =============================================================================
+# Section 3: Style System
+# =============================================================================
+
+_HOLOGRAPHIC_PREFIX = (
+    "Holographic intelligence display, dark high-security operations center, "
+    "holographic projections floating in dark space, clinical precision, "
+    "data-dense analytical visualization, photorealistic rendering, "
+    "16:9 cinematic composition."
+)
+
+_HOLOGRAPHIC_SUFFIX = (
+    ", no people visible no human figures no faces no silhouettes of people, "
+    "only data displays and holographic projections and room environment, "
+    "dark operations room background with subtle ambient equipment glow, "
+    "photorealistic rendering with cinematic depth of field, 16:9 aspect ratio"
+)
+
+_STYLE_SYSTEM = StyleSystemConfig(
+    style_prefix=_HOLOGRAPHIC_PREFIX,
+    style_suffix=_HOLOGRAPHIC_SUFFIX,
+    substyles={},  # Holographic uses 3-variable system, not substyles
+    accent_colors={
+        "geopolitical": "strategic",
+        "financial": "personal",
+        "conflict": "alert",
+        "default": "strategic",
+    },
+    accent_color_to_mood={
+        "cold teal": "strategic",
+        "warm amber": "archive",
+        "muted crimson": "alert",
+        "muted green": "contagion",
+        "deep green": "contagion",
+    },
+    category_to_mood={
+        "geopolitical": "strategic",
+        "ai_tech": "strategic",
+        "corporate_power": "power",
+        "surveillance": "strategic",
+        "economic": "personal",
+        "financial": "personal",
+        "historical_power": "archive",
+        "old_money": "archive",
+        "conflict": "alert",
+        "warfare": "alert",
+        "political_violence": "alert",
+        "military": "power",
+        "markets": "contagion",
+        "growth": "contagion",
+        "trade": "contagion",
+    },
+)
+
+
+# =============================================================================
+# Section 4: Rotation & Composition
+# =============================================================================
+
+_ROTATION = RotationConfig(
+    compositions=[
+        "wide", "medium", "closeup", "environmental",
+        "overhead", "low_angle",
+    ],
+    max_consecutive_same_content_type=2,
+    max_consecutive_same_format=2,
+    max_consecutive_same_palette=3,
+    max_consecutive_close_up=1,
+    act_weights={
+        "act1": {
+            "strategic": 0.50, "alert": 0.25, "power": 0.20,
+            "archive": 0.00, "contagion": 0.00, "personal": 0.05,
+        },
+        "act2": {
+            "strategic": 0.30, "alert": 0.35, "power": 0.20,
+            "archive": 0.05, "contagion": 0.05, "personal": 0.05,
+        },
+        "act3": {
+            "strategic": 0.10, "alert": 0.10, "power": 0.05,
+            "archive": 0.55, "contagion": 0.10, "personal": 0.10,
+        },
+        "act4": {
+            "strategic": 0.10, "alert": 0.30, "power": 0.10,
+            "archive": 0.30, "contagion": 0.15, "personal": 0.05,
+        },
+        "act5": {
+            "strategic": 0.05, "alert": 0.35, "power": 0.05,
+            "archive": 0.05, "contagion": 0.35, "personal": 0.15,
+        },
+        "act6": {
+            "strategic": 0.45, "alert": 0.10, "power": 0.20,
+            "archive": 0.05, "contagion": 0.05, "personal": 0.15,
+        },
+    },
+    scene_expander_style_distribution={
+        1: {"dossier": 90, "schema": 10, "echo": 0},
+        2: {"dossier": 70, "schema": 30, "echo": 0},
+        3: {"dossier": 45, "schema": 20, "echo": 35},
+        4: {"dossier": 35, "schema": 20, "echo": 45},
+        5: {"dossier": 50, "schema": 35, "echo": 15},
+        6: {"dossier": 65, "schema": 35, "echo": 0},
+    },
+)
+
+
+# =============================================================================
+# Section 5: Figure Rules
+# =============================================================================
+
+_PEOPLE_WORDS = [
+    "officer", "officers", "commander", "analyst", "operator", "operators",
+    "figure", "figures", "person", "people", "man", "woman", "soldier",
+    "soldiers", "guard", "guards", "hand", "hands", "silhouette",
+    "silhouettes", "face", "faces", "human", "crew", "staff",
+    "seated", "standing", "watching", "huddle", "checking", "dials",
+]
+
+_PEOPLE_REPLACEMENTS = [
+    (r"\bofficers?\s+(?:at|huddle\w*\s+around|seated\s+at)\s+\w+", "unmanned consoles with active displays"),
+    (r"\bcommander\s+\w+\s+\w+", "command terminal with priority alerts flashing"),
+    (r"\banalyst\s+workstation", "workstation with open data feeds"),
+    (r"\boperators?\s+(?:at|seated\s+at|monitoring)\s+\w+", "autonomous monitoring stations"),
+    (r"\bofficers?\b", "autonomous terminals"),
+    (r"\bcommander\b", "command terminal"),
+    (r"\banalysts?\b", "data terminals"),
+    (r"\boperators?\b", "monitoring stations"),
+    (r"\bfigures?\b", "equipment"),
+    (r"\bperson\b", "terminal"),
+    (r"\bpeople\b", "unmanned equipment"),
+    (r"\bsoldiers?\b", "military hardware"),
+    (r"\bguards?\b", "security sensors"),
+    (r"\bsilhouettes?\b", "equipment outlines"),
+    (r"\bhuman\b", "autonomous"),
+    (r"\bcrew\b", "autonomous systems"),
+    (r"\bstaff\b", "automated systems"),
+    (r"\bseated\b", "positioned"),
+    (r"\bstanding\b", "mounted"),
+    (r"\bwatching\b", "scanning"),
+    (r"\bhuddle\b", "cluster"),
+    (r"\bchecking\b", "processing"),
+    (r"\bdials\b", "activates"),
+    (r"\bhands?\b", "sensors"),
+    (r"\bfaces?\b", "displays"),
+    (r"\bman\b", "unit"),
+    (r"\bwoman\b", "unit"),
+]
+
+_FIGURE_RULES = FigureRulesConfig(
+    allow_human_figures=False,
+    allow_silhouettes=False,
+    allow_mannequins=False,
+    protagonist_config=None,
+    negative_prompt_suffix=(
+        "no people visible no human figures no faces no silhouettes of people"
+    ),
+    people_words=_PEOPLE_WORDS,
+    people_replacements=_PEOPLE_REPLACEMENTS,
+)
+
+
+# =============================================================================
+# Section 6: Scene Description Rules
+# =============================================================================
+
+_SCENE_DESCRIPTION = SceneDescriptionConfig(
+    system_prompt=(
+        "You are a visual director creating HOLOGRAPHIC INTELLIGENCE DISPLAY "
+        "image prompts for a YouTube documentary channel.\n\n"
+        "Every image exists inside a dark, high-security intelligence "
+        "operations center. The room is barely visible (10-15% of frame max). "
+        "The star of every frame is the HOLOGRAPHIC PROJECTION SURFACE — "
+        "a table, wall display, or floating mid-air projection showing "
+        "analytical content.\n\n"
+        "Think: war room from Tom Clancy crossed with Bloomberg Terminal "
+        "crossed with Minority Report. Clinical. Precise. Authoritative."
+    ),
+    metaphor_translation_table={
+        "money_flow": "Show the institution: central bank, trading floor, vault",
+        "power_consolidation": "Show the person/building: corporate HQ, signing ceremony",
+        "economic_pressure": "Show the data: price charts, inflation indicators, market terminals",
+        "military_force": "Show the hardware: fleet positions, weapon systems, satellite imagery",
+        "political_tension": "Show the documents: treaties, executive orders, diplomatic cables",
+    },
+    quantitative_requirement=True,
+    text_in_image_rules=(
+        "data-formatted only, not narrative — "
+        "text elements must be data-formatted labels, numbers, percentages, "
+        "or classification stamps only"
+    ),
+)
+
+
+# =============================================================================
+# Section 7: Animation Config
+# =============================================================================
+
+_LOW_MOTION = {
+    "A_geographic_map": "Static wide shot. Route arrows pulse with faint traveling light dots moving along paths.",
+    "B_data_terminal": "Static wide shot. Numerical values hold steady with occasional last-digit flicker.",
+    "C_object_comparison": "Static wide shot. Floating labels hold position, wireframe edges shimmer faintly.",
+    "D_document_display": "Static wide shot. Document page holds still, a single clause highlight pulses faintly.",
+    "E_network_diagram": "Static wide shot. Connection lines maintain steady brightness, one node pulses faintly brighter.",
+    "F_timeline": "Static wide shot. Timeline holds position, a single date marker glows faintly brighter.",
+    "G_satellite": "Static wide shot. Satellite image holds still, a single annotation marker blinks.",
+    "H_abstract_concept": "Static wide shot. Concept structure holds position, one element pulses with faint energy.",
+}
+
+_MEDIUM_MOTION = {
+    "A_geographic_map": "Static wide shot. Route lines draw themselves across the map progressively. Position markers appear one by one with brief flash effects.",
+    "B_data_terminal": "Static wide shot. Chart line draws itself from left to right revealing the trend. Warning indicators flash on at key thresholds.",
+    "C_object_comparison": "Static wide shot. Objects materialize from particle clouds assembling into wireframe form. Measurement lines extend and lock into position.",
+    "D_document_display": "Static wide shot. Document text reveals line by line as if being declassified. Key clauses highlight sequentially in amber.",
+    "E_network_diagram": "Static wide shot. Nodes light up in sequence following the flow direction. Connection lines pulse with traveling energy showing direction.",
+    "F_timeline": "Static wide shot. Timeline events appear in chronological order with connecting threads drawing between them.",
+    "G_satellite": "Static wide shot. Annotation overlays materialize one by one. Measurement lines extend from points of interest.",
+    "H_abstract_concept": "Static wide shot. Concept elements assemble from scattered particles into structured form. Force arrows activate showing direction.",
+}
+
+_HIGH_MOTION = {
+    "A_geographic_map": "Static wide shot. A shockwave explodes outward from the crisis point. Route lines sever and retract with sparking particle effects.",
+    "B_data_terminal": "Static wide shot. Chart line spikes violently upward with the screen shaking from the force. Warning indicators flood the display in red.",
+    "C_object_comparison": "Static wide shot. Projectile crosses the frame leaving a particle trail. Target object glitches violently on impact with wireframe sections breaking apart.",
+    "D_document_display": "Static wide shot. Document shatters into fragments that scatter across the display. DENIED stamp slams down with screen shake.",
+    "E_network_diagram": "Static wide shot. Nodes overload and burst in sequence creating a cascade failure. Connection lines snap with sparking disconnection effects.",
+    "F_timeline": "Static wide shot. A fracture line rips through the timeline splitting it. Events on one side dissolve while the other side burns brighter.",
+    "G_satellite": "Static wide shot. Explosion blooms at the facility location. Debris field expands outward. Before/after overlay wipes across the image.",
+    "H_abstract_concept": "Static wide shot. The balanced structure collapses as one side overwhelms the other. Force arrows reverse direction violently.",
+}
+
+_ANIMATION = AnimationConfig(
+    animation_model="grok-imagine/image-to-video",
+    animation_cost_per_clip=0.10,
+    motion_templates={
+        **{f"low_{k}": v for k, v in _LOW_MOTION.items()},
+        **{f"medium_{k}": v for k, v in _MEDIUM_MOTION.items()},
+        **{f"high_{k}": v for k, v in _HIGH_MOTION.items()},
+    },
+    motion_base_rule=(
+        "Maintain the full original frame composition and camera angle, "
+        "do not zoom or reframe"
+    ),
+    intensity_levels={
+        "low": "Subtle ambient motion. Single element animates, everything else still.",
+        "medium": "Active reveal motion. Up to two subject actions, static camera unless justified.",
+        "high": "Dramatic action. Up to two subject actions, camera only for REVEAL/SCALE/ISOLATION.",
+    },
+    universal_rules=[
+        "Maintain the full original frame composition.",
+        "No human figures, faces, or hands should appear at any point during the animation.",
+        "All text and data labels must remain legible throughout the animation.",
+        "Holographic elements maintain their established color palette.",
+    ],
+    banned_motion_words=[
+        "gently pulse", "softly intensif", "subtly flicker", "softly blink",
+        "dust particles drift", "reflections shift across", "ambient.*glow",
+        "equipment indicators", "projector beams", "light slowly sweeps",
+        "holographic data.*pulse", "subtle ambient",
+    ],
+    emotional_motion_dict={
+        "collapse_failure": [
+            "freeze", "stutter", "desync", "dim in sequence", "go dark one by one",
+            "slow to crawl", "lock up", "disconnect", "fragment", "dissolve",
+            "drain", "flatline",
+        ],
+        "escalation_threat": [
+            "accelerate", "multiply", "cascade", "spread outward", "intensify",
+            "stack up", "compound", "swarm", "converge", "tighten",
+        ],
+        "revelation_discovery": [
+            "snap into focus", "illuminate", "peel back layers", "zoom through",
+            "resolve from static", "sharpen", "decode", "materialize",
+        ],
+        "dominance_power": [
+            "override", "flood", "overwhelm", "lock on", "absorb", "eclipse",
+            "tower over", "consume", "replace",
+        ],
+        "tension_standoff": [
+            "hold unnaturally still", "vibrate", "strain", "pull apart slowly",
+            "hover", "suspend", "balance on edge",
+        ],
+        "loss_absence": [
+            "extinguish", "fade to nothing", "leave empty", "hollow out",
+            "strip away", "erode", "scatter",
+        ],
+    },
+)
+
+
+# =============================================================================
+# Section 8: Thumbnail Identity
+# =============================================================================
+
+_THUMBNAIL = ThumbnailConfig(
+    thumbnail_style="bright_editorial_illustration",
+    thumbnail_text_color="#FFD700",
+    thumbnail_text_style="bold block capitals, thick black outline",
+    thumbnail_max_words_per_line=4,
+    thumbnail_max_lines=2,
+    thumbnail_background="simple, recognizable, reads at 160x90px",
+    thumbnail_palette_max_colors=4,
+    thumbnail_prompt_templates={},  # Templates are in thumbnail_generator/templates.py
+    thumbnail_color_presets={
+        "geopolitics": ["#1a5c6b", "#FFD700", "#333", "#fff"],
+        "finance": ["#b8860b", "#FFD700", "#333", "#fff"],
+    },
+    thumbnail_system_prompt="",  # Full prompt is in anthropic_client.py
+    thumbnail_figure_rules="Generic building/hand, no named political figures",
+)
+
+
+# =============================================================================
+# Section 9: Ken Burns Config
+# =============================================================================
+
+_KEN_BURNS = KenBurnsConfig(
+    direction_map={
+        "wide": "slow_zoom_in",
+        "medium": "slow_pan_right",
+        "closeup": "slow_zoom_out",
+        "environmental": "slow_pan_left",
+        "portrait": "slow_zoom_in",
+        "overhead": "slow_zoom_in",
+        "low_angle": "slow_tilt_up",
+    },
+    presets={
+        "slow_zoom_in": {"start_scale": 1.0, "end_scale": 1.15},
+        "slow_zoom_out": {"start_scale": 1.15, "end_scale": 1.0},
+        "slow_pan_right": {"start_x_offset": -40, "end_x_offset": 40},
+        "slow_pan_left": {"start_x_offset": 40, "end_x_offset": -40},
+        "slow_tilt_up": {"start_y_offset": 30, "end_y_offset": -30},
+    },
+    base_duration=11.0,
+    pan_alternates={
+        "slow_pan_right": "slow_pan_left",
+        "slow_pan_left": "slow_pan_right",
+    },
+)
+
+
+# =============================================================================
+# Section 10: Raw data — enum configs for the 3-variable system
+# =============================================================================
+
+_RAW = {
+    # Content type configurations (8 types)
+    "content_types": {
+        "geographic_map": {
+            "label": "Geographic Map",
+            "use_for": "Locations, territories, shipping routes, military positions, chokepoints, borders",
+            "key_elements": "Country outlines with labels, route lines with directional arrows, position markers, distance annotations, terrain features",
+            "keywords": [
+                "map", "strait", "chokepoint", "border", "territory", "route",
+                "shipping lane", "coastline", "geography", "region", "peninsula",
+                "island", "ocean", "sea", "gulf", "channel", "passage",
+            ],
+        },
+        "data_terminal": {
+            "label": "Data/Financial Terminal",
+            "use_for": "Market reactions, price movements, economic data, statistics, inflation, trade volumes",
+            "key_elements": "Candlestick or line charts, ticker tape feeds, percentage changes with arrows, side panel data readouts, warning indicators",
+            "keywords": [
+                "price", "market", "stock", "inflation", "gdp", "trade volume",
+                "billion", "trillion", "percent", "rate", "index", "crash",
+                "surge", "spike", "plunge", "recession", "growth",
+            ],
+        },
+        "object_comparison": {
+            "label": "Object/Asset Comparison",
+            "use_for": "Scale contrasts, asymmetric warfare, cost comparisons, force comparisons",
+            "key_elements": "Two or more objects in holographic wireframe at relative scale, floating data labels with costs/specs, comparison panels",
+            "keywords": [
+                "versus", "compared to", "asymmetric", "scale", "cost",
+                "drone", "carrier", "fleet", "weapon", "defense", "missile",
+            ],
+        },
+        "document_display": {
+            "label": "Document/Contract Display",
+            "use_for": "Legal frameworks, treaties, insurance policies, executive orders, classified briefs",
+            "key_elements": "Floating translucent document with legible key clauses, highlight annotations, stamps (DENIED/CLASSIFIED/APPROVED), comparison panels",
+            "keywords": [
+                "treaty", "contract", "policy", "insurance", "sanction",
+                "executive order", "law", "regulation", "agreement", "clause",
+                "coverage", "premium", "legal",
+            ],
+        },
+        "network_diagram": {
+            "label": "Network/System Diagram",
+            "use_for": "Trade flows, supply chains, alliance structures, chokepoint networks, cascade effects",
+            "key_elements": "Nodes (glowing orbs) connected by flow lines of varying thickness, labels with percentages, disruption as severed connections",
+            "keywords": [
+                "supply chain", "network", "flow", "interconnected", "cascade",
+                "domino", "contagion", "ripple", "chain reaction", "system",
+                "pipeline", "dependency",
+            ],
+        },
+        "timeline": {
+            "label": "Timeline/Historical Comparison",
+            "use_for": "Historical parallels, pattern recognition, chronological sequences, before/after",
+            "key_elements": "Side-by-side or sequential panels showing different time periods, connecting visual threads, era labels with dates",
+            "keywords": [
+                "history", "historical", "century", "decade", "era", "parallel",
+                "pattern", "1956", "1973", "1979", "2008", "crisis", "before",
+                "precedent", "lesson",
+            ],
+        },
+        "satellite_recon": {
+            "label": "Satellite/Overhead Reconnaissance",
+            "use_for": "Facility damage, ship positions, military deployments, geographic features, before/after",
+            "key_elements": "Top-down or angled satellite perspective, annotation markers, measurement lines, timestamp/classification labels",
+            "keywords": [
+                "satellite", "overhead", "reconnaissance", "facility", "base",
+                "deployment", "imagery", "aerial", "surveillance",
+            ],
+        },
+        "concept_viz": {
+            "label": "Abstract Concept Visualization",
+            "use_for": "Theoretical frameworks, power dynamics, game theory, strategic concepts",
+            "key_elements": "Metaphorical visual structures (chess boards, scales, pressure systems, domino chains), force arrows, equilibrium diagrams",
+            "keywords": [
+                "theory", "framework", "game theory", "equilibrium", "balance",
+                "power dynamic", "strategy", "dilemma", "paradox", "concept",
+            ],
+        },
+    },
+    # Display format configurations (5 formats)
+    "display_formats": {
+        "war_table": {
+            "label": "The War Table (Top-Down Angled)",
+            "framing": "Overhead angled view of a holographic war table surface projecting",
+            "camera_angle": "30-45 degree overhead angle looking down at horizontal holographic table surface",
+            "best_for": "Geographic maps, network diagrams, satellite views",
+        },
+        "wall_display": {
+            "label": "The Wall Display (Front-Facing)",
+            "framing": "Front-facing view of a massive holographic wall display showing",
+            "camera_angle": "Straight-on or slight angle, massive wall-mounted display",
+            "best_for": "Financial terminals, document displays, timeline comparisons",
+        },
+        "floating": {
+            "label": "The Floating Projection (Mid-Air)",
+            "framing": "Eye-level view of holographic objects floating in dark space showing",
+            "camera_angle": "Eye level or slight low angle, content floating in dark space",
+            "best_for": "Object comparisons, abstract concepts, symbolic visualizations",
+        },
+        "multi_panel": {
+            "label": "The Multi-Panel Command (Split Screen)",
+            "framing": "Wide angle view of multiple holographic display panels showing",
+            "camera_angle": "Slight wide angle showing multiple displays at once",
+            "best_for": "Before/after comparisons, historical parallels, cascading events",
+        },
+        "close_up_detail": {
+            "label": "The Close-Up Detail (Macro Focus)",
+            "framing": "Extreme close-up of a holographic display detail showing",
+            "camera_angle": "Tight crop on specific data point, chart section, or document detail",
+            "best_for": "Key statistics, critical text, turning-point moments",
+        },
+    },
+    # Color mood configurations (6 moods)
+    "color_moods": {
+        "strategic": {
+            "label": "STRATEGIC (Teal/Cyan)",
+            "use_for": "Calm analysis, geographic explanation, establishing context, framework introduction",
+            "primary": "#00CED1 teal, #00FFFF cyan",
+            "prompt_language": "cool teal and cyan holographic light against dark background, clinical intelligence aesthetic",
+            "keywords": [
+                "analysis", "strategic", "map", "geography", "framework",
+                "chokepoint", "strait", "position", "context", "overview",
+                "examine", "consider", "intelligence",
+            ],
+        },
+        "alert": {
+            "label": "ALERT (Red/Amber)",
+            "use_for": "Crisis moments, market crashes, attacks, closures, breaking events",
+            "primary": "#FF2D2D deep red, #FFB000 amber",
+            "prompt_language": "red and amber warning colors dominating the display, emergency alert aesthetic, pulsing warning indicators",
+            "keywords": [
+                "crisis", "crash", "attack", "closure", "emergency", "war",
+                "strike", "collapse", "panic", "threat", "danger", "warning",
+                "breaking", "escalate", "conflict", "missile", "bomb",
+            ],
+        },
+        "archive": {
+            "label": "ARCHIVE (Gold/Sepia)",
+            "use_for": "Historical parallels, pattern recognition, lessons from the past",
+            "primary": "#C9A84C warm gold, #D4A574 antique amber",
+            "prompt_language": "warm golden amber holographic light suggesting historical archive, antique brass and wood tones in the room periphery",
+            "keywords": [
+                "history", "historical", "century", "1956", "1973", "1979",
+                "parallel", "pattern", "precedent", "lesson", "era", "past",
+                "archive", "ancient", "empire",
+            ],
+        },
+        "contagion": {
+            "label": "CONTAGION (Green-to-Red)",
+            "use_for": "Cascading effects, spreading economic damage, interconnected failures, domino chains",
+            "primary": "#00FF88 green transitioning through #FFD700 yellow to #FF2D2D red",
+            "prompt_language": "color transitioning from green through yellow to red showing contagion spread, pandemic-style cascade visualization",
+            "keywords": [
+                "cascade", "spread", "contagion", "ripple", "domino",
+                "chain reaction", "infect", "interconnected", "systemic",
+                "spillover", "downstream",
+            ],
+        },
+        "power": {
+            "label": "POWER (Deep Blue/White)",
+            "use_for": "Military force analysis, defense spending, naval power, institutional authority",
+            "primary": "#1B3A5C deep navy, #4682B4 steel blue",
+            "prompt_language": "deep navy blue and steel holographic wireframes with clean white labels, military precision aesthetic",
+            "keywords": [
+                "military", "navy", "fleet", "carrier", "defense", "pentagon",
+                "force", "power", "authority", "institutional", "deployment",
+                "base", "command",
+            ],
+        },
+        "personal": {
+            "label": "PERSONAL (Orange/White)",
+            "use_for": "Viewer impact scenes, personal financial consequences",
+            "primary": "#FF8C00 warm orange, white",
+            "prompt_language": "warm orange and white display with green and red financial indicators, personal impact dashboard aesthetic",
+            "keywords": [
+                "your", "viewer", "wallet", "personal", "afford", "pay",
+                "cost of living", "grocery", "gas price", "savings",
+                "retirement", "household",
+            ],
+        },
+    },
+    # Color mood priority order (for tie-breaking)
+    "color_mood_priority": ["alert", "archive", "strategic", "power", "contagion", "personal"],
+    # Content-format affinity mapping
+    "content_format_affinity": {
+        "geographic_map": ["war_table", "multi_panel"],
+        "data_terminal": ["wall_display", "close_up_detail"],
+        "object_comparison": ["floating", "war_table"],
+        "document_display": ["wall_display", "close_up_detail"],
+        "network_diagram": ["war_table", "floating"],
+        "timeline": ["multi_panel", "wall_display"],
+        "satellite_recon": ["war_table", "close_up_detail"],
+        "concept_viz": ["floating", "war_table"],
+    },
+    # Display format rotation cycle
+    "format_cycle": ["war_table", "wall_display", "floating", "multi_panel", "close_up_detail"],
+    # Establishing shot formats (preferred for first image of each act)
+    "establishing_formats": ["war_table", "wall_display"],
+    # Ken Burns rules per display format
+    "ken_burns_rules_by_format": {
+        "war_table": "slow_zoom_in",
+        "wall_display": "slow_pan_right",
+        "floating": "slow_zoom_out",
+        "multi_panel": "slow_pan_left",
+        "close_up_detail": "slow_zoom_in",
+    },
+    # Default config values
+    "default_config": {
+        "image_duration_seconds": 11,
+        "video_duration_seconds": 1500,
+        "total_images": 136,
+        "act_timestamps": {
+            "act1_end": 90,
+            "act2_end": 360,
+            "act3_end": 720,
+            "act4_end": 1020,
+            "act5_end": 1320,
+            "act6_end": 1500,
+        },
+    },
+    # Style engine legacy constants
+    "style_engine_prefix": _HOLOGRAPHIC_PREFIX,
+    "style_engine_suffix": (
+        "No people visible, no human figures, no faces, no silhouettes, "
+        "only holographic data displays and dark room environment, "
+        "cinematic depth of field, subtle ambient equipment glow."
+    ),
+    # Camera movement vocabulary (for video animation prompts)
+    "camera_movement_by_format": {
+        "war_table": [
+            "Slow orbit around the table surface",
+            "Gentle push-in toward the center of the projection",
+            "Slow crane upward revealing the full table layout",
+            "Subtle drift with parallax depth between table and floating panels",
+        ],
+        "wall_display": [
+            "Slow push-in toward the central display",
+            "Gentle lateral pan across the data panels",
+            "Slow drift from left panel to right panel",
+            "Subtle crane downward from overview to detail",
+        ],
+        "floating": [
+            "Slow orbit around the floating objects",
+            "Gentle push-in between floating elements",
+            "Slow rise from below the projection level",
+            "Subtle rotation revealing different angles of the display",
+        ],
+        "multi_panel": [
+            "Slow lateral pan from left panel to right panel",
+            "Gentle pull-back revealing all panels at once",
+            "Slow drift connecting the panels visually",
+            "Subtle push-in on the central connecting element",
+        ],
+        "close_up_detail": [
+            "Very slow drift to the right across the data",
+            "Gentle push-in on the key data point",
+            "Slow breathing zoom on the focal element",
+            "Subtle rack focus between foreground and background data",
+        ],
+    },
+    # Material vocabulary
+    "material_vocabulary": {
+        "premium": [
+            "holographic gold wireframe", "brass instrument bezels",
+            "polished console surfaces", "amber status indicators",
+        ],
+        "institutional": [
+            "dark console banks", "security-grade displays",
+            "reinforced server racks", "military-grade equipment",
+        ],
+        "data": [
+            "holographic projections", "translucent data overlays",
+            "glowing node networks", "floating analytical panels",
+        ],
+    },
+    # Prompt word budget
+    "prompt_min_words": 60,
+    "prompt_max_words": 150,
+    # Valid scene models for hot-swap
+    "valid_scene_models": {
+        "z-image": "Z Image (default — holographic display, $0.004/img)",
+        "nano-banana-2": "Nano Banana 2 (legacy — reference support, $0.025/img)",
+    },
+}
+
+
+# =============================================================================
+# PROFILE — the single export
+# =============================================================================
+
+PROFILE = VisualProfile(
+    **_IDENTITY,
+    image_gen=_IMAGE_GEN,
+    style_system=_STYLE_SYSTEM,
+    rotation=_ROTATION,
+    figure_rules=_FIGURE_RULES,
+    scene_description=_SCENE_DESCRIPTION,
+    animation=_ANIMATION,
+    thumbnail=_THUMBNAIL,
+    ken_burns=_KEN_BURNS,
+    raw=_RAW,
+)

--- a/skills/video-pipeline/visual_profiles/holographic_hud.py
+++ b/skills/video-pipeline/visual_profiles/holographic_hud.py
@@ -17,6 +17,7 @@ from visual_profiles.schema import (
     RotationConfig,
     SceneDescriptionConfig,
     StyleSystemConfig,
+    TemplateMetadata,
     ThumbnailConfig,
     VisualProfile,
 )
@@ -693,6 +694,54 @@ _RAW = {
 
 
 # =============================================================================
+# Section 11: Template Metadata (StoryEngine)
+# =============================================================================
+
+_TEMPLATE_METADATA = TemplateMetadata(
+    display_name="Holographic Intelligence Display",
+    category="documentary",
+    tags=["dark", "holographic", "data", "intelligence", "geopolitics", "military", "HUD"],
+    description=(
+        "Dark high-security intelligence operations center with holographic "
+        "projections. War room meets Bloomberg Terminal meets Minority Report. "
+        "Zero human figures — every frame is pure analytical data visualization. "
+        "8 content types, 5 display formats, 6 color moods create infinite "
+        "visual variety. Best for: geopolitics, military analysis, economic data, "
+        "investigative journalism."
+    ),
+    preview_prompts=[
+        (
+            "Overhead angled view of a holographic war table surface projecting "
+            "a geographic map of the South China Sea with route lines and position "
+            "markers, cool teal and cyan holographic light against dark background, "
+            "clinical intelligence aesthetic, no people visible, dark operations "
+            "room, photorealistic, 16:9"
+        ),
+        (
+            "Front-facing view of a massive holographic wall display showing "
+            "financial terminal data with candlestick charts spiking violently, "
+            "red and amber warning colors dominating, emergency alert aesthetic, "
+            "pulsing warning indicators, dark operations room, 16:9"
+        ),
+        (
+            "Eye-level view of holographic objects floating in dark space showing "
+            "two military assets in wireframe comparison, deep navy blue and steel "
+            "holographic wireframes with clean white labels, military precision "
+            "aesthetic, dark operations room, 16:9"
+        ),
+    ],
+    best_for=["geopolitics", "military analysis", "economic data", "investigative journalism"],
+    cost_tier="low",
+    estimated_cost_per_video={
+        "10min_no_animation": 1.20,
+        "10min_with_animation": 5.00,
+        "20min_no_animation": 2.00,
+        "20min_with_animation": 10.00,
+    },
+)
+
+
+# =============================================================================
 # PROFILE — the single export
 # =============================================================================
 
@@ -706,5 +755,6 @@ PROFILE = VisualProfile(
     animation=_ANIMATION,
     thumbnail=_THUMBNAIL,
     ken_burns=_KEN_BURNS,
+    template_metadata=_TEMPLATE_METADATA,
     raw=_RAW,
 )

--- a/skills/video-pipeline/visual_profiles/schema.py
+++ b/skills/video-pipeline/visual_profiles/schema.py
@@ -198,6 +198,19 @@ class KenBurnsConfig:
 
 
 @dataclass
+class TemplateMetadata:
+    """StoryEngine template metadata — what customers see during onboarding."""
+    display_name: str = ""
+    category: str = "documentary"
+    tags: list[str] = field(default_factory=list)
+    description: str = ""
+    preview_prompts: list[str] = field(default_factory=list)
+    best_for: list[str] = field(default_factory=list)
+    cost_tier: str = "mid"  # "low" ($2-4), "mid" ($8-12), "high" ($15-20)
+    estimated_cost_per_video: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
 class VisualProfile:
     """Complete visual identity profile for a channel/style.
 
@@ -220,6 +233,7 @@ class VisualProfile:
     animation: AnimationConfig = field(default_factory=AnimationConfig)
     thumbnail: ThumbnailConfig = field(default_factory=ThumbnailConfig)
     ken_burns: KenBurnsConfig = field(default_factory=KenBurnsConfig)
+    template_metadata: TemplateMetadata = field(default_factory=TemplateMetadata)
 
     # Raw profile data for sections that need enum-based configs
     # (e.g. content types, display formats, color moods with their

--- a/skills/video-pipeline/visual_profiles/schema.py
+++ b/skills/video-pipeline/visual_profiles/schema.py
@@ -1,0 +1,227 @@
+"""Visual Profile schema definition.
+
+A visual profile is a self-contained configuration that captures every
+aspect of a channel's visual identity: image generation models, style
+prefixes/suffixes, rotation constraints, figure rules, scene description
+prompts, animation templates, thumbnail identity, and Ken Burns config.
+
+Swapping the entire channel aesthetic = changing one profile reference.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class ImageGenConfig:
+    """Image generation model configuration."""
+    scene_model: str = "z-image"
+    scene_model_params: dict[str, Any] = field(default_factory=lambda: {
+        "aspect_ratio": "16:9",
+        "resolution": "1K",
+        "output_format": "png",
+    })
+    scene_cost_per_image: float = 0.004
+
+    thumbnail_model: str = "nano-banana-pro"
+    thumbnail_model_params: dict[str, Any] = field(default_factory=lambda: {
+        "aspect_ratio": "16:9",
+        "resolution": "2K",
+        "output_format": "png",
+    })
+    thumbnail_cost_per_image: float = 0.09
+
+
+@dataclass
+class SubstyleConfig:
+    """Configuration for a single substyle (e.g. dossier, schema, echo)."""
+    name: str
+    weight: float
+    suffix: str = ""
+    description: str = ""
+
+
+@dataclass
+class StyleSystemConfig:
+    """Style system configuration — replaces style_config.py constants."""
+    style_prefix: str = ""
+    style_suffix: str = ""
+    substyles: dict[str, SubstyleConfig] = field(default_factory=dict)
+
+    # Accent color mapping: topic_category -> color mood value
+    accent_colors: dict[str, str] = field(default_factory=dict)
+
+    # Legacy accent color -> mood value mapping
+    accent_color_to_mood: dict[str, str] = field(default_factory=dict)
+
+    # Topic category -> mood value mapping
+    category_to_mood: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class RotationConfig:
+    """Composition and rotation constraint configuration."""
+    compositions: list[str] = field(default_factory=lambda: [
+        "wide", "medium", "closeup", "environmental", "overhead", "low_angle",
+    ])
+
+    max_consecutive_same_content_type: int = 2
+    max_consecutive_same_format: int = 2
+    max_consecutive_same_palette: int = 3
+    max_consecutive_close_up: int = 1
+
+    # Act-based mood/style weight overrides — keys are act names ("act1".."act6")
+    act_weights: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    # Scene expander style distribution by act number (1-6)
+    scene_expander_style_distribution: dict[int, dict[str, int]] = field(default_factory=dict)
+
+
+@dataclass
+class FigureRulesConfig:
+    """Figure and subject rules — controls human presence in images."""
+    allow_human_figures: bool = False
+    allow_silhouettes: bool = False
+    allow_mannequins: bool = False
+    protagonist_config: Optional[dict[str, Any]] = None
+    negative_prompt_suffix: str = (
+        "no people, no faces, no hands, no silhouettes, no human figures"
+    )
+
+    # Words to detect people references in prompts
+    people_words: list[str] = field(default_factory=list)
+
+    # Regex pattern -> replacement pairs for auto-rewriting people references
+    people_replacements: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class SceneDescriptionConfig:
+    """Scene description rules for LLM system prompts."""
+    # The full system prompt fragment for image prompt generation
+    system_prompt: str = ""
+
+    # Metaphor translation table: abstract concept -> concrete visual
+    metaphor_translation_table: dict[str, str] = field(default_factory=dict)
+
+    # Whether images must contain quantitative data elements
+    quantitative_requirement: bool = False
+
+    # Text-in-image rules
+    text_in_image_rules: str = ""
+
+
+@dataclass
+class AnimationConfig:
+    """Animation/video generation configuration."""
+    animation_model: str = "grok-imagine/image-to-video"
+    animation_cost_per_clip: float = 0.10
+
+    # Motion templates by content_type x intensity
+    motion_templates: dict[str, str] = field(default_factory=dict)
+
+    # Base rule appended to every animation prompt
+    motion_base_rule: str = (
+        "Maintain the full original frame composition and camera angle, "
+        "do not zoom or reframe"
+    )
+
+    # Intensity level descriptions
+    intensity_levels: dict[str, str] = field(default_factory=dict)
+
+    # Universal rules appended to every animation prompt
+    universal_rules: list[str] = field(default_factory=list)
+
+    # Verb-first motion design vocabulary (banned/required words)
+    banned_motion_words: list[str] = field(default_factory=list)
+
+    # Emotional motion dictionary
+    emotional_motion_dict: dict[str, list[str]] = field(default_factory=dict)
+
+
+@dataclass
+class ThumbnailConfig:
+    """Thumbnail visual identity — separate from scene images."""
+    thumbnail_style: str = "bright_editorial_illustration"
+    thumbnail_text_color: str = "#FFD700"
+    thumbnail_text_style: str = "bold block capitals, thick black outline"
+    thumbnail_max_words_per_line: int = 4
+    thumbnail_max_lines: int = 2
+    thumbnail_background: str = "simple, recognizable, reads at 160x90px"
+    thumbnail_palette_max_colors: int = 4
+
+    # Prompt templates by category
+    thumbnail_prompt_templates: dict[str, str] = field(default_factory=dict)
+
+    # Color presets by topic
+    thumbnail_color_presets: dict[str, list[str]] = field(default_factory=dict)
+
+    # System prompt for thumbnail generation
+    thumbnail_system_prompt: str = ""
+
+    # Figure rules specific to thumbnails
+    thumbnail_figure_rules: str = ""
+
+
+@dataclass
+class KenBurnsConfig:
+    """Ken Burns / camera motion configuration."""
+    # Direction map: composition -> ken burns direction
+    direction_map: dict[str, str] = field(default_factory=lambda: {
+        "wide": "slow_zoom_in",
+        "medium": "slow_pan_right",
+        "closeup": "slow_zoom_out",
+        "environmental": "slow_pan_left",
+        "portrait": "slow_zoom_in",
+        "overhead": "slow_zoom_in",
+        "low_angle": "slow_tilt_up",
+    })
+
+    # Scale/offset presets per direction
+    presets: dict[str, dict[str, float]] = field(default_factory=lambda: {
+        "slow_zoom_in": {"start_scale": 1.0, "end_scale": 1.15},
+        "slow_zoom_out": {"start_scale": 1.15, "end_scale": 1.0},
+        "slow_pan_right": {"start_x_offset": -40, "end_x_offset": 40},
+        "slow_pan_left": {"start_x_offset": 40, "end_x_offset": -40},
+        "slow_tilt_up": {"start_y_offset": 30, "end_y_offset": -30},
+    })
+
+    base_duration: float = 11.0
+
+    # Pan alternation pairs
+    pan_alternates: dict[str, str] = field(default_factory=lambda: {
+        "slow_pan_right": "slow_pan_left",
+        "slow_pan_left": "slow_pan_right",
+    })
+
+
+@dataclass
+class VisualProfile:
+    """Complete visual identity profile for a channel/style.
+
+    Every aspect of how images, animations, and thumbnails look is
+    captured here. The pipeline reads the active profile at runtime.
+    """
+    # Identity
+    profile_id: str = ""
+    profile_name: str = ""
+    description: str = ""
+    version: str = "1.0"
+    channel: str = "economy_fastforward"
+
+    # Sections
+    image_gen: ImageGenConfig = field(default_factory=ImageGenConfig)
+    style_system: StyleSystemConfig = field(default_factory=StyleSystemConfig)
+    rotation: RotationConfig = field(default_factory=RotationConfig)
+    figure_rules: FigureRulesConfig = field(default_factory=FigureRulesConfig)
+    scene_description: SceneDescriptionConfig = field(default_factory=SceneDescriptionConfig)
+    animation: AnimationConfig = field(default_factory=AnimationConfig)
+    thumbnail: ThumbnailConfig = field(default_factory=ThumbnailConfig)
+    ken_burns: KenBurnsConfig = field(default_factory=KenBurnsConfig)
+
+    # Raw profile data for sections that need enum-based configs
+    # (e.g. content types, display formats, color moods with their
+    # full config dicts). Stored as plain dicts for flexibility.
+    raw: dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary

Introduces a pluggable visual profile system that allows Economy FastForward to swap entire channel aesthetics by changing a single configuration reference. This replaces hardcoded style constants with a modular, profile-based architecture where each profile is a self-contained configuration capturing image generation models, style rules, animation templates, figure constraints, and scene description prompts.

## Key Changes

- **New `visual_profiles/` package** with schema and loader:
  - `schema.py`: Dataclass definitions for `VisualProfile`, `StyleSystemConfig`, `RotationConfig`, `FigureRulesConfig`, `AnimationConfig`, etc.
  - `__init__.py`: Profile loader with registry and caching; supports environment variable and explicit overrides
  - `README.md`: Documentation for creating and using profiles

- **Three complete, standalone visual profiles**:
  - `holographic_hud.py` (4.0): Dark ops center with holographic projections, zero human figures, 3-variable system (8 content types × 5 formats × 6 moods), full 24-template animation system. Current production aesthetic.
  - `cinematic_dossier.py` (3.0): Prestige documentary photography with Rembrandt lighting, anonymous human figures with obscured faces, 3-substyle rotation (Dossier/Schema/Echo), act-weighted distribution.
  - `clay_mannequin.py` (2.0): 3D editorial clay renders with faceless ceramic mannequins, protagonist golden amber chest glow tracking narrative intensity, single-style composition cycling.

- **Integration points** (thin adapters with hardcoded fallbacks):
  - `image_client.py`: Reads scene/thumbnail models from profile
  - `animation_prompt_engine.py`: Reads universal rules and motion templates from profile
  - `audio_sync/config.py`: Reads Ken Burns config from profile
  - `clients/style_engine.py`: Reads style constants from profile
  - `image_prompt_engine/prompt_builder.py`: Reads prefix/suffix/figure rules from profile
  - `image_prompt_engine/style_config.py`: Reads constants from profile

## Implementation Details

- **Profile selection order**: Explicit `profile_id` argument → `VISUAL_PROFILE` env var → `"holographic_hud"` default
- **Backward compatible**: All integration points fall back to hardcoded defaults when profile loading fails
- **Module-level caching**: One profile loaded per pipeline run
- **Zero human figures enforcement**: Holographic profile includes comprehensive people-word detection and regex-based prompt rewriting
- **Act-weighted mood distribution**: Rotation config supports per-act style/mood weights for narrative pacing
- **Metaphor translation tables**: Scene description rules map abstract concepts to concrete visuals per profile

https://claude.ai/code/session_01SSnBknfJmnhX3dC6kgRHBB