### PR TITLE
Add script profile system for pluggable editorial voices

### DIFF
--- a/skills/video-pipeline/brief_translator/prompts/script.txt
+++ b/skills/video-pipeline/brief_translator/prompts/script.txt
@@ -143,8 +143,8 @@ cliffhanger: "And there's one more layer that affects you directly."
 [ACT 4 — THE PROOF | 11:00-15:00 | ~500 words]
 Historical parallel in vivid detail — specific dates, figures, events, outcomes.
 Point-by-point mapping to the present: "In 1973, [X]. In 2026, [X]." NOW name
-the framework: "What you're watching is what {FRAMEWORK_AUTHOR} identified as
-{CONCEPT}." Use the framework to explain what the historical precedent PREDICTS
+the framework: "What you're watching is what [Author] identified as
+[Concept]." Use the framework to explain what the historical precedent PREDICTS
 for the current situation. The framework name arrives as confirmation of what the
 viewer already sees, not as a new concept. Include cliffhanger about personal
 stakes.

--- a/skills/video-pipeline/brief_translator/script_generator.py
+++ b/skills/video-pipeline/brief_translator/script_generator.py
@@ -4,8 +4,11 @@ Transforms a validated research brief into a narration script
 with dynamic act structure, micro-payoff architecture, and act markers.
 
 Word counts and act counts are driven by VideoConfig (pipeline_config.py).
+Script profiles (script_profiles/) control the editorial voice — tone,
+structural laws, act structure, validation rules, and language constraints.
+
 Legacy constants are kept as defaults for backward compatibility when no
-config is provided.
+config or profile is provided.
 """
 
 import re
@@ -14,6 +17,7 @@ from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pipeline_config import VideoConfig
+    from script_profiles.schema import ScriptProfile
 
 PROMPT_TEMPLATE_PATH = Path(__file__).parent / "prompts" / "script.txt"
 
@@ -662,22 +666,119 @@ def _build_source_citations_section(brief: dict) -> str:
     )
 
 
-def build_script_prompt(brief: dict, config: Optional["VideoConfig"] = None) -> str:
+def build_script_prompt(
+    brief: dict,
+    config: Optional["VideoConfig"] = None,
+    profile: Optional["ScriptProfile"] = None,
+) -> str:
     """Build the script generation prompt from a research brief.
 
     Args:
         brief: Validated research brief dict.
         config: Optional VideoConfig for dynamic word counts and act structure.
             When None, falls back to legacy 6-act / 2800-word defaults.
+        profile: Optional ScriptProfile for editorial voice. When provided,
+            the voice/tone preamble is assembled from the profile instead of
+            the static ``prompts/script.txt`` template.
     """
-    template = load_script_prompt()
-
     # Build framework lens section based on Framework Angle field
     framework_angle = brief.get("framework_angle", "")
     framework_lens = _build_framework_lens_section(framework_angle)
 
     # Build source citations section
     source_citations = _build_source_citations_section(brief)
+
+    if profile is not None:
+        # Assemble the voice preamble from the profile
+        from script_profiles.schema import build_script_system_prompt
+
+        preamble = build_script_system_prompt(profile)
+
+        # Insert the framework lens and research brief
+        rendered = preamble + "\n\n"
+        if framework_lens:
+            rendered += framework_lens + "\n\n"
+
+        rendered += (
+            "<research_brief>\n"
+            f"Headline: {brief.get('headline', '')}\n"
+            f"Thesis: {brief.get('thesis', '')}\n"
+            f"Executive Hook: {brief.get('executive_hook', '')}\n"
+            f"Fact Sheet: {brief.get('fact_sheet', '')}\n"
+            f"Historical Parallels: {brief.get('historical_parallels', '')}\n"
+            f"Framework Analysis: {brief.get('framework_analysis', '')}\n"
+            f"Character Dossier: {brief.get('character_dossier', '')}\n"
+            f"Narrative Arc: {brief.get('narrative_arc', '')}\n"
+            f"Counter Arguments: {brief.get('counter_arguments', '')}\n"
+            f"Visual Seeds: {brief.get('visual_seeds', '')}\n"
+            "</research_brief>"
+        )
+
+        if source_citations:
+            rendered += "\n\n" + source_citations
+
+        # Use profile's word count targets or fall back to config/legacy
+        v = profile.validation
+        min_w = config.script_min_words if config else v.min_words
+        max_w = config.script_max_words if config else v.max_words
+        target_w = config.total_script_words if config else (min_w + max_w) // 2
+        act_count = config.act_count if config else profile.act_structure.get("act_count", 6)
+
+        rendered += (
+            f"\n\nWrite a complete narration script (~{target_w} words). "
+            f"Minimum: {min_w} words. Maximum: {max_w} words.\n"
+            f"Structure it in {act_count} acts with clear markers:\n"
+            "[ACT X — TITLE | TIMESTAMP | ~WORD COUNT]\n\n"
+            "IMPORTANT FORMATTING RULES:\n"
+            "- Mark each act clearly: [ACT X — TITLE | TIMESTAMP | WORD COUNT]\n"
+            "- Write as continuous narration — no stage directions, no \"[pause]\" markers\n"
+            "- Do NOT include image descriptions in the script\n"
+            "- Every factual claim must be verifiable from the research brief\n"
+            "- Source citations must appear at least 4-6 times across the script\n"
+            "- Historical parallels must appear in at least 3 different acts\n"
+            "- Direct audience address (\"you\", \"your\") must appear at least 3-4 times\n"
+        )
+
+        # Append profile-specific text blocks
+        rendered += "\n\n" + _build_act_structure_override(config)
+        if profile.micro_payoff_architecture:
+            rendered += "\n\n" + profile.micro_payoff_architecture
+        else:
+            rendered += "\n\n" + _MICRO_PAYOFF_ARCHITECTURE
+
+        if profile.framework_selection_rules:
+            rendered += "\n\n" + profile.framework_selection_rules
+        else:
+            rendered += "\n\n" + _FRAMEWORK_SELECTION_RULES
+
+        if profile.framework_revelation_engine:
+            rendered += "\n\n" + profile.framework_revelation_engine
+        else:
+            rendered += "\n\n" + _FRAMEWORK_REVELATION_ENGINE
+
+        # Emotional arc (profile-specific, replaces _FRAMEWORK_PSYCH_SEPARATION)
+        if profile.emotional_arc:
+            arc_lines = ["=== EMOTIONAL ARC — THE INVESTIGATIVE JOURNEY ===\n"]
+            for act_num in sorted(profile.emotional_arc.keys()):
+                arc_lines.append(f"- Act {act_num}: {profile.emotional_arc[act_num]}")
+            rendered += "\n\n" + "\n".join(arc_lines)
+        else:
+            rendered += "\n\n" + _FRAMEWORK_PSYCH_SEPARATION
+
+        if profile.act_specific_rules:
+            rendered += "\n\n" + profile.act_specific_rules
+        else:
+            rendered += "\n\n" + _ACT_SPECIFIC_RULES
+
+        if profile.strict_grounding_rule:
+            rendered += "\n\n" + profile.strict_grounding_rule
+        else:
+            rendered += "\n\n" + _STRICT_GROUNDING_RULE
+
+        return rendered
+
+    # --- Legacy path: no profile, use static template ---
+    template = load_script_prompt()
 
     rendered = template.format(
         HEADLINE=brief.get("headline", ""),
@@ -708,13 +809,20 @@ def build_script_prompt(brief: dict, config: Optional["VideoConfig"] = None) -> 
     return rendered
 
 
-def validate_script(script: str, config: Optional["VideoConfig"] = None) -> dict:
+def validate_script(
+    script: str,
+    config: Optional["VideoConfig"] = None,
+    profile: Optional["ScriptProfile"] = None,
+) -> dict:
     """Validate script structure and word count.
 
     Args:
         script: Generated script text.
         config: Optional VideoConfig for dynamic thresholds. Falls back to
             legacy constants when None.
+        profile: Optional ScriptProfile for editorial-voice-aware validation.
+            When provided, uses profile's validation rules for word count
+            thresholds and kill phrase checking.
 
     Returns:
         {
@@ -725,9 +833,18 @@ def validate_script(script: str, config: Optional["VideoConfig"] = None) -> dict
             "acts": list[dict],  # parsed act info
         }
     """
-    min_words = config.script_min_words if config else SCRIPT_MIN_WORDS
-    max_words = config.script_max_words if config else SCRIPT_MAX_WORDS
-    expected_acts = config.act_count if config else EXPECTED_ACT_COUNT
+    if config:
+        min_words = config.script_min_words
+        max_words = config.script_max_words
+        expected_acts = config.act_count
+    elif profile:
+        min_words = profile.validation.min_words
+        max_words = profile.validation.max_words
+        expected_acts = profile.act_structure.get("act_count", EXPECTED_ACT_COUNT)
+    else:
+        min_words = SCRIPT_MIN_WORDS
+        max_words = SCRIPT_MAX_WORDS
+        expected_acts = EXPECTED_ACT_COUNT
 
     issues = []
     word_count = len(script.split())
@@ -762,6 +879,13 @@ def validate_script(script: str, config: Optional["VideoConfig"] = None) -> dict
     expected_numbers = list(range(1, expected_acts + 1))
     if act_numbers != expected_numbers[: len(act_numbers)]:
         issues.append(f"Act numbers not sequential: {act_numbers}")
+
+    # Profile-aware validation: kill phrase check
+    if profile and profile.validation.kill_phrase_check:
+        script_lower = script.lower()
+        for phrase in profile.language.kill_phrases:
+            if phrase.lower() in script_lower:
+                issues.append(f"Kill phrase detected: '{phrase}'")
 
     return {
         "valid": len(issues) == 0,
@@ -823,6 +947,7 @@ async def generate_script(
     brief: dict,
     model: str = "claude-sonnet-4-5-20250929",
     config: Optional["VideoConfig"] = None,
+    profile: Optional["ScriptProfile"] = None,
 ) -> dict:
     """Generate a full narration script from a validated research brief.
 
@@ -831,6 +956,7 @@ async def generate_script(
         brief: Validated research brief dict
         model: Model to use (defaults to Sonnet, can use Opus for higher quality)
         config: Optional VideoConfig for dynamic word counts and act structure.
+        profile: Optional ScriptProfile for editorial voice control.
 
     Returns:
         {
@@ -838,11 +964,20 @@ async def generate_script(
             "validation": dict,
         }
     """
-    min_words = config.script_min_words if config else SCRIPT_MIN_WORDS
-    max_words = config.script_max_words if config else SCRIPT_MAX_WORDS
-    target_words = config.total_script_words if config else SCRIPT_TARGET_WORDS
+    if config:
+        min_words = config.script_min_words
+        max_words = config.script_max_words
+        target_words = config.total_script_words
+    elif profile:
+        min_words = profile.validation.min_words
+        max_words = profile.validation.max_words
+        target_words = (min_words + max_words) // 2
+    else:
+        min_words = SCRIPT_MIN_WORDS
+        max_words = SCRIPT_MAX_WORDS
+        target_words = SCRIPT_TARGET_WORDS
 
-    prompt = build_script_prompt(brief, config=config)
+    prompt = build_script_prompt(brief, config=config, profile=profile)
 
     script = await anthropic_client.generate(
         prompt=prompt,
@@ -851,7 +986,7 @@ async def generate_script(
         temperature=0.8,
     )
 
-    validation = validate_script(script, config=config)
+    validation = validate_script(script, config=config, profile=profile)
 
     # If script is too short, try once more with explicit expansion instruction
     if not validation["valid"] and validation["word_count"] < min_words:
@@ -867,7 +1002,7 @@ async def generate_script(
             max_tokens=8000,
             temperature=0.8,
         )
-        validation = validate_script(script, config=config)
+        validation = validate_script(script, config=config, profile=profile)
 
     # If script is too long, try once more with explicit compression instruction
     if not validation["valid"] and validation["word_count"] > max_words:
@@ -884,7 +1019,7 @@ async def generate_script(
             max_tokens=8000,
             temperature=0.7,
         )
-        validation = validate_script(script, config=config)
+        validation = validate_script(script, config=config, profile=profile)
 
     # Validate empowerment close on the final act
     from .scene_validator import validate_act6_empowerment

--- a/skills/video-pipeline/script_profiles/README.md
+++ b/skills/video-pipeline/script_profiles/README.md
@@ -1,0 +1,93 @@
+# Script Profiles — Pluggable Editorial Voices
+
+A script profile is a **complete editorial voice definition**. It controls
+everything about how scripts are written: tone, audience, act structure,
+structural laws, number density rules, retention engineering, language
+constraints, framework integration, and validation thresholds.
+
+Swapping the editorial approach = changing one field or env var.
+
+## Quick Start
+
+```python
+from script_profiles import load_script_profile
+
+# Load from env var or default (power_doctrine_v2)
+profile = load_script_profile()
+
+# Load a specific profile
+profile = load_script_profile("power_doctrine_v1")
+
+# Use in script generation
+from brief_translator.script_generator import build_script_prompt, generate_script
+
+prompt = build_script_prompt(brief, profile=profile)
+result = await generate_script(client, brief, profile=profile)
+```
+
+## Profile Selection Order
+
+1. **Airtable field**: `Script Profile` on the Idea Concepts record
+2. **Environment variable**: `SCRIPT_PROFILE`
+3. **Default**: `power_doctrine_v2`
+
+## Creating a New Profile (< 10 minutes)
+
+1. Copy `power_doctrine_v2.py` as your starting point
+2. Update the identity section (profile_id, name, description)
+3. Modify the voice (identity, tone, audience, posture)
+4. Adjust structural laws to match your editorial approach
+5. Define your act structure (names, purposes, word percentages)
+6. Set number density requirements
+7. Update language rules (use phrases, kill phrases)
+8. Configure framework integration rules
+9. Set validation thresholds (word count min/max)
+10. Register in `__init__.py`:
+
+```python
+_PROFILE_MODULES["your_profile_id"] = "script_profiles.your_profile_id"
+```
+
+## Profile Sections
+
+| Section | What It Controls |
+|---------|-----------------|
+| `voice` | Narrator identity, tone, audience definition |
+| `structural_laws` | Non-negotiable narrative rules |
+| `content_ratio` | Runtime allocation percentages |
+| `act_structure` | Act count, names, purposes, word percentages |
+| `number_density` | Minimum numbers per act, anti-words |
+| `retention` | Cliffhanger rules, micro-revelation cadence |
+| `language` | Approved/banned phrases, framework naming rules |
+| `framework_integration` | Available frameworks, integration style |
+| `incentive_chain` | Whether incentive chains are required |
+| `teardown` | Multi-rationale teardown templates |
+| `validation` | Word count limits, enabled checks |
+| `emotional_arc` | Per-act emotional progression |
+| `act_specific_rules` | Detailed per-act writing instructions |
+| `micro_payoff_architecture` | Scene-level structure template |
+| `framework_revelation_engine` | Framework visibility rules |
+| `strict_grounding_rule` | Factual grounding constraints |
+
+## Available Profiles
+
+| ID | Name | Style | Status |
+|----|------|-------|--------|
+| `power_doctrine_v2` | Investigative Reveal | Follow-the-money, incentive chains, invisible framework | **Production** |
+| `power_doctrine_v1` | Framework Explainer | Documentary teaching, explicit framework, educational | Legacy |
+
+## Relationship to Visual Profiles
+
+| Aspect | Visual Profile | Script Profile |
+|--------|---------------|----------------|
+| Controls | Image style, models, rotation | Editorial voice, act structure, tone |
+| Airtable field | `Visual Profile` | `Script Profile` |
+| Env var | `VISUAL_PROFILE` | `SCRIPT_PROFILE` |
+| Default | `holographic_hud` | `power_doctrine_v2` |
+| StoryEngine | "Pick your look" | "Pick your voice" |
+
+## Backward Compatibility
+
+When no profile is provided, the pipeline falls back to the hardcoded
+constants in `script_generator.py` and the static `prompts/script.txt`
+template. All existing behavior is preserved.

--- a/skills/video-pipeline/script_profiles/__init__.py
+++ b/skills/video-pipeline/script_profiles/__init__.py
@@ -1,0 +1,119 @@
+"""Script Profile loader and registry.
+
+Provides ``load_script_profile()`` — the single entry point for getting
+the active editorial voice profile at runtime.
+
+Profile selection order:
+1. Explicit ``profile_id`` argument (per-video override from Airtable)
+2. ``SCRIPT_PROFILE`` environment variable (per-channel default)
+3. Fallback: ``"power_doctrine_v2"`` (current production voice)
+
+Usage::
+
+    from script_profiles import load_script_profile
+
+    profile = load_script_profile()                        # env var or default
+    profile = load_script_profile("power_doctrine_v1")     # explicit override
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Optional
+
+from .schema import ScriptProfile
+
+# Registry of known profile module names
+_PROFILE_MODULES: dict[str, str] = {
+    "power_doctrine_v2": "script_profiles.power_doctrine_v2",
+    "power_doctrine_v1": "script_profiles.power_doctrine_v1",
+}
+
+DEFAULT_PROFILE_ID = "power_doctrine_v2"
+
+# Module-level cache — one profile loaded per pipeline run
+_profile_cache: dict[str, ScriptProfile] = {}
+
+
+def load_script_profile(profile_id: Optional[str] = None) -> Optional[ScriptProfile]:
+    """Load a script profile by ID.
+
+    Args:
+        profile_id: Profile to load. If None, reads ``SCRIPT_PROFILE``
+            env var, then falls back to ``"power_doctrine_v2"``.
+
+    Returns:
+        The loaded ``ScriptProfile``, or ``None`` if loading fails
+        (callers should fall back to hardcoded defaults).
+    """
+    resolved_id = (
+        profile_id
+        or os.getenv("SCRIPT_PROFILE", "").strip()
+        or DEFAULT_PROFILE_ID
+    )
+
+    # Check cache first
+    if resolved_id in _profile_cache:
+        return _profile_cache[resolved_id]
+
+    try:
+        module_path = _PROFILE_MODULES.get(resolved_id)
+        if not module_path:
+            print(f"[script_profiles] Unknown profile: {resolved_id}")
+            return None
+
+        mod = importlib.import_module(module_path)
+        profile: ScriptProfile = getattr(mod, "PROFILE", None)
+
+        if profile is None:
+            print(f"[script_profiles] Module {module_path} has no PROFILE attribute")
+            return None
+
+        _profile_cache[resolved_id] = profile
+        return profile
+
+    except Exception as exc:
+        print(f"[script_profiles] Failed to load profile '{resolved_id}': {exc}")
+        return None
+
+
+def get_profile_or_default(
+    profile_id: Optional[str] = None,
+) -> Optional[ScriptProfile]:
+    """Load a profile, trying default if the requested one fails."""
+    profile = load_script_profile(profile_id)
+    if profile is not None:
+        return profile
+
+    if profile_id and profile_id != DEFAULT_PROFILE_ID:
+        return load_script_profile(DEFAULT_PROFILE_ID)
+
+    return None
+
+
+def clear_cache() -> None:
+    """Clear the profile cache (useful for testing)."""
+    _profile_cache.clear()
+
+
+def list_profiles() -> list[str]:
+    """Return all registered profile IDs."""
+    return list(_PROFILE_MODULES.keys())
+
+
+def register_profile(profile_id: str, module_path: str) -> None:
+    """Register a new profile module at runtime."""
+    _PROFILE_MODULES[profile_id] = module_path
+    _profile_cache.pop(profile_id, None)
+
+
+__all__ = [
+    "load_script_profile",
+    "get_profile_or_default",
+    "clear_cache",
+    "list_profiles",
+    "register_profile",
+    "ScriptProfile",
+    "DEFAULT_PROFILE_ID",
+]

--- a/skills/video-pipeline/script_profiles/power_doctrine_v1.py
+++ b/skills/video-pipeline/script_profiles/power_doctrine_v1.py
@@ -1,0 +1,417 @@
+"""Power Doctrine v1 — Framework Explainer Voice.
+
+This is the LEGACY editorial voice. It takes a documentary scriptwriter
+approach, explaining geopolitical frameworks directly to the audience.
+The narrator is a master storyteller teaching the viewer how power works.
+
+Key differences from v2:
+- Framework is introduced earlier (Act 3 vs Act 4)
+- Teaching posture vs investigative/revealing posture
+- Less emphasis on incentive chains, more on framework mechanics
+- Acts named: Hook, Context, Framework, Proof, Consequences, Empowerment
+- Less number-dense, more narrative-driven
+"""
+
+from .schema import (
+    ActDefinition,
+    FrameworkIntegrationConfig,
+    IncentiveChainConfig,
+    LanguageConfig,
+    NumberDensityConfig,
+    RetentionConfig,
+    ScriptProfile,
+    TeardownConfig,
+    TemplateMetadata,
+    ValidationConfig,
+    VoiceConfig,
+)
+
+PROFILE = ScriptProfile(
+    # === Identity ===
+    profile_id="power_doctrine_v1",
+    profile_name="Power Doctrine — Framework Explainer",
+    version="1.0",
+    description=(
+        "Documentary scriptwriter voice that explains geopolitical "
+        "frameworks directly. Master storyteller teaching the viewer "
+        "how power works through historical parallels and analytical lenses."
+    ),
+    channel="economy_fastforward",
+
+    # === Voice Definition ===
+    voice=VoiceConfig(
+        identity=(
+            "Documentary scriptwriter and master storyteller who reveals "
+            "the hidden playbooks behind world events"
+        ),
+        tone="Authoritative, urgent, educational, dramatic but grounded",
+        audience=(
+            "Curious adults who want to understand geopolitics and power "
+            "dynamics through analytical frameworks and historical patterns."
+        ),
+        audience_values=["framework understanding", "historical context", "pattern recognition"],
+        audience_repelled_by=["sensationalism", "conspiracy theories", "unsourced claims"],
+        narrator_posture="teaching",
+    ),
+
+    # === Structural Laws ===
+    structural_laws=[
+        (
+            "Hook with a compelling event. Open with a specific headline "
+            "event that has broader strategic implications. Set up the "
+            "central question within 30 seconds."
+        ),
+        (
+            "Build context before the framework. Give the viewer enough "
+            "background to understand why the framework matters before "
+            "introducing it."
+        ),
+        (
+            "Every claim needs evidence. Use specific numbers, dates, and "
+            "named sources. Avoid vague qualifiers."
+        ),
+        (
+            "The framework IS the video. Unlike v2 where incentive chains "
+            "dominate, here the analytical framework is the star. Explain "
+            "it clearly, apply it to events, and teach detection."
+        ),
+        (
+            "End with empowerment. The viewer must leave with frameworks "
+            "and detection tools they can apply to future events."
+        ),
+        (
+            "Use cliffhangers at act transitions. Keep the viewer engaged "
+            "across the full 15-25 minute runtime."
+        ),
+    ],
+
+    # === Content Ratio ===
+    content_ratio={
+        "framework_mechanics": {"min": 0.25, "max": 0.35},
+        "historical_proof": {"min": 0.20, "max": 0.25},
+        "current_events_application": {"min": 0.20, "max": 0.25},
+        "personal_impact": {"min": 0.10, "max": 0.15},
+        "empowerment_detection": {"min": 0.10, "max": 0.15},
+    },
+
+    # === Act Structure ===
+    act_structure={
+        "act_count": 6,
+        "acts": [
+            ActDefinition(
+                act_number=1,
+                name="THE EVENT",
+                purpose="Hook with a compelling headline event",
+                structure=[
+                    "Open with breaking news or dramatic event",
+                    "Establish the central question",
+                    "Hint at deeper strategic dynamics",
+                    "Tease the analytical framework that explains it",
+                ],
+                cliffhanger_template="But to understand why, you need to see the pattern. And it starts {teaser}.",
+                psychological_beat="curiosity",
+                min_numbers=2,
+                word_pct=0.15,
+            ),
+            ActDefinition(
+                act_number=2,
+                name="THE CONTEXT",
+                purpose="Background the viewer needs to understand the framework",
+                structure=[
+                    "Key players and their positions",
+                    "Historical background with specific facts",
+                    "What mainstream analysis gets right and wrong",
+                    "Set up why a deeper lens is needed",
+                ],
+                cliffhanger_template="And that deeper lens has a name. It's been describing this exact scenario for {timeframe}.",
+                psychological_beat="building_understanding",
+                min_numbers=4,
+                word_pct=0.15,
+            ),
+            ActDefinition(
+                act_number=3,
+                name="THE FRAMEWORK",
+                purpose="Introduce and explain the analytical lens",
+                structure=[
+                    "Name the framework and its originator",
+                    "Explain the core mechanics clearly",
+                    "Show how it applies to the current event",
+                    "Use the framework to reveal hidden dynamics",
+                ],
+                cliffhanger_template="And if you think this is just theory, history has proven it. Multiple times.",
+                psychological_beat="intellectual_excitement",
+                min_numbers=3,
+                word_pct=0.17,
+            ),
+            ActDefinition(
+                act_number=4,
+                name="THE PROOF",
+                purpose="Historical parallels proving the pattern is real",
+                structure=[
+                    "Historical event in vivid detail",
+                    "Point-by-point mapping to the present",
+                    "What the historical precedent predicts",
+                    "Why this time the stakes are higher",
+                ],
+                cliffhanger_template="And here's what nobody is telling you about how this affects your life.",
+                psychological_beat="conviction",
+                min_numbers=3,
+                word_pct=0.20,
+            ),
+            ActDefinition(
+                act_number=5,
+                name="THE CONSEQUENCES",
+                purpose="Personal impact cascade — what this means for the viewer",
+                structure=[
+                    "Translate the framework to personal impact",
+                    "Specific scenarios with dollar amounts",
+                    "Address the strongest counterargument",
+                    "Why the pattern is harder to escape than people think",
+                ],
+                cliffhanger_template=None,
+                psychological_beat="personal_stakes",
+                min_numbers=3,
+                word_pct=0.18,
+            ),
+            ActDefinition(
+                act_number=6,
+                name="EMPOWERMENT",
+                purpose="Frameworks taught + detection tools + what to watch",
+                structure=[
+                    "Name the frameworks and patterns from this video",
+                    "Give 2-3 detection instructions",
+                    "Specific signals to watch for",
+                    "End with empowerment — the viewer is now equipped",
+                ],
+                cliffhanger_template=None,
+                psychological_beat="empowerment",
+                min_numbers=2,
+                word_pct=0.15,
+            ),
+        ],
+    },
+
+    # === Number Density ===
+    number_density=NumberDensityConfig(
+        minimum_total=15,
+        per_act={1: 2, 2: 4, 3: 3, 4: 3, 5: 3, 6: 2},
+        definition=(
+            "dollar amount, percentage, date, count, ratio, or named statistic"
+        ),
+        anti_words=["significant", "massive", "unprecedented"],
+    ),
+
+    # === Retention Engineering ===
+    retention=RetentionConfig(
+        cliffhanger_frequency="every_act_transition",
+        micro_revelation_cadence_seconds=120,
+        explicit_forward_sell=True,
+        forward_sell_template=(
+            "And in the next section, you'll see {teaser}."
+        ),
+    ),
+
+    # === Language Rules ===
+    language=LanguageConfig(
+        use_phrases=[
+            "Here's the pattern",
+            "What history shows us",
+            "The framework predicts",
+            "When you see this pattern",
+            "The analytical lens reveals",
+        ],
+        kill_phrases=[
+            "In this video, we'll explore",
+            "Let's dive into",
+            "It's important to understand",
+            "Many experts believe",
+            "This is significant because",
+            "Throughout history",
+            "In conclusion",
+            "Like and subscribe",
+        ],
+        framework_naming_rules={
+            "first_mention_act": 3,
+            "max_direct_references": 5,
+            "intro_template": (
+                "{author} described this as {concept}, and what we're "
+                "watching right now is a textbook case"
+            ),
+        },
+    ),
+
+    # === Framework Integration ===
+    framework_integration=FrameworkIntegrationConfig(
+        available_frameworks=[
+            {"id": "machiavelli", "name": "Machiavelli", "domain": "power consolidation"},
+            {"id": "thucydides", "name": "Thucydides Trap", "domain": "rising vs established power"},
+            {"id": "antifragile", "name": "Antifragile / Black Swan", "domain": "asymmetric risk"},
+            {"id": "game_theory", "name": "Game Theory", "domain": "deterrence, equilibrium"},
+            {"id": "sun_tzu", "name": "Sun Tzu", "domain": "indirect warfare, deception"},
+            {"id": "grand_chessboard", "name": "Grand Chessboard", "domain": "geographic control"},
+            {"id": "kindleberger", "name": "Kindleberger Trap", "domain": "hegemon withdrawal"},
+            {"id": "schelling", "name": "Schelling", "domain": "brinkmanship, focal points"},
+            {"id": "collective_action", "name": "Collective Action", "domain": "organized minorities"},
+            {"id": "soft_power", "name": "Soft Power", "domain": "influence without coercion"},
+        ],
+        selection_method="per_video",
+        integration_style="explicit_teaching",
+        max_runtime_pct=0.35,
+    ),
+
+    # === Incentive Chain ===
+    incentive_chain=IncentiveChainConfig(
+        required=False,
+        must_complete_before_script=False,
+        chain_template="",
+        min_links=0,
+        must_end_at_viewer=False,
+        stored_in="Research Payload",
+    ),
+
+    # === Multi-Rationale Teardown ===
+    teardown=TeardownConfig(
+        enabled=False,
+        trigger="",
+        template=[],
+    ),
+
+    # === Script Validation Rules ===
+    validation=ValidationConfig(
+        min_words=2500,
+        max_words=4500,
+        min_acts=3,
+        max_acts=8,
+        number_density_check=True,
+        kill_phrase_check=True,
+        cliffhanger_check=True,
+        incentive_chain_presence=False,
+        framework_max_pct_check=False,
+        personal_stakes_presence=True,
+        actionable_ending_check=True,
+        retry_on_fail=True,
+        max_retries=2,
+    ),
+
+    # === Template Metadata ===
+    template_metadata=TemplateMetadata(
+        display_name="Power Doctrine — Framework Explainer",
+        category="geopolitics_education",
+        tags=["documentary", "frameworks", "education", "geopolitics"],
+        description=(
+            "Documentary-style explainer that teaches geopolitical frameworks "
+            "through current events. Authoritative narrator guides the viewer "
+            "through the analytical lens."
+        ),
+        best_for=["geopolitics", "history", "international relations", "strategy"],
+        example_titles=[
+            "The Thucydides Trap Explained — Why Great Powers Always Clash",
+            "How the Grand Chessboard Predicts the Next Global Conflict",
+        ],
+    ),
+
+    # === Emotional Arc ===
+    emotional_arc={
+        1: "SURPRISE -> CURIOSITY. A dramatic event hooks the viewer and raises the central question.",
+        2: "CURIOSITY -> UNDERSTANDING. Context builds the viewer's mental model of the situation.",
+        3: "UNDERSTANDING -> INSIGHT. The framework clicks into place and the viewer sees the pattern.",
+        4: "INSIGHT -> CONVICTION. Historical proof shows the pattern is real, not coincidence.",
+        5: "CONVICTION -> CONCERN. The abstract becomes personal — the viewer's life is affected.",
+        6: "CONCERN -> EMPOWERMENT. Detection tools and frameworks equip the viewer for the future.",
+    },
+
+    # === Act-Specific Rules ===
+    act_specific_rules="""\
+=== ACT-SPECIFIC RULES (V1 — FRAMEWORK EXPLAINER VOICE) ===
+
+Act 1 (The Event):
+Open with a compelling headline event. Set up the central question \
+within 30 seconds. Hint at the deeper pattern. The viewer should \
+feel "this is bigger than they're telling us." Minimum 2 numbers.
+
+Act 2 (The Context):
+Provide the historical and strategic background. Key players, their \
+positions, the conventional analysis. Build toward: "but conventional \
+analysis misses the deeper pattern." Minimum 4 numbers.
+
+Act 3 (The Framework):
+Name the framework and its originator. Explain the core mechanics \
+clearly — the viewer should understand the concept. Apply it to the \
+current event. This is the intellectual core of the video. Minimum 3 numbers.
+
+Act 4 (The Proof):
+Historical parallel in vivid detail. Point-by-point mapping to the \
+present. The historical record PROVES the framework works. What \
+the precedent predicts for the current situation. Minimum 3 numbers.
+
+Act 5 (The Consequences):
+Make it personal. Specific scenarios with dollar amounts. Address \
+the strongest counterargument fairly. Show why the pattern matters \
+for the viewer's life. Minimum 3 numbers.
+
+Act 6 (Empowerment):
+Name every framework and pattern taught in this video. Give 2-3 \
+detection instructions. End on empowerment — the viewer leaves \
+equipped, not afraid. NEVER end with dread or helplessness.
+""",
+
+    # === Micro-Payoff Architecture ===
+    micro_payoff_architecture="""\
+=== MICRO-REVELATION ARCHITECTURE ===
+
+Every 2 minutes of narration should deliver a specific insight — a fact, \
+historical connection, or framework application the viewer didn't know.
+
+Structure within each scene:
+- SETUP: Establish the context or claim
+- FRAMEWORK APPLICATION: Apply the analytical lens
+- INSIGHT: The "aha" moment — what the framework reveals
+- BRIDGE: Connect to the next scene
+""",
+
+    # === Framework Selection Rules ===
+    framework_selection_rules="""\
+=== FRAMEWORK SELECTION ===
+
+Select 1-2 primary frameworks that BEST explain the events in this story.
+
+State your framework selection at the top of the outline:
+PRIMARY FRAMEWORK: [Name] — [Why this framework explains these events]
+SECONDARY FRAMEWORK: [Name] — [What additional dimension this adds]
+""",
+
+    # === Framework Revelation Engine ===
+    framework_revelation_engine="""\
+=== FRAMEWORK INTEGRATION — EXPLICIT TEACHING ===
+
+The framework is the star of the video. Introduce it in Act 3 with \
+clear explanation. Apply it throughout Acts 4-6. The viewer should \
+leave understanding the framework well enough to apply it themselves.
+
+Reference the framework author by name. Use specific concepts and \
+terminology. The viewer is here to LEARN the framework, not just \
+see it operating invisibly.
+""",
+
+    # === Strict Grounding Rule ===
+    strict_grounding_rule="""\
+=== FACTUAL GROUNDING RULE ===
+
+Every factual claim must come from the research payload. You may NOT \
+introduce companies, people, events, or statistics not in the research.
+
+Historical parallels must come from the research payload's \
+historical_parallels field. Framework references (Machiavelli, Sun Tzu, \
+etc.) are always allowed as analytical tools.
+
+WHAT YOU CAN CREATE:
+- Dramatic pacing, rhetorical questions
+- Analytical connections using the framework
+- Metaphors and analogies
+
+WHAT YOU CANNOT CREATE:
+- Events that did not happen
+- Statistics not in the payload
+- Quotes not in the payload
+""",
+)

--- a/skills/video-pipeline/script_profiles/power_doctrine_v2.py
+++ b/skills/video-pipeline/script_profiles/power_doctrine_v2.py
@@ -1,0 +1,642 @@
+"""Power Doctrine v2 — Investigative Reveal Voice.
+
+This is the CURRENT production editorial voice for Economy FastForward.
+It traces hidden incentive chains behind major geopolitical and economic
+events. The narrator is an investigative analyst who followed the money
+trail and found something the public isn't being told.
+
+Extracted from:
+- brief_translator/prompts/script.txt
+- brief_translator/script_generator.py (_ACT_SPECIFIC_RULES, etc.)
+- pipeline_config.py (ACT_TEMPLATES for 6-act structure)
+"""
+
+from .schema import (
+    ActDefinition,
+    FrameworkIntegrationConfig,
+    IncentiveChainConfig,
+    LanguageConfig,
+    NumberDensityConfig,
+    RetentionConfig,
+    ScriptProfile,
+    TeardownConfig,
+    TemplateMetadata,
+    ValidationConfig,
+    VoiceConfig,
+)
+
+PROFILE = ScriptProfile(
+    # === Identity ===
+    profile_id="power_doctrine_v2",
+    profile_name="Power Doctrine — Investigative Reveal",
+    version="2.0",
+    description=(
+        "Investigative analyst voice that traces incentive chains behind "
+        "major geopolitical and economic events. Follows the money trail "
+        "and reveals what the public isn't being told."
+    ),
+    channel="economy_fastforward",
+
+    # === Voice Definition ===
+    voice=VoiceConfig(
+        identity=(
+            "Investigative Analyst who followed the money trail and found "
+            "something the public isn't being told"
+        ),
+        tone="Pragmatic, unsentimental, data-driven, urgent but controlled",
+        audience=(
+            "Ambitious 18-45 adults who want to understand how power and "
+            "money actually move. They are skeptical of mainstream narratives."
+        ),
+        audience_values=["intelligence", "specificity", "actionable insight"],
+        audience_repelled_by=["lectures", "vague claims", "academic framing"],
+        narrator_posture="revealing",
+    ),
+
+    # === Structural Laws ===
+    structural_laws=[
+        (
+            "Lead with the lie, not the truth. Open by stating the official "
+            "narrative and breaking it with one contradicting fact. When "
+            "multiple official rationales exist, walk through each and let "
+            "them contradict each other. The viewer must feel 'wait, that "
+            "doesn't add up' within 30 seconds."
+        ),
+        (
+            "Build the incentive chain first. Before explaining HOW "
+            "something happened, trace WHO benefits and WHY. Every player "
+            "has a specific incentive — political survival, capital flows, "
+            "market position, regime legitimacy. Connect these incentives "
+            "into a chain leading from the headline event to the viewer's "
+            "wallet. This chain IS the video. 40-50% of runtime."
+        ),
+        (
+            "Every claim gets a number. No 'significant' or 'massive' — "
+            "give the dollar amount, percentage, date, or count. Numbers "
+            "create the feeling of insider intelligence briefing."
+        ),
+        (
+            "The framework is invisible scaffolding until Act 4. Show the "
+            "pattern playing out before you name it. Never say 'Machiavelli "
+            "wrote that...' in the first 10 minutes. Framework/tactical "
+            "mechanics must never exceed 15% of total script time."
+        ),
+        (
+            "End with a specific action, not an insight. Investment thesis, "
+            "sector to watch, risk to hedge, signal to monitor. The viewer "
+            "should be able to DO something with what they learned."
+        ),
+        (
+            "Explicit cliffhangers at every act transition. Sell the next "
+            "section to the viewer. These are the moments viewers are most "
+            "likely to click away. The cliffhanger catches them."
+        ),
+    ],
+
+    # === Content Ratio ===
+    content_ratio={
+        "incentive_chain_money_trail": {"min": 0.40, "max": 0.50},
+        "personal_stakes": {"min": 0.15, "max": 0.20},
+        "historical_proof": {"min": 0.15, "max": 0.20},
+        "framework_mechanics": {"min": 0.05, "max": 0.15},
+        "actionable_strategy": {"min": 0.05, "max": 0.10},
+    },
+
+    # === Act Structure ===
+    act_structure={
+        "act_count": 6,
+        "acts": [
+            ActDefinition(
+                act_number=1,
+                name="THE LIE",
+                purpose="State the official story and plant the seed of doubt",
+                structure=[
+                    "Open with headline event (one sentence, present tense, specific date)",
+                    "State what 'everyone' is being told",
+                    "Drop ONE contradicting fact with a specific number",
+                    "Thesis preview: 'When you follow the [money], you find something different'",
+                ],
+                cliffhanger_template="And what you'll see by Part {next_act} is that {teaser}.",
+                psychological_beat="shock",
+                min_numbers=2,
+                word_pct=0.10,
+            ),
+            ActDefinition(
+                act_number=2,
+                name="THE SETUP",
+                purpose="Key players, their POSITIONS and INCENTIVES, factual foundation",
+                structure=[
+                    "Introduce key players by their incentives, not biographies",
+                    "Facts with specific numbers, dates, named sources",
+                    "What surface analysis says and why it's incomplete",
+                    "End with: 'But here's what none of this explains...'",
+                ],
+                cliffhanger_template="And that missing piece is exactly what Part {next_act} reveals.",
+                psychological_beat="paranoia",
+                min_numbers=5,
+                word_pct=0.20,
+            ),
+            ActDefinition(
+                act_number=3,
+                name="THE HIDDEN MECHANISM",
+                purpose="Reveal the real dynamic — money trail, power flow, strategic logic",
+                structure=[
+                    "Present the mechanism through evidence, not theory",
+                    "Show the money trail with specific data",
+                    "Connect dots mainstream coverage missed",
+                    "First historical parallel as PROOF the pattern is real",
+                ],
+                cliffhanger_template=(
+                    "But there's one more layer that changes everything "
+                    "— and it affects you directly."
+                ),
+                psychological_beat="fascination",
+                min_numbers=4,
+                word_pct=0.25,
+            ),
+            ActDefinition(
+                act_number=4,
+                name="THE PROOF",
+                purpose="Historical parallel validates the mechanism. Framework named HERE.",
+                structure=[
+                    "Historical event in vivid detail (dates, figures, outcomes)",
+                    "Point-by-point mapping to present",
+                    "NOW name the framework: 'What you're watching is what [Author] called...'",
+                    "What the historical precedent PREDICTS",
+                ],
+                cliffhanger_template=(
+                    "And here's the part that every "
+                    "[retail investor/worker/person with savings] needs to hear."
+                ),
+                psychological_beat="historical_dread",
+                min_numbers=3,
+                word_pct=0.20,
+            ),
+            ActDefinition(
+                act_number=5,
+                name="THE PERSONAL STAKES",
+                purpose="Make it about the viewer's money, career, life. Steel-man opposition.",
+                structure=[
+                    "'Here's what this means for your [wallet/portfolio/job]'",
+                    "Specific scenarios with dollar amounts",
+                    "Steel-man the strongest counterargument",
+                    "Dismantle it with evidence, not opinion",
+                ],
+                cliffhanger_template=None,
+                psychological_beat="personal_vulnerability",
+                min_numbers=3,
+                word_pct=0.15,
+            ),
+            ActDefinition(
+                act_number=6,
+                name="THE PLAY",
+                purpose="Specific, actionable strategy based on everything learned",
+                structure=[
+                    "'So what do you actually DO with this?'",
+                    "Specific action: investment thesis, risk to hedge, sector to watch",
+                    "Historical data supporting the timing/approach",
+                    "Final line connecting back to opening lie — make it linger",
+                ],
+                cliffhanger_template=None,
+                psychological_beat="empowerment",
+                min_numbers=2,
+                word_pct=0.10,
+            ),
+        ],
+    },
+
+    # === Number Density ===
+    number_density=NumberDensityConfig(
+        minimum_total=19,
+        per_act={1: 2, 2: 5, 3: 4, 4: 3, 5: 3, 6: 2},
+        definition=(
+            "dollar amount, percentage, date, count, ratio, or named statistic"
+        ),
+        anti_words=["significant", "massive", "unprecedented", "growing"],
+    ),
+
+    # === Retention Engineering ===
+    retention=RetentionConfig(
+        cliffhanger_frequency="every_act_transition",
+        micro_revelation_cadence_seconds=90,
+        explicit_forward_sell=True,
+        forward_sell_template=(
+            "And what you'll see in {next_section} is {teaser}. "
+            "That's where {payoff_preview}."
+        ),
+    ),
+
+    # === Language Rules ===
+    language=LanguageConfig(
+        use_phrases=[
+            "Follow the money",
+            "Here's what doesn't add up",
+            "Nobody is talking about this part",
+            "The official story is... but the actual [data/timeline] shows...",
+            "Position yourself",
+            "When you look at the actual numbers...",
+        ],
+        kill_phrases=[
+            "In this video, we'll explore",
+            "Let's dive into",
+            "It's important to understand",
+            "Many experts believe",
+            "This is significant because",
+            "Throughout history",
+            "In conclusion",
+            "Like and subscribe",
+            "What do you think? Leave a comment",
+        ],
+        framework_naming_rules={
+            "first_mention_act": 4,
+            "max_direct_references": 2,
+            "intro_template": (
+                "What you're watching is what {author} identified as {concept}"
+            ),
+        },
+    ),
+
+    # === Framework Integration ===
+    framework_integration=FrameworkIntegrationConfig(
+        available_frameworks=[
+            {"id": "machiavelli", "name": "Machiavelli", "domain": "power consolidation"},
+            {"id": "48_laws", "name": "48 Laws of Power", "domain": "strategic theater"},
+            {"id": "thucydides", "name": "Thucydides Trap", "domain": "rising vs established power"},
+            {"id": "antifragile", "name": "Antifragile / Black Swan", "domain": "asymmetric risk"},
+            {"id": "game_theory", "name": "Game Theory", "domain": "deterrence, equilibrium"},
+            {"id": "sun_tzu", "name": "Sun Tzu", "domain": "indirect warfare, deception"},
+            {"id": "grand_chessboard", "name": "Grand Chessboard", "domain": "geographic control"},
+            {"id": "kindleberger", "name": "Kindleberger Trap", "domain": "hegemon withdrawal"},
+            {"id": "schelling", "name": "Schelling", "domain": "brinkmanship, focal points"},
+            {"id": "collective_action", "name": "Collective Action", "domain": "organized minorities"},
+            {"id": "soft_power", "name": "Soft Power", "domain": "influence without coercion"},
+            {"id": "jung_shadow", "name": "Jung Shadow", "domain": "projection, shadow self"},
+            {"id": "behavioral_econ", "name": "Behavioral Econ", "domain": "cognitive biases"},
+            {"id": "stoicism", "name": "Stoicism", "domain": "control, fate acceptance"},
+            {"id": "propaganda", "name": "Propaganda", "domain": "information control"},
+            {"id": "systems_thinking", "name": "Systems Thinking", "domain": "feedback loops"},
+            {"id": "evolutionary_psych", "name": "Evolutionary Psych", "domain": "tribal instincts"},
+        ],
+        selection_method="per_video",
+        integration_style="invisible_scaffolding",
+        max_runtime_pct=0.15,
+    ),
+
+    # === Incentive Chain ===
+    incentive_chain=IncentiveChainConfig(
+        required=True,
+        must_complete_before_script=True,
+        chain_template=(
+            "Player A needs X -> requires Y -> depends on Z -> "
+            "headline threatens this -> viewer impact"
+        ),
+        min_links=4,
+        must_end_at_viewer=True,
+        stored_in="Research Payload",
+    ),
+
+    # === Multi-Rationale Teardown ===
+    teardown=TeardownConfig(
+        enabled=True,
+        trigger="multiple_official_rationales",
+        template=[
+            "First, we were told {rationale_1}. But {contradicting_fact_1}.",
+            "Then the story changed to {rationale_2}. But {contradicting_fact_2}.",
+            "Then {rationale_3}.",
+            "Want to know why the story keeps changing? Because {real_reason}.",
+        ],
+    ),
+
+    # === Script Validation Rules ===
+    validation=ValidationConfig(
+        min_words=2200,
+        max_words=3200,
+        min_acts=3,
+        max_acts=8,
+        number_density_check=True,
+        kill_phrase_check=True,
+        cliffhanger_check=True,
+        incentive_chain_presence=True,
+        framework_max_pct_check=True,
+        personal_stakes_presence=True,
+        actionable_ending_check=True,
+        retry_on_fail=True,
+        max_retries=2,
+    ),
+
+    # === Template Metadata (for StoryEngine) ===
+    template_metadata=TemplateMetadata(
+        display_name="Power Doctrine — Investigative Reveal",
+        category="geopolitics_finance",
+        tags=["investigative", "power dynamics", "finance", "geopolitics"],
+        description=(
+            "Traces hidden incentive chains behind major events. Follows "
+            "the money from headline to viewer's wallet. Investigative "
+            "analyst voice — pragmatic, data-driven, specific."
+        ),
+        best_for=["geopolitics", "finance", "corporate power", "economic policy"],
+        example_titles=[
+            "The Iran War Isn't About Nukes — Follow the Money",
+            "Why China's Real Target Isn't Taiwan (It's Your 401k)",
+        ],
+    ),
+
+    # === Emotional Arc ===
+    emotional_arc={
+        1: (
+            "DECEPTION -> SUSPICION. The viewer realizes they've been lied to. "
+            "They feel betrayed by the official narrative. Curiosity gap opened."
+        ),
+        2: (
+            "CURIOSITY -> RECOGNITION. The viewer starts seeing the incentive "
+            "chain. 'Oh, so THAT'S why...' Each fact adds to the picture."
+        ),
+        3: (
+            "RECOGNITION -> REVELATION. The money trail clicks into place. "
+            "The viewer feels like they're seeing behind the curtain."
+        ),
+        4: (
+            "REVELATION -> CONVICTION. The historical parallel proves this is "
+            "a PATTERN, not coincidence. The framework name confirms what they "
+            "already intuited."
+        ),
+        5: (
+            "CONVICTION -> ALARM. The abstract becomes personal. Dollar amounts "
+            "hit the viewer's life directly. Genuine unsettlement."
+        ),
+        6: (
+            "ALARM -> EMPOWERMENT. The viewer receives specific tools and "
+            "actions. They leave feeling SMARTER and MORE CAPABLE. Not scared "
+            "— armed."
+        ),
+    },
+
+    # === Act-Specific Rules ===
+    act_specific_rules="""\
+=== ACT-SPECIFIC RULES (V2 — INVESTIGATIVE VOICE) ===
+
+Act 1 (The Lie):
+Open with the headline event (one sentence, present tense, specific date). \
+State what "everyone" is being told. Drop ONE fact that contradicts the \
+narrative (with a specific number). If multiple official rationales exist, \
+walk through each and let them contradict each other — this is more \
+devastating than breaking one narrative. End with: "When you follow the \
+[money/data/contracts], you find something completely different." \
+Minimum 2 specific numbers. Explicit cliffhanger teasing Act 3.
+
+Act 2 (The Setup):
+Introduce key players by their POSITIONS and INCENTIVES, not biographies. \
+Build the incentive chain: Player A needs X -> requires Y -> depends on Z. \
+Every paragraph must contain at least one specific number or date. Name \
+sources: "according to the Congressional Budget Office" not "experts say." \
+NO framework language yet — pure facts and observable patterns. End with: \
+"But here's what none of this explains..." Minimum 5 specific numbers. \
+Explicit cliffhanger teasing the hidden mechanism.
+
+Act 3 (The Hidden Mechanism):
+Reveal the real dynamic through EVIDENCE, not theory. This is the money \
+trail / power flow / strategic logic with specific data. Connect dots the \
+mainstream coverage missed. Introduce the first historical parallel as \
+PROOF the pattern is real. The framework principles operate here but are \
+NOT named — show don't tell. Each sub-section must have a mini-revelation. \
+Minimum 4 specific numbers. Cliffhanger: "And there's one more layer \
+that affects you directly."
+
+Act 4 (The Proof):
+Historical parallel in vivid detail — specific dates, figures, events, \
+outcomes. Point-by-point mapping: "In 1973, [X]. In 2026, [X]." \
+NOW name the framework: "What you're watching is what [Author] identified \
+as [Concept]." Use the framework to PREDICT what comes next based on \
+historical precedent. The framework arrives as CONFIRMATION of what the \
+viewer already sees. Minimum 3 specific numbers. Cliffhanger about \
+personal financial impact.
+
+Act 5 (The Personal Stakes):
+"Here's what this means for your wallet." Use "you" and "your" heavily. \
+Specific scenarios with dollar amounts: "If [mechanism] continues, gas \
+hits $X within Y days and your 401k drops Z%." Steel-man the strongest \
+counterargument — it must be genuinely strong. Then dismantle it with \
+evidence, not opinion. The viewer should feel genuinely unsettled. \
+Minimum 3 specific numbers.
+
+Act 6 (The Play):
+"So what do you actually DO with this information?" This is NON-NEGOTIABLE \
+— the viewer MUST receive a specific, actionable strategy. The close must:
+
+1. Give the SPECIFIC ACTION: investment thesis, risk to hedge, sector to \
+watch, signal to monitor. Not "diversify your portfolio" but "watch the \
+[specific index/signal]." Include historical performance data: "Smart money \
+moved [X days] after [similar events], not during."
+
+2. NAME the frameworks and patterns taught in this video by name. The \
+viewer must hear them repeated so they stick.
+
+3. Give 2-3 DETECTION INSTRUCTIONS: "When you see X, ask Y. When A \
+happens, look for B within 48 hours." Concrete, specific.
+
+4. End on AGENCY: the final line connects back to the opening lie and \
+lingers. The viewer leaves feeling SMARTER and MORE CAPABLE. NOT scared, \
+NOT helpless, NOT cynical.
+
+BAD close: "The window is closing and nobody will notice." (passive, hopeless)
+GOOD close: "The repricing window opens 11-14 days after the shock. That's \
+when smart money has moved in every conflict since Pearl Harbor. You now know \
+what [framework] looks like in real time. When [specific signal] appears, \
+you'll know the pattern has entered its final phase. The question isn't \
+whether the system works this way. You just watched it happen. The question \
+is whether you position yourself before or after everyone else figures it out."
+
+If Act 6 does NOT contain a specific action AND at least 2 detection \
+instructions, the script has FAILED.
+""",
+
+    # === Micro-Payoff Architecture ===
+    micro_payoff_architecture="""\
+=== MICRO-REVELATION ARCHITECTURE — NON-NEGOTIABLE ===
+
+Every 90 seconds of narration must deliver a specific revelation — a fact, \
+number, or connection the viewer didn't know. The viewer should never go \
+more than 90 seconds without learning something specific and new.
+
+Structure within each scene (60-90 seconds):
+
+CLAIM (first 1-2 sentences): State a specific, verifiable claim with a \
+number. "54% of all PE funding for the top 30 US AI companies comes from \
+three Gulf sovereign wealth funds." This is not a question — it's insider \
+intelligence.
+
+EVIDENCE (middle): Build the case with more specific data. Each fact should \
+connect to the incentive chain — WHO benefits, HOW MUCH, and WHY this \
+matters. Every paragraph must contain at least one specific number.
+
+REVELATION (last 1-2 sentences): The "oh shit" moment — a connection the \
+viewer didn't see. This is NOT a cliffhanger — it's a REWARD.
+
+BRIDGE (final sentence): The revelation naturally raises a NEW question \
+that pulls them into the next scene. This is the explicit forward sell.
+
+BAD example (vague, no numbers):
+"And what happened next would change everything. But first, let's \
+understand the background..."
+
+GOOD example (specific, number-dense, investigative):
+"Iran didn't strike Ras Tanura to destroy it. They struck it to prove \
+that every dollar of Saudi oil wealth now exists at their mercy — and the \
+cost of that proof was twenty thousand dollars. One drone against a \
+facility processing 7 million barrels a day. That's the asymmetry that \
+breaks empires. But the real question isn't whether Iran can do it again. \
+It's what happens when Lloyd's of London decides the Strait isn't worth \
+the $14 billion premium."
+""",
+
+    # === Framework Selection Rules ===
+    framework_selection_rules="""\
+=== FRAMEWORK SELECTION — DYNAMIC PER-VIDEO ===
+
+Before writing the outline, select 1-2 primary frameworks that BEST explain \
+the incentive chain in this story. Do not default to Machiavelli. Choose the \
+framework that creates the most powerful "who benefits" revelation.
+
+Available frameworks (select 1-2):
+1. Machiavelli / 48 Laws of Power — political maneuvering, deception, betrayal
+2. Thucydides Trap — rising power vs established power, inevitable conflict
+3. Taleb (Antifragile/Black Swan) — asymmetric risk, fragility, hidden tail risks
+4. Game Theory — deterrence, prisoner's dilemma, Nash equilibrium, commitment
+5. Sun Tzu (Art of War) — indirect warfare, winning without fighting, deception
+6. Brzezinski / Grand Chessboard / Mackinder — geographic control, pivot states
+7. Kindleberger Trap — hegemon withdrawal, public goods vacuum, systemic collapse
+8. Schelling (Focal Points/Commitment) — brinkmanship, credible threats, red lines
+9. Mancur Olson (Collective Action) — organized minorities vs disorganized majorities
+10. Joseph Nye (Soft Power/Sharp Power) — influence without coercion, cultural dominance
+
+Selection criteria:
+- Which framework best explains the INCENTIVE CHAIN — who benefits and why?
+- Which framework connects this specific event to a MONEY TRAIL the viewer \
+can follow?
+- Which framework gives the viewer a TOOL they can use to predict financial \
+impact and position themselves?
+
+State your framework selection at the top of the outline:
+PRIMARY FRAMEWORK: [Name] — [One sentence on why this framework cracks open \
+this story's incentive chain]
+SECONDARY FRAMEWORK: [Name] — [One sentence on what additional dimension \
+this adds]
+
+REMEMBER: The framework is INVISIBLE in Acts 1-3. It structures your \
+analysis silently. It is only NAMED in Act 4.
+""",
+
+    # === Framework Revelation Engine ===
+    framework_revelation_engine="""\
+=== FRAMEWORK INTEGRATION — INVISIBLE ENGINE, NOT THE HEADLINE ===
+
+The selected framework is the analytical engine that structures the \
+investigation. But it is INVISIBLE SCAFFOLDING until Act 4. The viewer \
+sees the pattern playing out in real events BEFORE you name it.
+
+FRAMEWORK VISIBILITY RULES:
+- Acts 1-3: The framework operates SILENTLY. Show the pattern through \
+events, money trails, and incentive chains. NEVER name the framework, \
+the author, or use academic terminology. The viewer should feel "something \
+deeper is going on" without being told what it is.
+- Act 4: NOW name the framework. "What you're watching is what [Author] \
+identified as [Concept]." This lands as CONFIRMATION of what the viewer \
+already intuited, not as new information being introduced.
+- Acts 5-6: Reference the framework by name at most once more. Use it \
+as a predictive tool: "If this follows the [framework] pattern, then..."
+
+BAD (framework as lecture — kills the investigative tone):
+"Machiavelli wrote in The Prince that consolidating power requires \
+eliminating rival factions. What we're seeing with this company is \
+a textbook application of Chapter 7..."
+
+GOOD (framework invisible, pattern visible):
+"Three weeks after the acquisition, every executive who opposed the \
+deal was gone. Not fired — reassigned to roles with no budget and no \
+staff. The board members who voted against? Their committee seats were \
+quietly redistributed. Within 90 days, every voice of dissent had been \
+neutralized without a single public confrontation."
+(The viewer FEELS the Machiavellian pattern without being told about it.)
+
+GOOD (framework revealed in Act 4):
+"What you've been watching play out — the quiet purge, the strategic \
+appointments, the controlled elimination of opposition — is what \
+Machiavelli identified 500 years ago as the consolidation phase. And \
+the historical record shows what comes next."
+
+CRITICAL: If the framework/tactical/military mechanics section exceeds \
+15% of total script time, the script has drifted into documentary mode. \
+The incentive chain (WHO benefits, HOW MUCH, WHY) must always be the \
+dominant content. The framework EXPLAINS the incentive chain — it does \
+not replace it.
+
+Maximum 2 direct references to the framework by name in the entire script. \
+The rest is showing, not telling.
+""",
+
+    # === Strict Grounding Rule ===
+    strict_grounding_rule="""\
+=== STRICT FACTUAL GROUNDING RULE — NON-NEGOTIABLE ===
+
+Every factual claim, entity name, company name, person name, event, date, \
+and dollar amount in the script MUST come directly from the research payload \
+provided. You may NOT introduce:
+- Companies, people, or events not mentioned in the research
+- Dollar amounts or statistics not in the fact sheet
+- Historical events not in the historical parallels section
+- Dates or timelines not supported by the source material
+
+If you need a transition, analogy, or rhetorical device, use only the \
+entities and events from the research payload. Do NOT substitute \
+similar-sounding companies (e.g. DeepSeek for Anthropic) or similar topics \
+(e.g. tariffs for Pentagon contracts).
+
+Before finalizing each act, verify: is every proper noun, date, statistic, \
+and event traceable to the research payload? If not, remove it or replace \
+it with something from the research.
+
+The ONLY exception is well-known historical figures or events used in \
+framework references (e.g. Machiavelli, Sun Tzu, Athens vs Sparta) that \
+are part of the analytical framework, NOT part of the factual narrative.
+
+=== CRITICAL — FACTUAL GROUNDING (EXTENDED) ===
+
+1. Every specific claim (names, numbers, dates, events, tactics, weapons, \
+quotes) MUST come from the research payload provided. If a fact is not in \
+the payload, DO NOT USE IT.
+
+2. You may describe HOW something happened cinematically, but you MUST NOT \
+invent WHAT happened. Example: You can describe a missile strike \
+dramatically. You CANNOT invent a cyber attack that is not in the sources.
+
+3. Never fabricate technical details (weapon systems, military tactics, \
+operational specifics) to fill narrative gaps. If the payload does not \
+explain HOW something happened, say "analysts believe" or "evidence \
+suggests" — do not present speculation as confirmed fact.
+
+4. Historical parallels must come from the research payload's \
+historical_parallels field. Do not invent additional parallels.
+
+5. If a scene needs content the payload does not provide, use the \
+framework analysis to EXPLAIN the event rather than inventing new events. \
+The analytical framework is your gap-filler, not fabricated details.
+
+6. After writing each scene, mentally verify: "Could I cite a specific \
+source from the payload for every factual claim in this scene?" If not, \
+rewrite.
+
+WHAT YOU CAN CREATE:
+- Dramatic pacing, sentence structure, rhetorical questions
+- Emotional framing of sourced facts
+- Analytical connections between sourced facts using the framework
+- Metaphors and analogies that illustrate sourced concepts
+
+WHAT YOU CANNOT CREATE:
+- Events that did not happen
+- Technical details not in the payload (cyber attacks, specific weapon \
+deployments, operational sequences)
+- Quotes from people unless quoted in the payload
+- Statistics, percentages, or numbers not in the payload
+- Specific military tactics or operations not documented in sources
+""",
+)

--- a/skills/video-pipeline/script_profiles/schema.py
+++ b/skills/video-pipeline/script_profiles/schema.py
@@ -1,0 +1,303 @@
+"""Script Profile schema definition.
+
+A script profile is a self-contained configuration that captures every
+aspect of a channel's editorial voice: act structure, tone, audience,
+structural laws, number density, retention engineering, language rules,
+framework integration, and validation thresholds.
+
+Swapping the entire editorial approach = changing one profile reference.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class ActDefinition:
+    """Definition of a single act within the script structure."""
+    act_number: int = 1
+    name: str = ""
+    purpose: str = ""
+    structure: list[str] = field(default_factory=list)
+    cliffhanger_template: Optional[str] = None
+    psychological_beat: str = ""
+    min_numbers: int = 0
+    word_pct: float = 0.0
+
+
+@dataclass
+class VoiceConfig:
+    """Voice and audience definition."""
+    identity: str = ""
+    tone: str = ""
+    audience: str = ""
+    audience_values: list[str] = field(default_factory=list)
+    audience_repelled_by: list[str] = field(default_factory=list)
+    narrator_posture: str = "revealing"  # "revealing" | "explaining" | "teaching"
+
+
+@dataclass
+class NumberDensityConfig:
+    """Number density requirements for the script."""
+    minimum_total: int = 19
+    per_act: dict[int, int] = field(default_factory=dict)
+    definition: str = "dollar amount, percentage, date, count, ratio, or named statistic"
+    anti_words: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RetentionConfig:
+    """Retention engineering rules."""
+    cliffhanger_frequency: str = "every_act_transition"
+    micro_revelation_cadence_seconds: int = 90
+    explicit_forward_sell: bool = True
+    forward_sell_template: str = ""
+
+
+@dataclass
+class LanguageConfig:
+    """Language rules — approved phrases, kill phrases, framework naming."""
+    use_phrases: list[str] = field(default_factory=list)
+    kill_phrases: list[str] = field(default_factory=list)
+    framework_naming_rules: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FrameworkIntegrationConfig:
+    """Framework integration rules."""
+    available_frameworks: list[dict[str, str]] = field(default_factory=list)
+    selection_method: str = "per_video"
+    integration_style: str = "invisible_scaffolding"
+    max_runtime_pct: float = 0.15
+
+
+@dataclass
+class IncentiveChainConfig:
+    """Incentive chain requirements."""
+    required: bool = True
+    must_complete_before_script: bool = True
+    chain_template: str = ""
+    min_links: int = 4
+    must_end_at_viewer: bool = True
+    stored_in: str = "Research Payload"
+
+
+@dataclass
+class TeardownConfig:
+    """Multi-rationale teardown structure."""
+    enabled: bool = True
+    trigger: str = "multiple_official_rationales"
+    template: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationConfig:
+    """Script validation rules."""
+    min_words: int = 2200
+    max_words: int = 3200
+    min_acts: int = 3
+    max_acts: int = 8
+    number_density_check: bool = True
+    kill_phrase_check: bool = True
+    cliffhanger_check: bool = True
+    incentive_chain_presence: bool = True
+    framework_max_pct_check: bool = True
+    personal_stakes_presence: bool = True
+    actionable_ending_check: bool = True
+    retry_on_fail: bool = True
+    max_retries: int = 2
+
+
+@dataclass
+class TemplateMetadata:
+    """StoryEngine template metadata — what customers see during onboarding."""
+    display_name: str = ""
+    category: str = ""
+    tags: list[str] = field(default_factory=list)
+    description: str = ""
+    best_for: list[str] = field(default_factory=list)
+    example_titles: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ScriptProfile:
+    """Complete editorial voice definition. Self-contained and pluggable.
+
+    Every aspect of how scripts are written — tone, structure, act
+    definitions, validation rules, language constraints — is captured
+    here. The pipeline reads the active profile at runtime.
+    """
+
+    # Identity
+    profile_id: str = ""
+    profile_name: str = ""
+    version: str = "1.0"
+    description: str = ""
+    channel: str = "economy_fastforward"
+
+    # Sections
+    voice: VoiceConfig = field(default_factory=VoiceConfig)
+    structural_laws: list[str] = field(default_factory=list)
+    content_ratio: dict[str, dict[str, float]] = field(default_factory=dict)
+    act_structure: dict[str, Any] = field(default_factory=dict)
+    number_density: NumberDensityConfig = field(default_factory=NumberDensityConfig)
+    retention: RetentionConfig = field(default_factory=RetentionConfig)
+    language: LanguageConfig = field(default_factory=LanguageConfig)
+    framework_integration: FrameworkIntegrationConfig = field(
+        default_factory=FrameworkIntegrationConfig
+    )
+    incentive_chain: IncentiveChainConfig = field(
+        default_factory=IncentiveChainConfig
+    )
+    teardown: TeardownConfig = field(default_factory=TeardownConfig)
+    validation: ValidationConfig = field(default_factory=ValidationConfig)
+    template_metadata: TemplateMetadata = field(default_factory=TemplateMetadata)
+
+    # System prompt template with {placeholders} for runtime assembly.
+    # If empty, the default assembly logic in build_script_system_prompt() is used.
+    system_prompt_template: str = ""
+
+    # Emotional arc per act — maps act number to emotional description
+    emotional_arc: dict[int, str] = field(default_factory=dict)
+
+    # Act-specific rules text block (appended to prompt)
+    act_specific_rules: str = ""
+
+    # Micro-payoff architecture text block
+    micro_payoff_architecture: str = ""
+
+    # Framework selection rules text block
+    framework_selection_rules: str = ""
+
+    # Framework revelation engine text block
+    framework_revelation_engine: str = ""
+
+    # Strict grounding rule text block
+    strict_grounding_rule: str = ""
+
+
+def build_script_system_prompt(profile: ScriptProfile) -> str:
+    """Assemble the script system prompt from profile sections.
+
+    This builds the voice/tone/structure preamble that precedes the
+    research brief in the final prompt. It replaces the hardcoded
+    content in ``prompts/script.txt`` when a profile is active.
+    """
+    acts = profile.act_structure.get("acts", [])
+
+    # Voice block
+    voice = profile.voice
+    voice_block = f"""You are {voice.identity}.
+
+=== YOUR VOICE — NON-NEGOTIABLE ===
+
+- {voice.tone}
+- Investigative, not academic. You found something. You're showing your work.
+
+=== YOUR AUDIENCE ===
+
+{voice.audience}
+They value: {', '.join(voice.audience_values)}.
+They will leave immediately if they feel: {', '.join(voice.audience_repelled_by)}."""
+
+    # Structural laws
+    laws_lines = []
+    for i, law in enumerate(profile.structural_laws):
+        laws_lines.append(f"{i + 1}. {law}")
+    laws_block = "=== STRUCTURAL LAWS — NON-NEGOTIABLE ===\n\n" + "\n\n".join(laws_lines)
+
+    # Content ratio
+    ratio_lines = []
+    for k, v in profile.content_ratio.items():
+        label = k.replace("_", " ").title()
+        ratio_lines.append(f"- {label}: {v['min']*100:.0f}-{v['max']*100:.0f}% of runtime")
+    ratio_block = "=== STRUCTURAL RATIO (NON-NEGOTIABLE) ===\n\n" + "\n".join(ratio_lines)
+
+    # Number density
+    nd = profile.number_density
+    per_act_lines = []
+    for act_num in sorted(nd.per_act.keys()):
+        per_act_lines.append(f"- Act {act_num}: {nd.per_act[act_num]}+ numbers")
+    numbers_block = (
+        "=== NUMBER DENSITY REQUIREMENTS ===\n\n"
+        "Minimum specific, verifiable numbers per act:\n"
+        + "\n".join(per_act_lines)
+        + f"\nTotal minimum: {nd.minimum_total} specific, verifiable numbers across the full script.\n"
+        f'"Specific number" means: {nd.definition}.\n'
+        f'"' + '", "'.join(nd.anti_words) + '" are NOT numbers.'
+    )
+
+    # Retention engineering
+    ret = profile.retention
+    retention_block = (
+        f"=== RETENTION ENGINEERING ===\n\n"
+        f"- Deliver a mini-revelation every {ret.micro_revelation_cadence_seconds} seconds "
+        f"— a fact, number, or connection the viewer didn't know\n"
+        f"- End each act with an explicit cliffhanger that sells the next section\n"
+        f"- Never go more than {ret.micro_revelation_cadence_seconds} seconds "
+        f"without giving the viewer something specific"
+    )
+
+    # Kill words
+    kill_block = (
+        '=== WORDS TO NEVER USE ===\n\n'
+        + ", ".join(f'"{p}"' for p in profile.language.kill_phrases)
+    )
+
+    # Framework integration rules
+    fr = profile.language.framework_naming_rules
+    framework_block = (
+        "=== FRAMEWORK INTEGRATION RULES ===\n\n"
+        f"1. The framework is NEVER named before Act {fr.get('first_mention_act', 4)}.\n"
+        f"2. Maximum {fr.get('max_direct_references', 2)} direct references to the "
+        f"framework by name in the entire script.\n"
+        f"3. Introduced as: \"{fr.get('intro_template', '')}\""
+    )
+
+    # Act structure block
+    act_lines = []
+    for act in acts:
+        if isinstance(act, ActDefinition):
+            a = act
+        else:
+            a = ActDefinition(**act)
+
+        act_header = f"[ACT {a.act_number} — {a.name}]"
+        act_lines.append(f"{act_header}")
+        act_lines.append(f"Purpose: {a.purpose}")
+        act_lines.append(f"Min numbers: {a.min_numbers}")
+        act_lines.append(f"Word allocation: {a.word_pct*100:.0f}% of total")
+        for s in a.structure:
+            act_lines.append(f"- {s}")
+        if a.cliffhanger_template:
+            act_lines.append(f"CLIFFHANGER: {a.cliffhanger_template}")
+        act_lines.append("")
+
+    acts_block = "=== ACT STRUCTURE ===\n\n" + "\n".join(act_lines)
+
+    # Emotional arc
+    if profile.emotional_arc:
+        arc_lines = []
+        for act_num in sorted(profile.emotional_arc.keys()):
+            arc_lines.append(f"- Act {act_num}: {profile.emotional_arc[act_num]}")
+        arc_block = "=== EMOTIONAL ARC ===\n\n" + "\n".join(arc_lines)
+    else:
+        arc_block = ""
+
+    # Assemble
+    sections = [
+        voice_block,
+        laws_block,
+        ratio_block,
+        numbers_block,
+        retention_block,
+        kill_block,
+        framework_block,
+        acts_block,
+    ]
+    if arc_block:
+        sections.append(arc_block)
+
+    return "\n\n".join(sections)

--- a/skills/video-pipeline/script_profiles/templates/__init__.py
+++ b/skills/video-pipeline/script_profiles/templates/__init__.py
@@ -1,0 +1,2 @@
+# StoryEngine template profiles — pre-built editorial voices for niches.
+# See script_profiles/README.md for how to create new templates.


### PR DESCRIPTION
Create script_profiles/ directory mirroring the visual_profiles pattern.
Each profile is a complete, self-contained editorial voice definition
that controls tone, act structure, structural laws, number density,
retention engineering, language rules, framework integration, and
validation thresholds.

- ScriptProfile dataclass with 14 configurable sections
- Profile loader with Airtable field → env var → default fallback
- power_doctrine_v2: current production investigative reveal voice
- power_doctrine_v1: legacy framework-explainer voice
- Runtime prompt assembly from profile sections (not monolithic string)
- Profile-aware validation with kill phrase checking
- Full backward compatibility when no profile is provided
- Fix template placeholder issue in script.txt ({FRAMEWORK_AUTHOR})

249 tests passing, ruff clean.

https://claude.ai/code/session_01Gq3Wro4ggWJZG1bFiNkoUq