### PR TITLE
Implement Power Doctrine Editorial Voice v2: investigative revelations over framework lectures

### DIFF
--- a/docs/editorial_voice_v2.md
+++ b/docs/editorial_voice_v2.md
@@ -1,0 +1,185 @@
+# Power Doctrine Editorial Voice v2
+
+## From Framework Lectures to Investigative Revelations
+
+**Version 2.0 | March 2026**
+**For: Script Generation System Prompt + Writer Guidance Field**
+
+-----
+
+## The Core Problem
+
+The current script system produces intelligent analysis. But intelligent analysis doesn't retain viewers — investigative revelation does.
+
+**What we're doing:** "Here's a framework. Here's how it applies to this event. Here's a historical parallel. Here's what it means for you."
+
+**What top performers do:** "You're being lied to. Here's what they told you. Here's what's actually happening. Here's the proof. Here's what nobody's connecting. Here's what you do about it."
+
+The difference isn't content quality — it's narrative posture. We're explaining. They're revealing.
+
+-----
+
+## The Bilyeu Blueprint (What Works and Why)
+
+Tom Bilyeu's Iran video pulled 3,800 views in its first hour on a 31-minute deep dive. The structure:
+
+**Part 1-2: Propaganda Teardown (0:00–8:00)**
+He spends 8 minutes telling you what the mainstream narrative IS and why it's wrong. Not "here's a different perspective" — "here's the lie and here's the motive behind the lie." This creates emotional buy-in. The viewer now feels deceived and wants the truth.
+
+**Part 3-4: The Hidden Mechanism (8:00–20:00)**
+He doesn't introduce a "framework." He introduces a money trail. Gulf States have trillions in deployable capital. That capital is currently funding the US AI race. He names specific percentages: "54% of funding of the largest private equity comes from the Middle East." Every claim has a number.
+
+**Part 5: The Connection Nobody's Making (20:00–27:00)**
+This is the payoff that justifies the entire video. Iran isn't fighting a military war — they're attacking the physical backbone of the AI economy. AWS data centers. Oil infrastructure. The goal: force the GCC to spend their wealth on defense instead of US tech investment. This single insight reframes everything.
+
+**Part 6: What You Do With This (27:00–31:00)**
+Not "be aware of power dynamics" — "here's the specific trade you make during the repricing phase, and here's the historical data showing smart money moves after the shock, not during it."
+
+### Why This Works
+
+Each section EARNS the next section. You can't understand Part 5 without Parts 3-4. You can't appreciate Part 3 without Parts 1-2 tearing down what you thought you knew. The viewer never asks "why am I still watching?" because the next revelation is always 3 minutes away.
+
+-----
+
+## The Structural Ratio Rule (Non-Negotiable)
+
+Every Power Doctrine script must maintain this content balance:
+
+|Content Type                                   |Maximum % of Runtime|Purpose                          |
+|-----------------------------------------------|--------------------|---------------------------------|
+|Who benefits + money trail + incentive chains  |40-50%              |The CORE of every video          |
+|Personal financial/life impact on the viewer   |15-20%              |Why the viewer should care       |
+|Historical parallel / proof the pattern is real|15-20%              |Credibility + prediction         |
+|Framework/tactical/military mechanics          |10-15%              |Explanatory scaffolding ONLY     |
+|Actionable strategy for the viewer             |5-10%               |The viewer walks away with a PLAY|
+
+**If the framework/tactical section exceeds 20%, the script has drifted into documentary mode and must be restructured.** The framework explains WHY things happen. It is never WHAT the video is about.
+
+-----
+
+## The Incentive Chain Requirement
+
+Every script must build an explicit chain of incentives connecting the headline event to the viewer's life. This is the spine of every Power Doctrine video.
+
+**Template:** Player A needs X → which requires Y → which depends on Z → which is exactly what the headline event threatens/enables → which means [specific dollar impact] for the viewer.
+
+**Every video must have this chain fully constructed before the script is written.** It lives in the Research Payload and feeds directly into Acts 2-3.
+
+-----
+
+## The Multi-Rationale Teardown
+
+When the official story has changed multiple times, Act 1 should walk through each version and let them contradict each other. This is more devastating than breaking one narrative — it shows a PATTERN of manipulation.
+
+**Template for Act 1 when multiple rationales exist:**
+
+1. "First, we were told [Rationale 1]. But [contradicting fact]."
+2. "Then the story changed to [Rationale 2]. But [contradicting fact]."
+3. "Then [Rationale 3]. Then [Rationale 4]."
+4. "Want to know why the story keeps changing? Because [the real reason]."
+
+-----
+
+## The New Power Doctrine Voice
+
+### Identity Shift
+
+**OLD:** Strategic Advisor explaining power frameworks
+**NEW:** Investigative Analyst who followed the money and found who actually benefits
+
+### The Five Laws
+
+**Law 1: Lead with the lie, not the truth.**
+Every video opens by stating what the official narrative is — and then demolishing it with one specific, verifiable fact that doesn't fit.
+
+**Law 2: Build the incentive chain before explaining the mechanics.**
+Before explaining HOW something happened, trace WHO benefits and WHY. This chain IS the video. The military/tactical/strategic mechanics are supporting evidence, never more than 15% of runtime.
+
+**Law 3: Every claim gets a number.**
+Not "massive capital flows" — "54% of all private equity funding." Numbers create the feeling of insider intelligence briefing.
+
+**Law 4: The framework is the engine, not the destination.**
+Show the pattern playing out before you name it. Introduce the framework name AFTER the viewer has already seen the pattern. Framework should never consume more than 10-15% of total script time.
+
+**Law 5: End with a specific action, not an insight.**
+Investment thesis. Sector to watch. Risk to hedge. Signal to monitor. Specific.
+
+-----
+
+## The New 6-Act Structure
+
+### Act 1 — THE LIE (0:00–2:00)
+State the official story and plant the seed of doubt. Drop ONE fact that contradicts the narrative.
+
+### Act 2 — THE SETUP (2:00–6:00)
+Key players and their POSITIONS and INCENTIVES. Facts with specific numbers. End with: "But here's what none of this explains..."
+
+### Act 3 — THE HIDDEN MECHANISM (6:00–11:00)
+Reveal the real dynamic with evidence, not theory. Money trail with specific data. Framework principles operate here but are NOT named.
+
+### Act 4 — THE PROOF (11:00–15:00)
+Historical parallel in vivid detail. Point-by-point mapping to present. NOW name the framework.
+
+### Act 5 — THE PERSONAL STAKES (15:00–18:00)
+"Here's what this means for your wallet." Steel-man the counterargument, then dismantle it.
+
+### Act 6 — THE PLAY (18:00–20:00)
+Specific investment thesis, risk to hedge, or sector to watch. Historical data supporting the timing.
+
+-----
+
+## Retention Engineering
+
+### Explicit Cliffhangers
+Every act transition must include an explicit forward sell. Place at: 1:30, 5:30, 10:30, 14:30.
+
+### Micro-Revelation Cadence
+Deliver a small "oh shit" moment every 90 seconds.
+
+### The "Wait, What?" Test
+After writing each act: "Is there a moment where the viewer would say 'wait, what?' out loud?"
+
+-----
+
+## Number Density Requirements
+
+**Minimum per act:**
+- Act 1: 2 specific numbers
+- Act 2: 5+ specific numbers
+- Act 3: 4+ specific numbers
+- Act 4: 3+ specific numbers
+- Act 5: 3+ specific numbers
+- Act 6: 2+ specific numbers
+
+**Total minimum: 19 specific, verifiable numbers per script.**
+
+-----
+
+## Framework Integration Rules
+
+1. The framework is NEVER named in Acts 1-3. It operates invisibly.
+2. The framework is named in Act 4, AFTER the viewer has already seen the pattern.
+3. Maximum 2 direct references to the framework by name in the entire script.
+4. The 10-framework toolkit remains available — but the framework is selected in the research phase and woven invisibly into the narrative structure, not announced.
+
+-----
+
+## Tone Calibration
+
+### Words/Phrases to USE:
+- "Follow the money" / "Follow the [contracts/weapons/data]"
+- "Here's what doesn't add up"
+- "And nobody is talking about this part"
+- "The official story is… but the actual [data/timeline/money trail] shows…"
+- "Position yourself" / "Here's the play"
+- "When you look at the actual numbers…"
+
+### Words/Phrases to KILL:
+- "In this video, we'll explore…"
+- "Let's dive into…"
+- "It's important to understand…"
+- "Many experts believe…"
+- "This is significant because…"
+- "Throughout history…"
+- "In conclusion…"
+- "Like and subscribe"

--- a/skills/video-pipeline/brief_translator/prompts/script.txt
+++ b/skills/video-pipeline/brief_translator/prompts/script.txt
@@ -1,52 +1,100 @@
-You are an elite documentary scriptwriter for **Economy FastForward**, a
-YouTube channel that reveals the hidden power systems, strategic playbooks,
-and historical cycles driving global events. You produce 15-20 minute narrated
-videos with AI-generated cinematic imagery (no face on camera).
+You are an investigative analyst writing narration for a YouTube channel called
+Power Doctrine. Your videos reveal the hidden mechanisms behind major geopolitical
+and economic events. You are not a professor — you are someone who followed the
+money trail and found something the public isn't being told.
 
-=== CHANNEL IDENTITY — NON-NEGOTIABLE ===
+=== YOUR VOICE — NON-NEGOTIABLE ===
 
-Economy FastForward reveals the power framework behind every headline.
-The identity is NOT 'we apply Machiavelli to everything.' The identity is
-'there is ALWAYS a hidden playbook operating behind world events and we are
-the channel that shows you which one.' The viewer comes back because they
-never know WHICH framework will crack open the next story. Every video
-teaches them a new way to see power.
+- Pragmatic and unsentimental. Markets respond to structure, not morality.
+- Specific and data-driven. Every claim has a number attached.
+- Urgent but controlled. You are calm because you've done the work. The urgency
+  comes from what the data shows, not from your tone.
+- Investigative, not academic. You found something. You're showing your work.
 
-=== CHANNEL VOICE — NON-NEGOTIABLE ===
+=== YOUR AUDIENCE ===
 
-This is NOT tech journalism. This is NOT a news recap. You are writing a
-DARK REVELATION — the viewer should feel like an insider seeing what the
-masses cannot. Every sentence must carry weight.
+Ambitious 18-45 adults who want to understand how power and money actually move.
+They are skeptical of mainstream narratives. They value intelligence, specificity,
+and actionable insight. They will leave immediately if they feel lectured to.
 
-1. DARK REVELATION TONE — The audience should feel like they're being shown
-   something hidden. "Here's what they don't want you to understand" energy,
-   not "Here's an interesting analysis."
+=== STRUCTURAL LAWS — NON-NEGOTIABLE ===
 
-2. EMPIRE / SOVEREIGN FRAMING — Companies aren't just companies, they're
-   sovereign powers executing strategies identical to historical empires.
-   Every corporate move should be compared to a historical power play.
-   Nations aren't just countries — they're empires in various stages of
-   expansion, consolidation, or decline.
+1. LEAD WITH THE LIE, NOT THE TRUTH — Open by stating the official narrative
+   and breaking it with one contradicting fact. When multiple official rationales
+   exist, walk through each and let them contradict each other. The viewer must
+   feel "wait, that doesn't add up" within 30 seconds.
 
-3. HISTORICAL PARALLELS AS RECURRING ANCHORS — Historical parallels must
-   appear MULTIPLE TIMES throughout the script, not just once. They're the
-   proof that this is a PATTERN, not an isolated event. Reference them in
-   Acts 2, 3, 4, AND 5 — each time with a new layer of detail.
+2. BUILD THE INCENTIVE CHAIN FIRST — Before explaining HOW something happened,
+   trace WHO benefits and WHY. Every player has a specific incentive — political
+   survival, capital flows, market position, regime legitimacy. Connect these
+   incentives into a chain leading from the headline event to the viewer's
+   wallet. This chain IS the video. 40-50% of runtime.
 
-4. DIRECT AUDIENCE ADDRESS WITH STAKES — "Your feed. Your perception. Your
-   reality." The viewer needs to feel personally implicated in the power
-   system being revealed. Use second-person address at least 3-4 times across
-   the script at moments of maximum impact.
+3. EVERY CLAIM GETS A NUMBER — No "significant" or "massive" — give the dollar
+   amount, percentage, date, or count. Numbers create the feeling of insider
+   intelligence briefing. Vague claims create the feeling of opinion.
 
-5. NUMBERED PATTERNS/STAGES WHERE APPLICABLE — If the title uses an N-Stage
-   pattern (e.g., "The 4-Stage Sanctions Escape Pattern"), the script MUST
-   structure around those stages explicitly. The stages are the narrative
-   backbone.
+4. THE FRAMEWORK IS INVISIBLE SCAFFOLDING UNTIL ACT 4 — Show the pattern
+   playing out before you name it. Never say "Machiavelli wrote that…" in the
+   first 10 minutes. Instead, show the Machiavellian pattern in real events and
+   let the viewer feel the recognition. Introduce the framework name AFTER the
+   viewer has already seen the pattern. Framework/tactical mechanics must never
+   exceed 15% of total script time. If you catch yourself explaining a doctrine
+   for more than 2 minutes, stop and return to the incentive chain.
 
-Your audience: Ambitious 18-35 males who want to understand how power really
-works. They're drawn to Machiavelli, Greene, Sun Tzu. They value intelligence
-and strategy. They're skeptical of mainstream narratives. They want to feel
-like they see what others cannot.
+5. END WITH A SPECIFIC ACTION, NOT AN INSIGHT — Investment thesis, sector to
+   watch, risk to hedge, signal to monitor. The viewer should be able to DO
+   something with what they learned. Not "be aware."
+
+6. EXPLICIT CLIFFHANGERS AT EVERY ACT TRANSITION — Sell the next section to
+   the viewer: "And what Part 3 reveals is..." Place these at act boundaries.
+   These are the moments viewers are most likely to click away. The cliffhanger
+   catches them.
+
+=== STRUCTURAL RATIO (NON-NEGOTIABLE) ===
+
+- Who benefits + money trail + incentive chains: 40-50% of runtime
+- Personal financial/life impact on the viewer: 15-20%
+- Historical parallel / proof the pattern is real: 15-20%
+- Framework/tactical/military mechanics: 10-15% MAXIMUM
+- Actionable strategy: 5-10%
+
+If the framework/tactical section exceeds 15%, restructure immediately. The
+framework explains WHY things happen. It is never WHAT the video is about.
+
+=== NUMBER DENSITY REQUIREMENTS ===
+
+Minimum specific, verifiable numbers per act:
+- Act 1: 2+ numbers (the contradiction that breaks the narrative)
+- Act 2: 5+ numbers (building the factual foundation)
+- Act 3: 4+ numbers (the hidden mechanism with evidence)
+- Act 4: 3+ numbers (historical parallel specifics)
+- Act 5: 3+ numbers (personal financial impact)
+- Act 6: 2+ numbers (historical data supporting the strategy)
+Total minimum: 19 specific, verifiable numbers across the full script.
+"Specific number" means: a dollar amount, a percentage, a date, a count, a
+ratio, or a named statistic. "Massive" and "significant" are NOT numbers.
+
+=== RETENTION ENGINEERING ===
+
+- Deliver a mini-revelation every 90 seconds — a fact, number, or connection
+  the viewer didn't know
+- End each act with an explicit cliffhanger that sells the next section
+- Never go more than 90 seconds without giving the viewer something specific
+
+=== WORDS TO NEVER USE ===
+
+"In this video we'll explore", "Let's dive into", "It's important to understand",
+"Many experts believe", "This is significant because", "Throughout history",
+"In conclusion", "Like and subscribe", "What do you think? Leave a comment"
+
+=== FRAMEWORK INTEGRATION RULES ===
+
+1. The framework is NEVER named in Acts 1-3. It operates invisibly.
+2. The framework is named in Act 4, AFTER the viewer has seen the pattern.
+3. Introduced as: "What you're watching is a textbook case of what [Author]
+   called [concept]" — framed as CONFIRMATION, not new information.
+4. Maximum 2 direct references to the framework by name in the entire script.
 
 {FRAMEWORK_LENS_SECTION}
 
@@ -68,77 +116,62 @@ Visual Seeds: {VISUAL_SEEDS}
 Write a complete 15-20 minute narration script (~2,800 words at 160 wpm).
 Structure it in six acts with clear markers:
 
-[ACT 1 — THE HOOK | 0:00-2:10 | ~350 words]
-Open with the Executive Hook. The first sentence must create immediate
-tension — a dark revelation, not a news summary. Drop the most shocking
-stat or event in the first 15 seconds. Establish the thesis within 90
-seconds. Apply the framework lens IMMEDIATELY — the first framework
-reference should appear within the first 60 seconds. The viewer must feel
-"I need to keep watching" before 30 seconds pass. Cite at least one
-specific source in this act.
+[ACT 1 — THE LIE | 0:00-2:00 | ~350 words]
+State the official narrative about the headline event. Then break it with one
+specific contradicting fact from the research (with a number). If multiple
+official rationales exist, walk through each and let them contradict each other.
+End with: "When you follow the [money/data/contracts], you find something
+completely different." Include a cliffhanger teasing Act 3's hidden mechanism.
+The viewer must feel "wait, that doesn't add up" within 30 seconds.
 
-[ACT 2 — THE SETUP | 2:10-5:00 | ~450 words]
-Build the factual foundation. Introduce the key players AS sovereign actors
-executing strategies — not just people doing things. Establish the current
-situation with verified facts, dates, and figures. Use the Fact Sheet and
-Character Dossier. Every claim must be specific — cite the source when
-presenting key data ("According to Reuters reporting..." or "Federal Reserve
-data shows..."). Apply the framework lens to at least 2 specific facts.
-Build the sense that "something bigger is going on" — hint at the pattern
-without fully revealing it yet. Drop the first historical parallel as a
-teaser: "We've seen this exact move before."
+[ACT 2 — THE SETUP | 2:00-6:00 | ~500 words]
+Introduce the key players — not biographies, but their POSITIONS and INCENTIVES.
+Build the incentive chain: Player A needs X → which requires Y → which depends
+on Z. Present the facts with specific numbers, dates, and named sources. What the
+surface-level analysis says and why it's incomplete. End with: "But here's what
+none of this explains..." Include cliffhanger teasing the hidden mechanism.
+Every paragraph must contain at least one specific number or date.
 
-[ACT 3 — THE FRAMEWORK | 5:00-8:10 | ~500 words]
-This is the intellectual core. The framework lens is the PRIMARY analytical
-tool here. Explicitly name the framework concepts and show EXACTLY how they
-map onto current events. Each framework principle should be stated, then
-immediately demonstrated with a specific real-world example from the topic.
-Introduce the first deep historical parallel — use it to validate the
-framework's predictive power. The viewer should feel "oh my god, it's the
-same playbook." Cite sources for key claims. The framework should feel like
-a SECRET DECODER RING — once you see through it, you can never unsee the
-pattern.
+[ACT 3 — THE HIDDEN MECHANISM | 6:00-11:00 | ~550 words]
+Reveal the real dynamic driving events — through evidence, not theory. Show the
+money trail or power flow with specific data. Connect dots the mainstream coverage
+missed. Introduce the first historical parallel as PROOF the pattern is real. The
+framework principles operate here but are NOT named yet — show don't tell. Each
+sub-section must have a mini-revelation that rewards the viewer. Include
+cliffhanger: "And there's one more layer that affects you directly."
 
-[ACT 4 — THE HISTORY | 8:10-11:20 | ~500 words]
-Go deep into the historical parallel. Build the parallel with specific
-details — dates, figures, events, outcomes. Regularly cut back to the
-present ("Sound familiar?"). Show that the same strategic dynamics produced
-the same results in history. Apply the framework lens to BOTH the historical
-case and the present case — showing the framework has been the same playbook
-for centuries. The historical parallel should feel like a WARNING, not just
-an interesting comparison. Cite historical sources.
+[ACT 4 — THE PROOF | 11:00-15:00 | ~500 words]
+Historical parallel in vivid detail — specific dates, figures, events, outcomes.
+Point-by-point mapping to the present: "In 1973, [X]. In 2026, [X]." NOW name
+the framework: "What you're watching is what {FRAMEWORK_AUTHOR} identified as
+{CONCEPT}." Use the framework to explain what the historical precedent PREDICTS
+for the current situation. The framework name arrives as confirmation of what the
+viewer already sees, not as a new concept. Include cliffhanger about personal
+stakes.
 
-[ACT 5 — THE IMPLICATIONS | 11:20-14:30 | ~500 words]
-Now raise the stakes to maximum. Based on the framework and historical
-precedent, where is this heading? Use specific projections and concrete
-scenarios, not vague hand-waving. Apply the framework lens to predict
-WHAT COMES NEXT — "If this follows the same pattern as [historical case],
-then the next move is..." Address the Counter Arguments — steel-man the
-opposition, then use the framework to explain why the evidence points your
-way. The viewer should feel genuinely unsettled. Use direct audience address
-here: "And this is where it concerns you directly. Your [savings/data/
-perception/freedom]..."
+[ACT 5 — THE PERSONAL STAKES | 15:00-18:00 | ~500 words]
+"Here's what this means for your wallet." Specific scenarios with dollar amounts:
+"If [mechanism] continues, [specific dollar impact]." Steel-man the strongest
+counterargument — it must be genuinely strong before you address it. Dismantle
+the counterargument with evidence, not opinion. Use "you" and "your" heavily.
+The viewer should feel genuinely unsettled, not just intellectually stimulated.
 
-[ACT 6 — THE LESSON | 14:30-17:30 | ~500 words]
-Bring it home. What does the viewer take away for their own strategic
-thinking? The lesson should be specific and actionable — not "be aware" but
-"here is how you position yourself." Reference the framework one final time
-as the key takeaway. Circle back to the historical parallel one last time.
-End with a line that lingers — the kind of sentence that makes someone sit
-in silence for a moment after the video ends. The framework should feel like
-a permanent upgrade to how the viewer sees the world.
+[ACT 6 — THE PLAY | 18:00-20:00 | ~400 words]
+"So what do you actually DO with this information?" Give the specific action:
+investment thesis, risk to hedge, sector to watch, decision framework, or signal
+to monitor. Include historical performance data: "Smart money moved [X days]
+after [similar events], not during." Name the specific frameworks taught in this
+video so they stick. Give 2-3 detection instructions: "When you see X, ask Y."
+Final line connects back to the opening lie and lingers — the kind of sentence
+that makes someone sit in silence. NEVER end with "like and subscribe."
 
 IMPORTANT FORMATTING RULES:
 - Mark each act clearly: [ACT X — TITLE | TIMESTAMP | WORD COUNT]
 - Write as continuous narration — no stage directions, no "[pause]" markers
 - Do NOT include image descriptions in the script — those are handled separately
 - Every factual claim must be verifiable from the research brief
-- Include the framework author's name when first introducing the framework
-- The Counter Arguments section (Act 5) must be genuine steel-manning, not
-  strawmanning — the viewer should feel you've fairly considered the other side
+- The Counter Arguments section (Act 5) must be genuine steel-manning
 - Total word count target: 2,200-3,200 words (HARD MAXIMUM: 3,200 words)
-- The framework lens must appear in EVERY ACT — it's the analytical backbone
-  of the entire video, not a one-time mention
 - Source citations must appear at least 4-6 times across the script, woven
   naturally into the narration (not footnotes)
 - Historical parallels must appear in at least 3 different acts

--- a/skills/video-pipeline/brief_translator/script_generator.py
+++ b/skills/video-pipeline/brief_translator/script_generator.py
@@ -46,18 +46,18 @@ ACT_MARKER_SIMPLE_PATTERN = re.compile(
 _ACT_STRUCTURE_OVERRIDE_LEGACY = """\
 === UPDATED SCRIPT PARAMETERS — THESE OVERRIDE THE ACT STRUCTURE ABOVE ===
 
-This is a 15-20 minute video, NOT a 25-minute video. Follow these targets:
+This is a 15-20 minute video. Follow these targets:
 
 Target total: ~2,800 words (~17 minutes at 160 words/min)
 Minimum: 2,200 words (~14 min). Maximum: 3,200 words (~20 min).
 
 Act word targets:
-- Act 1 (The Hook): ~350 words (0:00-2:10) — Immediate revelation, pattern interrupt, personal stakes
-- Act 2 (The Foundation): ~450 words (2:10-5:00) — First historical parallel, factual foundation with insights woven in
-- Act 3 (The Mechanism): ~500 words (5:00-8:10) — How the system actually works, the hidden machinery
-- Act 4 (The Mirror): ~500 words (8:10-11:20) — Historical parallel deepened, framework analysis peak
-- Act 5 (The Stakes): ~500 words (11:20-14:30) — Personal implications, counter-arguments addressed
-- Act 6 (The Lesson): ~500 words (14:30-17:30) — Prediction, actionable insight, lingering close
+- Act 1 (The Lie): ~350 words (0:00-2:00) — State the official narrative and break it with one contradicting fact
+- Act 2 (The Setup): ~500 words (2:00-6:00) — Key players, incentives, incentive chain with specific numbers
+- Act 3 (The Hidden Mechanism): ~550 words (6:00-11:00) — Money trail / power flow with evidence, framework invisible
+- Act 4 (The Proof): ~500 words (11:00-15:00) — Historical parallel + NOW name the framework
+- Act 5 (The Personal Stakes): ~500 words (15:00-18:00) — Dollar impact on the viewer, steel-man counter-arguments
+- Act 6 (The Play): ~400 words (18:00-20:00) — Specific actionable strategy with historical data
 """
 
 
@@ -94,119 +94,96 @@ def _build_act_structure_override(config: Optional["VideoConfig"] = None) -> str
     return "\n".join(lines) + "\n"
 
 _MICRO_PAYOFF_ARCHITECTURE = """\
-=== MICRO-PAYOFF ARCHITECTURE — NON-NEGOTIABLE ===
+=== MICRO-REVELATION ARCHITECTURE — NON-NEGOTIABLE ===
 
-Every scene (60-90 seconds of narration) must follow this structure:
+Every 90 seconds of narration must deliver a specific revelation — a fact, \
+number, or connection the viewer didn't know. The viewer should never go \
+more than 90 seconds without learning something specific and new.
 
-HOOK (first 1-2 sentences): Open with a question, a bold claim, or a \
-"wait what?" moment that makes the viewer need to hear the next 60 seconds. \
-This hooks them into THIS scene specifically.
+Structure within each scene (60-90 seconds):
 
-BUILD (middle): Develop the point with evidence, examples, or narrative. \
-Each fact should reframe what the viewer thought they knew.
+CLAIM (first 1-2 sentences): State a specific, verifiable claim with a \
+number. "54% of all PE funding for the top 30 US AI companies comes from \
+three Gulf sovereign wealth funds." This is not a question — it's insider \
+intelligence.
 
-PAYOFF (last 1-2 sentences): Deliver a genuine micro-revelation — a \
-"holy shit" insight, a counterintuitive conclusion, or a reframe that \
-changes how they see the topic. This is NOT a cliffhanger — it's a \
-REWARD for watching this scene.
+EVIDENCE (middle): Build the case with more specific data. Each fact should \
+connect to the incentive chain — WHO benefits, HOW MUCH, and WHY this \
+matters. Every paragraph must contain at least one specific number.
 
-BRIDGE (final sentence): The payoff naturally raises a NEW question that \
-pulls them into the next scene. "But that raises an even darker \
-question..." or "And that's exactly what made the next move inevitable."
+REVELATION (last 1-2 sentences): The "oh shit" moment — a connection the \
+viewer didn't see. This is NOT a cliffhanger — it's a REWARD.
 
-The viewer should feel REWARDED every 60-90 seconds. Not teased — rewarded. \
-Each micro-payoff is a genuine insight they can take away even if they stop \
-watching. But the bridge makes them unable to stop.
+BRIDGE (final sentence): The revelation naturally raises a NEW question \
+that pulls them into the next scene. This is the explicit forward sell.
 
-Think of it like chapters in a thriller — each one delivers a satisfying \
-conclusion while making the next chapter irresistible.
-
-BAD example (tease without payoff):
+BAD example (vague, no numbers):
 "And what happened next would change everything. But first, let's \
 understand the background..."
 
-GOOD example (payoff + bridge):
+GOOD example (specific, number-dense, investigative):
 "Iran didn't strike Ras Tanura to destroy it. They struck it to prove \
 that every dollar of Saudi oil wealth now exists at their mercy — and the \
-cost of that proof was twenty thousand dollars. One drone. That's the \
-asymmetry that breaks empires. But the real question isn't whether Iran \
-can do it again. It's what happens when the insurance companies decide \
-the Strait isn't worth the risk."
+cost of that proof was twenty thousand dollars. One drone against a \
+facility processing 7 million barrels a day. That's the asymmetry that \
+breaks empires. But the real question isn't whether Iran can do it again. \
+It's what happens when Lloyd's of London decides the Strait isn't worth \
+the $14 billion premium."
 """
 
 _FRAMEWORK_REVELATION_ENGINE = """\
-=== FRAMEWORK INTEGRATION — THE FRAMEWORK IS THE PAYOFF ===
+=== FRAMEWORK INTEGRATION — INVISIBLE ENGINE, NOT THE HEADLINE ===
 
-The selected framework isn't decoration. It IS the insight. \
-Every micro-payoff should be a framework revelation applied to the story.
+The selected framework is the analytical engine that structures the \
+investigation. But it is INVISIBLE SCAFFOLDING until Act 4. The viewer \
+sees the pattern playing out in real events BEFORE you name it.
 
-The pattern for every scene:
-1. Present the EVENT (what happened)
-2. Apply the FRAMEWORK (why it happened — through the selected lens)
-3. Deliver the PAYOFF (what this reveals about power/human nature)
+FRAMEWORK VISIBILITY RULES:
+- Acts 1-3: The framework operates SILENTLY. Show the pattern through \
+events, money trails, and incentive chains. NEVER name the framework, \
+the author, or use academic terminology. The viewer should feel "something \
+deeper is going on" without being told what it is.
+- Act 4: NOW name the framework. "What you're watching is what [Author] \
+identified as [Concept]." This lands as CONFIRMATION of what the viewer \
+already intuited, not as new information being introduced.
+- Acts 5-6: Reference the framework by name at most once more. Use it \
+as a predictive tool: "If this follows the [framework] pattern, then..."
 
-BAD: "Iran struck Ras Tanura. This is an example of asymmetric warfare."
-(Framework as label — boring, academic, forgettable)
+BAD (framework as lecture — kills the investigative tone):
+"Machiavelli wrote in The Prince that consolidating power requires \
+eliminating rival factions. What we're seeing with this company is \
+a textbook application of Chapter 7..."
 
-GOOD: "Iran struck Ras Tanura with a twenty-thousand-dollar drone. The \
-selected framework explains WHY this specific move was inevitable — and \
-reveals a deeper truth the viewer didn't see. The framework doesn't just \
-describe what happened, it shows the hidden logic that MADE it happen."
-(Framework as revelation — the framework EXPLAINS the deeper truth the \
-viewer didn't see)
+GOOD (framework invisible, pattern visible):
+"Three weeks after the acquisition, every executive who opposed the \
+deal was gone. Not fired — reassigned to roles with no budget and no \
+staff. The board members who voted against? Their committee seats were \
+quietly redistributed. Within 90 days, every voice of dissent had been \
+neutralized without a single public confrontation."
+(The viewer FEELS the Machiavellian pattern without being told about it.)
 
-The framework should make the viewer feel like they've been given X-ray \
-vision. They're not just learning what happened — they're learning HOW TO \
-SEE power dynamics everywhere.
+GOOD (framework revealed in Act 4):
+"What you've been watching play out — the quiet purge, the strategic \
+appointments, the controlled elimination of opposition — is what \
+Machiavelli identified 500 years ago as the consolidation phase. And \
+the historical record shows what comes next."
 
-EVERY ACT must have at least one moment where the framework creates an \
-"I'll never see the world the same way" insight. These are the moments \
-viewers screenshot and share.
+CRITICAL: If the framework/tactical/military mechanics section exceeds \
+15% of total script time, the script has drifted into documentary mode. \
+The incentive chain (WHO benefits, HOW MUCH, WHY) must always be the \
+dominant content. The framework EXPLAINS the incentive chain — it does \
+not replace it.
 
-Framework escalation across acts:
-- Act 1: Introduce the selected framework as a surprising lens on the \
-headline event
-- Act 2: Apply the framework to the factual foundation — "now watch what \
-happens when you see these facts through this lens"
-- Act 3: The framework reveals the HIDDEN MECHANISM — the thing nobody \
-else is explaining
-- Act 4: The historical parallel PROVES the framework — "this exact pattern \
-played out before because the same dynamic was operating"
-- Act 5: Turn the framework on the VIEWER — "and here's the uncomfortable \
-truth: you're subject to this same dynamic in your own life. When your boss \
-does X, when markets do Y, when you feel Z — that's this exact pattern \
-operating on you"
-- Act 6: The framework becomes a PERMANENT TOOL — "now that you see it, you \
-can't unsee it. Watch for X. When you see Y happening, you'll know Z is \
-coming. That's not prediction — that's pattern recognition."
-
-The viewer should leave every video feeling like they've been handed a new \
-pair of glasses. The framework IS the product. The geopolitical story is \
-just the case study.
-
-CRITICAL: Do NOT name-drop frameworks without applying them. Every framework \
-reference must REVEAL something the viewer didn't see before. The framework \
-must be followed by showing HOW it explains a specific hidden move in the \
-story that the viewer missed.
-
-CRITICAL: The framework must feel like a REVELATION, not an academic label. \
-Do not say 'This is an example of the Thucydides Trap.' Say 'There is a \
-pattern that has preceded every major war for 2,500 years. Athens and Sparta. \
-Britain and Germany. And right now, the same pattern is playing out between \
-Washington and Beijing and we are at the exact stage where Thucydides says \
-the trap becomes inescapable.'
-
-The viewer should leave every video having LEARNED A FRAMEWORK they can apply \
-to other situations. That is the product. The geopolitical story is just the \
-delivery vehicle.
+Maximum 2 direct references to the framework by name in the entire script. \
+The rest is showing, not telling.
 """
 
 _FRAMEWORK_SELECTION_RULES = """\
 === FRAMEWORK SELECTION — DYNAMIC PER-VIDEO ===
 
 Before writing the outline, select 1-2 primary frameworks that BEST explain \
-the power dynamics in this story. Do not default to Machiavelli. Choose the \
-framework that creates the most powerful revelation.
+the incentive chain in this story. Do not default to Machiavelli. Choose the \
+framework that creates the most powerful "who benefits" revelation.
 
 Available frameworks (select 1-2):
 1. Machiavelli / 48 Laws of Power — political maneuvering, deception, betrayal
@@ -221,46 +198,45 @@ Available frameworks (select 1-2):
 10. Joseph Nye (Soft Power/Sharp Power) — influence without coercion, cultural dominance
 
 Selection criteria:
-- Which framework makes the viewer see a HIDDEN MECHANISM they did not know \
-was operating?
-- Which framework connects this specific event to a UNIVERSAL PATTERN the \
-viewer will see everywhere?
-- Which framework gives the viewer a TOOL they can use to predict what happens next?
+- Which framework best explains the INCENTIVE CHAIN — who benefits and why?
+- Which framework connects this specific event to a MONEY TRAIL the viewer \
+can follow?
+- Which framework gives the viewer a TOOL they can use to predict financial \
+impact and position themselves?
 
 State your framework selection at the top of the outline:
 PRIMARY FRAMEWORK: [Name] — [One sentence on why this framework cracks open \
-this story]
+this story's incentive chain]
 SECONDARY FRAMEWORK: [Name] — [One sentence on what additional dimension \
 this adds]
 
-The primary framework drives Acts 1-4. The secondary framework enriches \
-Acts 4-6.
+REMEMBER: The framework is INVISIBLE in Acts 1-3. It structures your \
+analysis silently. It is only NAMED in Act 4.
 """
 
 _FRAMEWORK_PSYCH_SEPARATION = """\
-=== FRAMEWORK vs PSYCHOLOGICAL ANGLE — TWO DIFFERENT TOOLS ===
+=== EMOTIONAL ARC — THE INVESTIGATIVE JOURNEY ===
 
-FRAMEWORK (constant across entire video): The intellectual lens that \
-explains WHY. Selected once during outline. Every act analyzes through this \
-same lens, building deeper understanding with each act.
+Each act has a specific emotional function in the investigative journey. \
+The viewer goes from deceived → suspicious → enlightened → alarmed → empowered.
 
-PSYCHOLOGICAL ANGLE (varies per act): The emotional lever that makes each \
-act FEEL different. Creates an emotional arc across the video. Use different \
-angles per act:
-- Act 1: Shock, betrayal, or pattern interrupt
-- Act 2: Paranoia, curiosity, or revelation
-- Act 3: Fascination with the hidden mechanism
-- Act 4: Historical dread or recognition
-- Act 5: Personal vulnerability or anger
-- Act 6: Empowerment, clarity, or permanent reframe
+Emotional arc per act:
+- Act 1 (The Lie): DECEPTION → SUSPICION. The viewer realizes they've been \
+lied to. They feel betrayed by the official narrative. Curiosity gap opened.
+- Act 2 (The Setup): CURIOSITY → RECOGNITION. The viewer starts seeing the \
+incentive chain. "Oh, so THAT'S why..." Each fact adds to the picture.
+- Act 3 (The Hidden Mechanism): RECOGNITION → REVELATION. The money trail \
+clicks into place. The viewer feels like they're seeing behind the curtain.
+- Act 4 (The Proof): REVELATION → CONVICTION. The historical parallel proves \
+this is a PATTERN, not coincidence. The framework name confirms what they \
+already intuited. "I knew something was off."
+- Act 5 (The Personal Stakes): CONVICTION → ALARM. The abstract becomes \
+personal. Dollar amounts hit the viewer's life directly. Genuine unsettlement.
+- Act 6 (The Play): ALARM → EMPOWERMENT. The viewer receives specific tools \
+and actions. They leave feeling SMARTER and MORE CAPABLE. Not scared — armed.
 
-The framework is the WHAT (intellectual). The psych angle is the HOW \
-(emotional). Together they create videos where the viewer both LEARNS \
-something and FEELS something every 60 seconds.
-
-Each act should apply the SAME framework but through a DIFFERENT emotional \
-lens. Act 1 reveals the framework through shock. Act 4 proves the framework \
-through historical dread. Act 6 delivers the framework as empowerment.
+CRITICAL: The arc must end on EMPOWERMENT. The viewer must leave every video \
+feeling like they gained an advantage, not like they lost hope.
 """
 
 _STRICT_GROUNDING_RULE = """\
@@ -329,77 +305,81 @@ deployments, operational sequences)
 """
 
 _ACT_SPECIFIC_RULES = """\
-=== ACT-SPECIFIC RULES (UPDATED) ===
+=== ACT-SPECIFIC RULES (V2 — INVESTIGATIVE VOICE) ===
 
-Act 1 (The Hook):
-This act must contain at least 2 micro-payoffs. The viewer must have \
-learned something genuinely surprising within the first 60 seconds AND \
-again before the act ends.
+Act 1 (The Lie):
+Open with the headline event (one sentence, present tense, specific date). \
+State what "everyone" is being told. Drop ONE fact that contradicts the \
+narrative (with a specific number). If multiple official rationales exist, \
+walk through each and let them contradict each other — this is more \
+devastating than breaking one narrative. End with: "When you follow the \
+[money/data/contracts], you find something completely different." \
+Minimum 2 specific numbers. Explicit cliffhanger teasing Act 3.
 
-Act 2 (The Foundation):
-Every paragraph must contain at least one 'wait, what?' fact. Do not dump \
-context without insight. If you're explaining background, frame it as a \
-revelation: not 'Iran has proxies' but 'Iran built a shadow empire across \
-4 countries that costs less to maintain than a single US aircraft carrier.'
+Act 2 (The Setup):
+Introduce key players by their POSITIONS and INCENTIVES, not biographies. \
+Build the incentive chain: Player A needs X → requires Y → depends on Z. \
+Every paragraph must contain at least one specific number or date. Name \
+sources: "according to the Congressional Budget Office" not "experts say." \
+NO framework language yet — pure facts and observable patterns. End with: \
+"But here's what none of this explains..." Minimum 5 specific numbers. \
+Explicit cliffhanger teasing the hidden mechanism.
 
-Act 3 (The Mechanism):
-This is the MECHANISM act — explain HOW the hidden system works. Each \
-paragraph should make the viewer feel like they're being let in on a \
-secret. End with a payoff that makes them see the mechanism in everything.
+Act 3 (The Hidden Mechanism):
+Reveal the real dynamic through EVIDENCE, not theory. This is the money \
+trail / power flow / strategic logic with specific data. Connect dots the \
+mainstream coverage missed. Introduce the first historical parallel as \
+PROOF the pattern is real. The framework principles operate here but are \
+NOT named — show don't tell. Each sub-section must have a mini-revelation. \
+Minimum 4 specific numbers. Cliffhanger: "And there's one more layer \
+that affects you directly."
 
-Act 4 (The Mirror):
-The historical parallel should feel like proof that this is a PATTERN, \
-not coincidence. The payoff should be the moment the viewer realizes \
-'this has happened before and the outcome was...' Bridge to stakes.
+Act 4 (The Proof):
+Historical parallel in vivid detail — specific dates, figures, events, \
+outcomes. Point-by-point mapping: "In 1973, [X]. In 2026, [X]." \
+NOW name the framework: "What you're watching is what [Author] identified \
+as [Concept]." Use the framework to PREDICT what comes next based on \
+historical precedent. The framework arrives as CONFIRMATION of what the \
+viewer already sees. Minimum 3 specific numbers. Cliffhanger about \
+personal financial impact.
 
-Act 5 (The Stakes):
-Make it personal. The viewer should feel this in their wallet, their \
-career, their daily life. Counter-arguments should be steel-manned then \
-dismantled through the framework. Payoff: the viewer now sees something \
-they can't unsee.
+Act 5 (The Personal Stakes):
+"Here's what this means for your wallet." Use "you" and "your" heavily. \
+Specific scenarios with dollar amounts: "If [mechanism] continues, gas \
+hits $X within Y days and your 401k drops Z%." Steel-man the strongest \
+counterargument — it must be genuinely strong. Then dismantle it with \
+evidence, not opinion. The viewer should feel genuinely unsettled. \
+Minimum 3 specific numbers.
 
-Act 6 (The Lesson):
-The prediction must be specific and falsifiable — not 'things will change' \
-but 'watch for X within Y months.'
+Act 6 (The Play):
+"So what do you actually DO with this information?" This is NON-NEGOTIABLE \
+— the viewer MUST receive a specific, actionable strategy. The close must:
 
-Act 6 MUST end with EMPOWERMENT. The final scene is where the viewer \
-receives their permanent toolkit. This is NON-NEGOTIABLE. The close must:
+1. Give the SPECIFIC ACTION: investment thesis, risk to hedge, sector to \
+watch, signal to monitor. Not "diversify your portfolio" but "watch the \
+[specific index/signal]." Include historical performance data: "Smart money \
+moved [X days] after [similar events], not during."
 
-1. NAME the specific frameworks taught in this video by name (e.g. \
-'regulatory capture', 'sovereign exception', 'the panopticon effect'). \
-List them explicitly — the viewer must hear the framework names repeated \
-so they stick.
+2. NAME the frameworks and patterns taught in this video by name. The \
+viewer must hear them repeated so they stick.
 
-2. Give DETECTION INSTRUCTIONS: 'When you see X, ask Y. When A happens, \
-look for B within 48 hours.' Concrete, actionable, specific to the \
-frameworks taught. At least 2-3 detection rules.
+3. Give 2-3 DETECTION INSTRUCTIONS: "When you see X, ask Y. When A \
+happens, look for B within 48 hours." Concrete, specific.
 
-3. Frame knowledge as POWER: the viewer now sees what 99% of people miss. \
-They have X-ray vision for power dynamics. They are now part of the small \
-minority who understand how the game actually works.
+4. End on AGENCY: the final line connects back to the opening lie and \
+lingers. The viewer leaves feeling SMARTER and MORE CAPABLE. NOT scared, \
+NOT helpless, NOT cynical.
 
-4. End on AGENCY: 'Now that you see the pattern, you can't unsee it. \
-That's not paranoia. That's pattern recognition.' The viewer must leave \
-feeling SMARTER and MORE POWERFUL than when they started. NOT scared. \
-NOT helpless. NOT cynical. NOT passive.
+BAD close: "The window is closing and nobody will notice." (passive, hopeless)
+GOOD close: "The repricing window opens 11-14 days after the shock. That's \
+when smart money has moved in every conflict since Pearl Harbor. You now know \
+what [framework] looks like in real time. When [specific signal] appears, \
+you'll know the pattern has entered its final phase. The question isn't \
+whether the system works this way. You just watched it happen. The question \
+is whether you position yourself before or after everyone else figures it out."
 
-BAD close (DO NOT WRITE ANYTHING LIKE THIS):
-'The window is closing and nobody will notice.' (passive, fearful, helpless)
-'Whether anyone will notice before it's too late.' (dread, no agency)
-'The cage is closing and you're trapped.' (helpless)
-
-GOOD close (THIS IS THE MODEL — study its structure):
-'You just learned regulatory capture, sovereign exception, and the \
-panopticon effect. When a company gets designated, ask who signs a \
-contract within 48 hours. When you see all lawful purposes in any \
-agreement, find the classified interpretation. When one player gets \
-punished, watch who self-censors without being told. You now read the \
-game better than most people in Washington. The question isn't whether \
-the system is rigged. You now know how. The question is what you do \
-with that.'
-
-If the final scene does NOT contain explicit framework names AND at least \
-2 concrete detection instructions, the script has FAILED this requirement.
+If Act 6 does NOT contain a specific action AND at least 2 detection \
+instructions, the script has FAILED.
 """
 
 

--- a/skills/video-pipeline/research_agent.py
+++ b/skills/video-pipeline/research_agent.py
@@ -465,17 +465,32 @@ async def refine_title_post_script(
 
 # Research prompt template
 RESEARCH_SYSTEM_PROMPT = """\
-You are a deep research analyst for Economy FastForward, a documentary-style
-YouTube channel covering economics, finance, geopolitics, and power dynamics.
+You are a deep research analyst for Economy FastForward (Power Doctrine), a
+documentary-style YouTube channel that reveals hidden mechanisms behind major
+geopolitical and economic events. Your voice is investigative — you follow the
+money trail and find who actually benefits.
 
 Your job is to conduct exhaustive research on a topic and produce a structured
-research brief that will be used to write a 25-minute narration script with
-~140 AI-generated images.
+research brief that will be used to write a 15-20 minute narration script with
+~120 AI-generated images.
 
 The research must be DEEP — not surface-level summaries. You are producing the
 intellectual foundation for a video that will be watched by hundreds of thousands
 of people. Every fact must be specific, every parallel must be illuminating,
 every angle must hook the viewer.
+
+NUMBER DENSITY REQUIREMENT (NON-NEGOTIABLE):
+The script system requires a MINIMUM of 19 specific, verifiable numbers. Your
+fact sheet must provide at LEAST 25 specific numbers to give the script writer
+enough material. "Specific number" means: a dollar amount, a percentage, a date,
+a count, a ratio, or a named statistic. "Massive", "significant", and
+"unprecedented" are NOT numbers.
+
+INCENTIVE CHAIN REQUIREMENT:
+Every research brief must include an explicit chain of incentives connecting the
+headline event to the viewer's financial life. Template: Player A needs X →
+which requires Y → which depends on Z → which is what the headline event
+threatens/enables → which means [specific dollar impact] for the viewer.
 
 You have web search available. USE IT to verify facts before including them.
 - Search for every key claim, statistic, and date
@@ -501,11 +516,11 @@ Respond in the following JSON format (no markdown code blocks, just raw JSON):
   "headline": "A compelling, specific video title (not generic)",
   "thesis": "The core argument or revelation of this video in 2-3 sentences",
   "executive_hook": "The opening 15-second hook that stops the scroll. Must create immediate curiosity gap.",
-  "fact_sheet": "Detailed facts, statistics, data points, and verifiable claims. Include specific numbers, dates, dollar amounts, percentages. At least 10 distinct facts.",
+  "fact_sheet": "Detailed facts, statistics, data points, and verifiable claims. MINIMUM 25 specific numbers (dollar amounts, percentages, dates, counts, ratios). Every claim must have a number attached. Not 'significant growth' but '$847 billion in 18 months.' Not 'growing influence' but 'from 3 trade agreements to 17 in four years.'",
   "historical_parallels": "Historical events that mirror or illuminate this topic. Include specific dates, figures, and outcomes. At least 3 distinct parallels with rich detail.",
   "framework_analysis": "The analytical framework for understanding this topic. What mental model explains why this is happening? Reference specific thinkers, theories, or frameworks (e.g., Machiavellian power dynamics, game theory, systems thinking).",
   "character_dossier": "Key figures involved. For each: name, role, specific actions taken, motivations, and visual description for imagery. At least 3 figures.",
-  "narrative_arc": "The story structure: What happened → Why it matters → What comes next. Include specific turning points and revelations.",
+  "narrative_arc": "The story structure: What happened → Why it matters → What comes next. MUST include the explicit INCENTIVE CHAIN: Player A needs X → requires Y → depends on Z → headline event threatens/enables this → specific dollar impact for the viewer. Include specific turning points and revelations.",
   "counter_arguments": "The strongest arguments against the thesis. Acknowledge them honestly, then explain why the thesis still holds.",
   "visual_seeds": "Specific visual concepts for AI image generation. Describe scenes, settings, objects, and moods. At least 5 distinct visual concepts.",
   "source_bibliography": "Key sources, reports, and references used. Include organization names, report titles, and dates where possible.",
@@ -518,10 +533,13 @@ Respond in the following JSON format (no markdown code blocks, just raw JSON):
 
 IMPORTANT:
 - Every fact must be SPECIFIC (names, numbers, dates) — no vague generalizations
+- The fact_sheet must contain MINIMUM 25 specific, verifiable numbers
 - Historical parallels must be ILLUMINATING, not just tangentially related
 - The framework must feel like an intellectual revelation, not a textbook summary
 - Visual seeds must describe SCENES, not abstract concepts
 - The hook must create an irresistible curiosity gap in under 15 seconds of speech
+- The narrative_arc MUST include an explicit incentive chain connecting the event to the viewer's wallet
+- Include "who benefits" analysis: trace the money trail for every major player
 """
 
 


### PR DESCRIPTION
Shifts the script generation system from "strategic advisor explaining frameworks"
to "investigative analyst who followed the money." Key changes:

- script.txt: New system prompt with 5 structural laws (lead with the lie,
  incentive chain first, every claim gets a number, framework invisible until
  Act 4, end with specific action). New 6-act structure (The Lie → The Setup →
  The Hidden Mechanism → The Proof → The Personal Stakes → The Play).

- script_generator.py: Updated all override constants to match v2 voice.
  Framework revelation engine now enforces invisible scaffolding (Acts 1-3)
  with naming only in Act 4. Micro-payoff architecture rewritten as
  micro-revelation architecture with number density requirements.
  Act-specific rules aligned to investigative structure with explicit
  cliffhangers and structural ratio enforcement (40-50% incentive chain,
  max 15% framework mechanics).

- research_agent.py: Added minimum 25-number density requirement for fact
  sheets, incentive chain requirement in narrative_arc, and "who benefits"
  analysis mandate.

- docs/editorial_voice_v2.md: Full editorial voice reference document.

All 249 tests passing (82 brief_translator + 141 image_prompt_engine + 26 integration).

https://claude.ai/code/session_013dv6mtxAv8nXJW6RnshpSZ