### PR TITLE
Reduce entity hallucination false positives in script validation

### DIFF
--- a/skills/video-pipeline/brief_translator/__init__.py
+++ b/skills/video-pipeline/brief_translator/__init__.py
@@ -30,7 +30,7 @@ from .supplementer import (
 from .script_generator import generate_script, verify_script_claims
 from .scene_expander import expand_scene_concepts
 from .scene_validator import validate_scene_list, auto_fix_minor_issues, check_entity_consistency
-from .pipeline_writer import graduate_to_pipeline
+from .pipeline_writer import graduate_to_pipeline, select_video_title, build_sources_list
 from .psych_angle_assigner import (
     assign_angles_to_scenes,
     format_psych_arc_summary,
@@ -247,6 +247,7 @@ class BriefTranslator:
                     logger.warning(
                         f"Could not write Framework Angle to Airtable: {fw_err}"
                     )
+                    self._notify(f"⚠️ Framework Angle write failed: {fw_err}")
             else:
                 logger.info("No framework found in script output or research brief")
 
@@ -300,6 +301,18 @@ class BriefTranslator:
             psych_arc_summary = format_psych_arc_summary(psych_assignments)
             if psych_arc_summary:
                 logger.info(f"Psychological arc: {psych_arc_summary}")
+
+            # === STEP 2e: Write Script records progressively ===
+            # Write each act to the Scripts table BEFORE scene expansion so
+            # records are saved even if expansion times out or fails.
+            script_record_ids = self._write_script_records(
+                acts=acts,
+                brief=brief,
+                psych_assignments=psych_assignments,
+                unverified_claims=unverified_claims,
+                editorial_summary=editorial_summary,
+            )
+            result["script_record_ids"] = script_record_ids
 
             # === STEP 3: Scene Expansion (per-scene concept expansion) ===
             logger.info("Step 3: Expanding script into visual concepts (scene by scene)...")
@@ -468,6 +481,76 @@ class BriefTranslator:
             self._notify(
                 f"⚠️ Script Validation field write failed: {e}"
             )
+
+    def _write_script_records(
+        self,
+        acts: dict,
+        brief: dict,
+        psych_assignments: list | None = None,
+        unverified_claims: str = "",
+        editorial_summary: str = "",
+    ) -> list[str]:
+        """Write script records to the Scripts table progressively (one per act).
+
+        Called BEFORE scene expansion so records exist even if expansion
+        times out or fails. Returns list of created record IDs.
+        """
+        video_title = select_video_title(brief)
+        sources_text = build_sources_list(brief)
+
+        angle_lookup = {}
+        if psych_assignments:
+            for pa in psych_assignments:
+                angle_lookup[pa["scene"]] = pa["angle"]
+
+        record_ids: list[str] = []
+        first_record_id = None
+
+        for act_num in sorted(acts.keys()):
+            act_text = acts[act_num]
+            psych_angle = angle_lookup.get(act_num, "")
+            try:
+                record = self.airtable.create_script_record(
+                    scene_number=act_num,
+                    scene_text=act_text,
+                    title=video_title,
+                    psych_angle=psych_angle,
+                    sources=sources_text if act_num == 1 else "",
+                )
+                rid = record.get("id", "")
+                record_ids.append(rid)
+                if act_num == min(acts.keys()):
+                    first_record_id = rid
+                logger.info(f"Script record written: act {act_num}")
+            except Exception as e:
+                logger.error(f"Failed to write Script record for act {act_num}: {e}")
+                self._notify(
+                    f"⚠️ Script record write FAILED for act {act_num}: {e}"
+                )
+
+        # Write unverified claims to the first script record
+        if unverified_claims and first_record_id:
+            try:
+                self.airtable.update_script_record(
+                    first_record_id,
+                    {"Unverified Claims": unverified_claims},
+                )
+            except Exception as e:
+                logger.warning(f"Could not write Unverified Claims: {e}")
+                self._notify(f"⚠️ Unverified Claims write failed: {e}")
+
+        # Write editorial validation to the first script record
+        if editorial_summary and first_record_id:
+            try:
+                self.airtable.update_script_record(
+                    first_record_id,
+                    {"Script Validation": editorial_summary},
+                )
+            except Exception as e:
+                logger.warning(f"Could not write Script Validation to Script table: {e}")
+                self._notify(f"⚠️ Script Validation write (Script table) failed: {e}")
+
+        return record_ids
 
     def _notify(self, message: str):
         """Send a Slack notification if client is available."""

--- a/skills/video-pipeline/brief_translator/pipeline_writer.py
+++ b/skills/video-pipeline/brief_translator/pipeline_writer.py
@@ -320,55 +320,20 @@ async def graduate_to_pipeline(
         result = airtable_client.create_idea(core_fields)
         pipeline_record_id = result["id"]
         print(f"  ⚠️ Some new fields not yet in Airtable: {e}")
-
-    # 4. Create Script table records (one per act) with Psych Angle
-    if acts:
-        video_title = select_video_title(brief)
-        sources_text = build_sources_list(brief)
-        # Build a lookup: scene_number → psych_angle
-        angle_lookup = {}
-        if psych_assignments:
-            for pa in psych_assignments:
-                angle_lookup[pa["scene"]] = pa["angle"]
-
-        first_record_id = None
-        for act_num in sorted(acts.keys()):
-            act_text = acts[act_num]
-            psych_angle = angle_lookup.get(act_num, "")
+        if slack_client:
             try:
-                record = airtable_client.create_script_record(
-                    scene_number=act_num,
-                    scene_text=act_text,
-                    title=video_title,
-                    psych_angle=psych_angle,
-                    sources=sources_text if act_num == 1 else "",
+                slack_client.send_message(
+                    f"⚠️ Pipeline record created with core fields only "
+                    f"(some fields dropped): {e}"
                 )
-                if act_num == min(acts.keys()):
-                    first_record_id = record.get("id")
-            except Exception as e:
-                print(f"  ⚠️ Could not create Script record for scene {act_num}: {e}")
+            except Exception:
+                pass
 
-        # Write unverified claims to the first script record (non-blocking)
-        if unverified_claims and first_record_id:
-            try:
-                airtable_client.update_script_record(
-                    first_record_id,
-                    {"Unverified Claims": unverified_claims},
-                )
-            except Exception as e:
-                print(f"  ⚠️ Could not write Unverified Claims: {e}")
+    # 4. Script table records are now written progressively by
+    #    BriefTranslator._write_script_records() BEFORE scene expansion.
+    #    This ensures records exist even if expansion fails or times out.
 
-        # Write editorial validation results to the first script record (non-blocking)
-        if editorial_validation and first_record_id:
-            try:
-                airtable_client.update_script_record(
-                    first_record_id,
-                    {"Script Validation": editorial_validation},
-                )
-            except Exception as e:
-                print(f"  ⚠️ Could not write Script Validation: {e}")
-
-    # 5. Update Idea Concepts record status  (was step 4)
+    # 5. Update Idea Concepts record status
     try:
         airtable_client.update_idea_status(idea_record_id, "sent_to_pipeline")
     except Exception as e:
@@ -381,6 +346,13 @@ async def graduate_to_pipeline(
             )
         except Exception:
             print(f"  ⚠️ Could not update Idea Concepts status: {e}")
+            if slack_client:
+                try:
+                    slack_client.send_message(
+                        f"⚠️ Airtable status update FAILED for {idea_record_id}: {e}"
+                    )
+                except Exception:
+                    pass
 
     # 6. Notify via Slack
     if slack_client:

--- a/skills/video-pipeline/brief_translator/scene_validator.py
+++ b/skills/video-pipeline/brief_translator/scene_validator.py
@@ -371,7 +371,19 @@ _ACRONYM_RE = re.compile(r"\b([A-Z]{2,})\b")
 # Common English words that start with a capital letter at sentence starts.
 # We skip these to reduce false positives.
 _COMMON_WORDS = {
-    # Pronouns, determiners, conjunctions, prepositions
+    # Articles, pronouns, determiners, conjunctions, prepositions (including
+    # SHORT words — critical for multi-word phrase filtering like "The House")
+    "a", "an", "the", "and", "or", "but", "nor", "for", "yet", "so",
+    "in", "on", "at", "to", "by", "of", "up", "if", "it", "is", "as",
+    "be", "he", "we", "do", "no", "my", "am", "us", "me", "go",
+    "his", "her", "its", "our", "who", "how", "all", "any", "not",
+    "was", "are", "has", "had", "can", "may", "did", "got", "get",
+    "own", "let", "say", "see", "use", "way", "set", "new", "old",
+    "day", "end", "big", "own", "put", "run", "try", "ask", "far",
+    "few", "ago", "act", "cut", "hit", "pay", "top", "low", "oil",
+    "war", "age", "era", "tax", "law", "aid", "bit", "led", "won",
+    "two", "ten", "man", "men", "one", "red", "raw",
+    # Pronouns, determiners — longer
     "this", "that", "these", "those", "there", "their", "they",
     "what", "when", "where", "which", "while", "with", "will",
     "from", "have", "here", "been", "being", "before", "after",
@@ -400,7 +412,7 @@ _COMMON_WORDS = {
     "increasingly", "effectively", "significantly", "approximately",
     "except", "despite", "besides", "toward", "across", "within",
     "whether", "rather", "already", "perhaps", "actually", "simply",
-    # Common descriptive / generic words (not named entities)
+    # Common descriptive / generic nouns that appear capitalized
     "budget", "eastern", "western", "northern", "southern", "central",
     "federal", "national", "global", "domestic", "foreign", "military",
     "political", "economic", "financial", "industrial", "commercial",
@@ -411,7 +423,27 @@ _COMMON_WORDS = {
     "hook", "build", "payoff", "bridge", "lesson", "stakes",
     "framework", "mechanism", "mirror", "foundation", "history",
     "dark", "revelation", "pattern", "system", "empire", "stage",
+    # Common nouns frequently capitalized in geopolitical / economic scripts
+    # that trigger false positives as "entity hallucinations"
+    "cold", "house", "white", "street", "deal", "plan", "market",
+    "game", "race", "trade", "bank", "bond", "debt", "fund",
+    "peak", "boom", "bust", "rise", "fall", "wave", "shift",
+    "block", "chain", "belt", "road", "iron", "steel", "gold",
+    "land", "free", "rich", "poor", "middle", "class", "rate",
+    "price", "cost", "loss", "gain", "growth", "crisis", "reform",
+    "party", "group", "force", "front", "order", "union", "league",
+    "council", "court", "board", "office", "agency", "committee",
+    "congress", "parliament", "senate", "assembly", "ministry",
+    "republic", "kingdom", "island", "valley", "mountain", "river",
+    "north", "south", "east", "west", "great", "little", "long",
+    "modern", "ancient", "royal", "civil", "total", "general",
+    "special", "final", "chief", "prime", "senior", "junior",
 }
+
+# Minimum word count for multi-word phrases to be considered entities.
+# Two-word phrases where ALL words are common (e.g. "Cold War", "The House")
+# are almost never hallucinated entities — they're common English.
+_MIN_MULTIWORD_ENTITY_WORDS = 3
 
 # Minimum character length for single-word entities to be checked.
 # Shorter words are almost always common English, not named entities.
@@ -425,12 +457,22 @@ def _extract_entities_from_text(text: str) -> set[str]:
     """
     entities: set[str] = set()
 
-    # Multi-word proper nouns (high confidence — but skip if all words are common)
+    # Multi-word proper nouns — skip if all words are common English OR if
+    # the phrase is short (2 words) and all words are in the stopword list.
+    # Phrases like "Cold War", "The House", "The Iraq War" are almost never
+    # hallucinations; they're common English phrases that appear capitalized.
     for m in _MULTI_WORD_PN_RE.findall(text):
         lowered = m.lower()
         words = lowered.split()
         if all(w in _COMMON_WORDS for w in words):
             continue
+        # For 2-word phrases, require at least one word NOT in common words
+        # AND that uncommon word must be >= _MIN_ENTITY_LENGTH chars.
+        # This filters "Cold War" (war=3 chars), "The House" (all common now).
+        if len(words) <= 2:
+            uncommon = [w for w in words if w not in _COMMON_WORDS]
+            if not uncommon or all(len(w) < _MIN_ENTITY_LENGTH for w in uncommon):
+                continue
         entities.add(lowered)
 
     # CamelCase always included (high confidence: "DeepSeek", "OpenAI")

--- a/skills/video-pipeline/brief_translator/tests/test_entity_checker.py
+++ b/skills/video-pipeline/brief_translator/tests/test_entity_checker.py
@@ -1,0 +1,88 @@
+"""Tests for entity consistency checker — false positive reduction."""
+
+from brief_translator.scene_validator import (
+    _extract_entities_from_text,
+    check_entity_consistency,
+)
+
+
+class TestExtractEntities:
+    """Tests for _extract_entities_from_text."""
+
+    def test_cold_war_not_flagged(self):
+        entities = _extract_entities_from_text("The Cold War shaped geopolitics.")
+        assert "cold war" not in entities
+        assert "the cold war" not in entities
+
+    def test_the_house_not_flagged(self):
+        entities = _extract_entities_from_text("The House passed the bill.")
+        assert "the house" not in entities
+
+    def test_wall_street_not_flagged(self):
+        entities = _extract_entities_from_text("Wall Street panicked.")
+        assert "wall street" not in entities
+
+    def test_white_house_not_flagged(self):
+        entities = _extract_entities_from_text("The White House issued a statement.")
+        assert "white house" not in entities
+        assert "the white house" not in entities
+
+    def test_real_entity_goldman_sachs_flagged(self):
+        entities = _extract_entities_from_text("Goldman Sachs reported earnings.")
+        assert "goldman sachs" in entities
+
+    def test_real_entity_sam_altman_flagged(self):
+        entities = _extract_entities_from_text("Sam Altman announced changes.")
+        assert "sam altman" in entities
+
+    def test_acronyms_still_flagged(self):
+        entities = _extract_entities_from_text("NATO issued a warning.")
+        assert "nato" in entities
+
+    def test_camelcase_still_flagged(self):
+        entities = _extract_entities_from_text("DeepSeek released a new model.")
+        assert "deepseek" in entities
+
+    def test_single_short_word_not_flagged(self):
+        """Words under 6 chars should not be flagged as entities."""
+        entities = _extract_entities_from_text("The Plan was simple.")
+        assert "plan" not in entities
+
+
+class TestCheckEntityConsistency:
+    """End-to-end tests for entity consistency checking."""
+
+    def test_entity_in_research_not_flagged(self):
+        script = "The Iraq War cost trillions."
+        brief = {
+            "fact_sheet": "The Iraq War began in 2003.",
+            "headline": "Costs of War",
+        }
+        warnings = check_entity_consistency(script, brief)
+        assert len(warnings) == 0
+
+    def test_entity_only_in_script_flagged(self):
+        script = "Goldman Sachs led the bailout negotiations."
+        brief = {
+            "fact_sheet": "Banks received government aid.",
+            "headline": "Financial Crisis",
+        }
+        warnings = check_entity_consistency(script, brief)
+        assert any("goldman sachs" in w.lower() for w in warnings)
+
+    def test_common_phrases_never_flag_regardless(self):
+        """Common geopolitical phrases should never produce warnings."""
+        script = (
+            "The Cold War ended. The White House responded. "
+            "Wall Street crashed. The House voted."
+        )
+        brief = {
+            "fact_sheet": "Economic analysis of policy impacts.",
+            "headline": "Policy Analysis",
+        }
+        warnings = check_entity_consistency(script, brief)
+        flagged_entities = " ".join(warnings).lower()
+        assert "cold war" not in flagged_entities
+        assert "white house" not in flagged_entities
+        assert "wall street" not in flagged_entities
+        assert "the house" not in flagged_entities


### PR DESCRIPTION
## Summary
This PR significantly improves the entity consistency checker by reducing false positives from common English phrases and geopolitical terminology that are frequently capitalized in video scripts. It also refactors script record writing to occur progressively before scene expansion, ensuring records are persisted even if downstream processing fails.

## Key Changes

### Entity Extraction Improvements
- **Expanded common words list**: Added 50+ common English words (articles, prepositions, short nouns) to the `_COMMON_WORDS` stopword set to filter out phrases like "Cold War", "The House", "Wall Street", and "The White House"
- **Multi-word phrase filtering**: Implemented logic to skip 2-word phrases where all words are common English or where uncommon words are too short (< 6 chars), preventing false positives on legitimate English phrases
- **Geopolitical terminology**: Added domain-specific common nouns frequently capitalized in scripts (e.g., "cold", "house", "street", "market", "trade", "party", "congress") that were triggering false entity hallucination warnings

### Script Record Writing Refactor
- **Progressive persistence**: Moved script record creation from `graduate_to_pipeline()` to a new `_write_script_records()` method in `BriefTranslator`, called BEFORE scene expansion (Step 2e)
- **Improved resilience**: Script records are now written and persisted even if scene expansion times out or fails downstream
- **Better error handling**: Added Slack notifications for write failures and improved logging throughout the process

### Testing
- Added comprehensive test suite (`test_entity_checker.py`) with 10 test cases covering:
  - Common phrases that should NOT be flagged (Cold War, The House, Wall Street, White House)
  - Real entities that SHOULD be flagged (Goldman Sachs, Sam Altman)
  - Edge cases (acronyms, CamelCase, short words)
  - End-to-end consistency checking

### Code Organization
- Exported `select_video_title` and `build_sources_list` from `pipeline_writer.py` for reuse in the new script writing method
- Cleaned up `graduate_to_pipeline()` by removing script record creation logic (now handled earlier in the pipeline)

## Implementation Details
- The entity extraction now uses a two-tier filtering approach: first checking if all words in a phrase are common, then for 2-word phrases specifically requiring at least one uncommon word of sufficient length
- Script records are written per-act with psychological angle assignments and sources (only on the first act to avoid duplication)
- Unverified claims and editorial validation are written to the first script record after all acts are persisted

https://claude.ai/code/session_0147WXdZiHU1pWfae7GEjwy1