### PR TITLE
Wire sequencer.py rotation into prompt generation — fix all-war-table…

### DIFF
--- a/skills/video-pipeline/SEQUENCER_INTEGRATION.md
+++ b/skills/video-pipeline/SEQUENCER_INTEGRATION.md
@@ -1,0 +1,227 @@
+# Sequencer Integration Fix
+
+**Date:** 2026-03-11
+**Issue:** All image prompts were identical - "Overhead angled view of a holographic war table..."
+**Root Cause:** Parameter mismatch between scene_expander.py output and build_prompt() expectations
+**Fix:** Wired image_prompt_engine/sequencer.py into run_styled_image_prompts() for proper rotation
+
+---
+
+## What Changed
+
+### Before (Broken)
+```python
+# scene_expander.py generated:
+visual_style = "dossier"/"schema"/"echo"
+composition = "wide"/"medium"/"closeup"
+
+# But build_prompt() expected:
+content_type = "geographic_map"/"data_terminal"/etc.
+display_format = "war_table"/"wall_display"/etc.
+
+# Result: Everything defaulted to WAR_TABLE
+```
+
+### After (Fixed)
+```python
+# sequencer.py now generates proper style assignments:
+style_assignments = assign_styles(total_images=estimated_total_images)
+
+# Each assignment has:
+{
+    "content_type": "geographic_map",  # 8 types rotate
+    "display_format": "war_table",     # 5 formats rotate
+    "color_mood": "strategic",         # 6 moods rotate
+    "ken_burns": "slow_zoom_in",
+}
+
+# build_prompt() gets correct parameters:
+prompt = build_prompt(
+    scene_description=visual_desc,
+    content_type=style["content_type"],
+    display_format=style["display_format"],
+    color_mood=style["color_mood"],
+)
+```
+
+---
+
+## Code Changes
+
+**File:** `skills/video-pipeline/pipeline.py`
+
+### 1. Import sequencer (line ~2017)
+```python
+from image_prompt_engine.sequencer import assign_styles
+```
+
+### 2. Generate style assignments BEFORE scene loop (line ~2065)
+```python
+# Estimate total images: ~7 images per scene average
+estimated_total_images = total_scripts * 7
+print(f"  Generating style assignments for ~{estimated_total_images} images...")
+
+style_assignments = assign_styles(
+    total_images=estimated_total_images,
+    seed=hash(self.video_title) % (2**32),  # Deterministic per video
+)
+```
+
+### 3. Track global image_index (line ~2094)
+```python
+image_index = 0  # Global counter across all scenes
+```
+
+### 4. Use sequencer assignments in prompt generation (line ~2150)
+```python
+for concept in concepts:
+    visual_desc = concept["visual_description"]
+
+    # Get style from sequencer (with bounds check)
+    if image_index < len(style_assignments):
+        style = style_assignments[image_index]
+        content_type = style["content_type"]
+        display_format = style["display_format"]
+        color_mood = style["color_mood"]
+    else:
+        # Fallback if we exceed estimate
+        content_type = "geographic_map"
+        display_format = "war_table"
+        color_mood = "strategic"
+
+    # Build styled prompt using sequencer-assigned styles
+    prompt = build_prompt(
+        scene_description=visual_desc,
+        content_type=content_type,
+        display_format=display_format,
+        color_mood=color_mood,
+        image_style_override=image_style_override,
+    )
+
+    image_index += 1  # Increment global counter
+```
+
+### 5. Updated reporting (line ~2190)
+```python
+# Report display format distribution instead of old dossier/schema/echo
+if style_counts:
+    total_styled = sum(style_counts.values())
+    print(f"  Display format variety:")
+    for fmt, count in sorted(style_counts.items(), key=lambda x: -x[1]):
+        pct = count / total_styled * 100
+        print(f"    {fmt}: {count} ({pct:.0f}%)")
+```
+
+---
+
+## Rotation Rules (Enforced by Sequencer)
+
+| Style Dimension | Rotation Rule | Purpose |
+|----------------|---------------|---------|
+| **Content Type** (8 types) | Max 2 consecutive same type | Prevents repetitive subject matter |
+| **Display Format** (5 formats) | Max 2 consecutive same format | Varies camera angles and framing |
+| **Close-Up Detail** | Max 1 consecutive | Prevents tunnel vision - punctuation only |
+| **Color Mood** (6 moods) | Max 3 consecutive same palette | Emotional pacing across acts |
+| **Ken Burns Motion** | Alternates pans (L↔R) | Prevents directional monotony |
+
+---
+
+## Expected Results
+
+### Display Format Distribution (Typical)
+- **War Table** (overhead angled): 30-40% - Geographic maps, networks, satellite
+- **Wall Display** (front-facing): 30-40% - Charts, documents, timelines
+- **Floating Projection** (mid-air): 10-20% - Object comparisons, concepts
+- **Multi-Panel** (split screen): 5-10% - Before/after, parallels
+- **Close-Up Detail** (macro focus): 5-10% - Key stats, critical text
+
+### Content Type Variety
+All 8 types should appear across a full video:
+- Geographic Map, Data Terminal, Object Comparison, Document Display,
+- Network Diagram, Timeline, Satellite Recon, Concept Visualization
+
+### Color Mood Pacing
+Act-weighted rotation:
+- Act 1 (Hook): Strategic (teal/cyan)
+- Act 2-4: Alert (red/amber), Archive (gold/sepia), Contagion (green/yellow)
+- Act 5-6: Power (purple/magenta), Personal (warm amber)
+
+---
+
+## Testing
+
+### Quick Test (Run on one video)
+```bash
+cd skills/video-pipeline
+python test_prompt_variety.py "Your Video Title Here"
+```
+
+Tests verify:
+1. ✅ Not all prompts are war_table (variety exists)
+2. ✅ At least 3 different display formats appear
+3. ✅ Max consecutive same format ≤ 2 (rotation enforced)
+4. ✅ At least 3 different content types detected
+
+### Manual Test (Visual inspection)
+```bash
+# Generate prompts for a new video
+python run_image_pipeline.py "Video Title"
+
+# Check Airtable Images table - Image Prompt field should show variety:
+# - "Overhead angled view of a holographic war table..." (30-40%)
+# - "Front-facing view of a massive holographic wall display..." (30-40%)
+# - "Eye-level view of holographic objects floating..." (10-20%)
+# - "Wide angle view of multiple holographic display panels..." (5-10%)
+# - "Extreme close-up of a holographic display detail..." (5-10%)
+```
+
+---
+
+## Commit Message
+
+```
+Wire sequencer.py rotation into prompt generation — fix all-war-table repetition bug
+
+Root cause: pipeline.py was passing visual_style ("dossier"/"schema"/"echo")
+and composition ("wide"/"medium"/"closeup") to build_prompt(), but build_prompt()
+expects content_type ("geographic_map"/etc.) and display_format ("war_table"/etc.).
+Everything fell back to WAR_TABLE default.
+
+Fix: Use sequencer.assign_styles() to pre-generate proper ContentType +
+DisplayFormat + ColorMood assignments with rotation enforcement. Each image
+now gets a unique style combo respecting max consecutive constraints.
+
+Changes:
+- Import sequencer.assign_styles() in run_styled_image_prompts()
+- Pre-generate style assignments for estimated total images
+- Track global image_index counter across all scenes
+- Pass content_type, display_format, color_mood to build_prompt()
+- Update reporting to show display format distribution
+
+Tests: test_prompt_variety.py verifies 4 rotation rules are enforced.
+```
+
+---
+
+## What Was NOT Changed
+
+- ❌ build_prompt() internals (unchanged)
+- ❌ style_config.py constants (unchanged)
+- ❌ sequencer.py rotation logic (unchanged)
+- ❌ Legacy path in anthropic_client.py (deprecated, untouched)
+- ❌ Old visual_style/composition code (still exists, just not used)
+
+Clean-up can happen later - this fix is surgical and minimal.
+
+---
+
+## Rollback Instructions
+
+If this breaks something:
+
+```bash
+git diff HEAD pipeline.py  # Review changes
+git checkout HEAD -- pipeline.py  # Restore previous version
+```
+
+The old path still exists in run_image_prompt_bot_legacy() if needed.

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2013,6 +2013,7 @@ class VideoPipeline:
             Dict with prompt generation results.
         """
         from image_prompt_engine.prompt_builder import build_prompt
+        from image_prompt_engine.sequencer import assign_styles
         from brief_translator.scene_expander import expand_scene_concepts, expand_scene_concepts_deterministic
 
         if not self.current_idea:
@@ -2062,6 +2063,19 @@ class VideoPipeline:
             print(f"  Found existing records for scenes {sorted(existing_scenes)} — will skip")
 
         # ---------------------------------------------------------------
+        # Pre-generate style assignments for all images using sequencer
+        # ---------------------------------------------------------------
+        # Estimate total images: ~7 images per scene average (range 6-10)
+        estimated_total_images = total_scripts * 7
+        print(f"  Generating style assignments for ~{estimated_total_images} images...")
+
+        style_assignments = assign_styles(
+            total_images=estimated_total_images,
+            seed=hash(self.video_title) % (2**32),  # Deterministic seed per video
+        )
+        print(f"  ✓ Style rotation configured: {len(style_assignments)} assignments ready")
+
+        # ---------------------------------------------------------------
         # Expand each script record into visual concepts + styled prompts
         # ---------------------------------------------------------------
         # Apply scene filter if set
@@ -2075,6 +2089,7 @@ class VideoPipeline:
         scenes_expanded = 0
         scenes_skipped = 0
         style_counts = {"dossier": 0, "schema": 0, "echo": 0}
+        image_index = 0  # Global image index across all scenes for style sequencing
 
         for script in scripts:
             scene_num = script.get("scene", 0)
@@ -2143,36 +2158,57 @@ class VideoPipeline:
 
             for concept in concepts:
                 visual_desc = concept["visual_description"]
-                visual_style = concept.get("visual_style", "dossier")
-                composition = concept.get("composition", "medium")
 
-                # Build styled prompt immediately — no intermediate storage
-                prompt = build_prompt(visual_desc, visual_style, composition, accent_color,
-                                      image_style_override=image_style_override)
+                # Get style assignment from sequencer (with bounds check)
+                if image_index < len(style_assignments):
+                    style = style_assignments[image_index]
+                    content_type = style["content_type"]
+                    display_format = style["display_format"]
+                    color_mood = style["color_mood"]
+                else:
+                    # Fallback if we exceed estimate (shouldn't happen often)
+                    print(f"      ⚠️ Image index {image_index} exceeds assignments, using defaults")
+                    content_type = "geographic_map"
+                    display_format = "war_table"
+                    color_mood = "strategic"
+
+                # Build styled prompt using sequencer-assigned styles
+                prompt = build_prompt(
+                    scene_description=visual_desc,
+                    content_type=content_type,
+                    display_format=display_format,
+                    color_mood=color_mood,
+                    image_style_override=image_style_override,
+                )
 
                 self.airtable.create_concept_record(
                     scene_number=scene_num,
                     concept_index=concept["concept_index"],
                     sentence_text=concept["sentence_text"],
                     image_prompt=prompt,
-                    composition=composition,
+                    composition=display_format,  # Store display_format in composition field
                     video_title=self.video_title,
                 )
 
-                style_counts[visual_style] = style_counts.get(visual_style, 0) + 1
+                # Track style distribution for reporting
+                style_counts[display_format] = style_counts.get(display_format, 0) + 1
+                image_index += 1  # Increment global image counter
 
             total_concepts += len(concepts)
             scenes_expanded += 1
             print(f"    {len(concepts)} concepts + prompts written to Airtable")
 
         skip_note = f" ({scenes_skipped} resumed)" if scenes_skipped else ""
-        total_styled = sum(style_counts.values()) or 1
-        dossier_pct = style_counts["dossier"] / total_styled * 100
-        schema_pct = style_counts["schema"] / total_styled * 100
-        echo_pct = style_counts["echo"] / total_styled * 100
         print(f"\n  Done: {scenes_expanded} scenes expanded, "
               f"{total_concepts} concepts created{skip_note}")
-        print(f"  Style mix: Dossier {dossier_pct:.0f}% | Schema {schema_pct:.0f}% | Echo {echo_pct:.0f}%")
+
+        # Report display format distribution
+        if style_counts:
+            total_styled = sum(style_counts.values())
+            print(f"  Display format variety:")
+            for fmt, count in sorted(style_counts.items(), key=lambda x: -x[1]):
+                pct = count / total_styled * 100
+                print(f"    {fmt}: {count} ({pct:.0f}%)")
 
         # ---------------------------------------------------------------
         # Audio Sync: Whisper-aligned durations

--- a/skills/video-pipeline/test_prompt_variety.py
+++ b/skills/video-pipeline/test_prompt_variety.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Test script to verify image prompt variety after sequencer integration.
+
+Checks that prompts:
+1. Don't all start with "Overhead angled view of a holographic war table"
+2. Have at least 3 different display formats
+3. Have at least 3 different content types
+4. Respect rotation constraints (max 2 consecutive same format)
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from clients.airtable_client import AirtableClient
+
+
+async def test_prompt_variety(video_title: str):
+    """Test prompt variety for a specific video."""
+    client = AirtableClient()
+
+    print(f"\n{'='*70}")
+    print(f"IMAGE PROMPT VARIETY TEST: {video_title}")
+    print(f"{'='*70}\n")
+
+    # Get all image records for this video
+    images = client.get_all_images_for_video(video_title)
+
+    if not images:
+        print(f"❌ No image records found for '{video_title}'")
+        return False
+
+    print(f"Found {len(images)} image records\n")
+
+    # Extract prompts
+    prompts = []
+    for img in images:
+        prompt = img.get("Image Prompt", "")
+        if prompt:
+            prompts.append(prompt)
+
+    if not prompts:
+        print(f"❌ No prompts found in image records")
+        return False
+
+    print(f"Analyzing {len(prompts)} prompts...\n")
+
+    # Test 1: Check for variety in opening phrases
+    war_table_count = sum(1 for p in prompts if p.startswith("Overhead angled view of a holographic war table"))
+    wall_display_count = sum(1 for p in prompts if p.startswith("Front-facing view of a massive holographic wall display"))
+    floating_count = sum(1 for p in prompts if p.startswith("Eye-level view of holographic objects floating"))
+    multi_panel_count = sum(1 for p in prompts if p.startswith("Wide angle view of multiple holographic display panels"))
+    close_up_count = sum(1 for p in prompts if p.startswith("Extreme close-up of a holographic display detail"))
+
+    print("DISPLAY FORMAT DISTRIBUTION:")
+    print(f"  War Table: {war_table_count} ({war_table_count/len(prompts)*100:.0f}%)")
+    print(f"  Wall Display: {wall_display_count} ({wall_display_count/len(prompts)*100:.0f}%)")
+    print(f"  Floating: {floating_count} ({floating_count/len(prompts)*100:.0f}%)")
+    print(f"  Multi-Panel: {multi_panel_count} ({multi_panel_count/len(prompts)*100:.0f}%)")
+    print(f"  Close-Up: {close_up_count} ({close_up_count/len(prompts)*100:.0f}%)\n")
+
+    # Count unique display formats
+    unique_formats = sum(1 for count in [war_table_count, wall_display_count, floating_count, multi_panel_count, close_up_count] if count > 0)
+
+    # Test results
+    tests_passed = 0
+    tests_total = 4
+
+    # Test 1: Not all war table
+    if war_table_count < len(prompts):
+        print(f"✅ TEST 1 PASS: Not all prompts are war_table ({war_table_count}/{len(prompts)})")
+        tests_passed += 1
+    else:
+        print(f"❌ TEST 1 FAIL: All prompts are war_table (bug still present)")
+
+    # Test 2: At least 3 different formats
+    if unique_formats >= 3:
+        print(f"✅ TEST 2 PASS: At least 3 different display formats ({unique_formats})")
+        tests_passed += 1
+    else:
+        print(f"❌ TEST 2 FAIL: Only {unique_formats} display formats (need 3+)")
+
+    # Test 3: Check for consecutive repetition
+    # Extract format type from each prompt
+    format_sequence = []
+    for p in prompts:
+        if p.startswith("Overhead angled"):
+            format_sequence.append("war_table")
+        elif p.startswith("Front-facing"):
+            format_sequence.append("wall_display")
+        elif p.startswith("Eye-level"):
+            format_sequence.append("floating")
+        elif p.startswith("Wide angle"):
+            format_sequence.append("multi_panel")
+        elif p.startswith("Extreme close-up"):
+            format_sequence.append("close_up")
+        else:
+            format_sequence.append("unknown")
+
+    max_consecutive = 0
+    current_consecutive = 1
+    for i in range(1, len(format_sequence)):
+        if format_sequence[i] == format_sequence[i-1]:
+            current_consecutive += 1
+            max_consecutive = max(max_consecutive, current_consecutive)
+        else:
+            current_consecutive = 1
+
+    if max_consecutive <= 2:
+        print(f"✅ TEST 3 PASS: Max consecutive same format is {max_consecutive} (≤2)")
+        tests_passed += 1
+    else:
+        print(f"❌ TEST 3 FAIL: Max consecutive same format is {max_consecutive} (should be ≤2)")
+
+    # Test 4: Variety in content (check if different content types appear in prompts)
+    # Simple heuristic: check for content-specific keywords
+    content_keywords = {
+        "map": ["country", "border", "territory", "route", "coastline"],
+        "chart": ["chart", "candlestick", "ticker", "percentage", "graph"],
+        "object": ["wireframe", "comparison", "scale", "floating objects"],
+        "document": ["document", "treaty", "contract", "clause", "stamp"],
+        "network": ["nodes", "connections", "flow lines", "network"],
+        "timeline": ["timeline", "historical", "before/after", "era"],
+    }
+
+    content_type_hits = {k: 0 for k in content_keywords.keys()}
+    for prompt in prompts:
+        prompt_lower = prompt.lower()
+        for content_type, keywords in content_keywords.items():
+            if any(kw in prompt_lower for kw in keywords):
+                content_type_hits[content_type] += 1
+                break
+
+    unique_content_types = sum(1 for hits in content_type_hits.values() if hits > 0)
+
+    print(f"\nCONTENT TYPE VARIETY (detected via keywords):")
+    for content_type, hits in content_type_hits.items():
+        if hits > 0:
+            print(f"  {content_type}: {hits} prompts")
+
+    if unique_content_types >= 3:
+        print(f"\n✅ TEST 4 PASS: At least 3 different content types detected ({unique_content_types})")
+        tests_passed += 1
+    else:
+        print(f"\n❌ TEST 4 FAIL: Only {unique_content_types} content types detected (need 3+)")
+
+    # Final summary
+    print(f"\n{'='*70}")
+    print(f"RESULTS: {tests_passed}/{tests_total} tests passed")
+    print(f"{'='*70}\n")
+
+    if tests_passed == tests_total:
+        print("🎉 ALL TESTS PASSED - Prompt variety is working correctly!\n")
+        return True
+    else:
+        print("⚠️  SOME TESTS FAILED - Review the results above\n")
+        return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python test_prompt_variety.py <video_title>")
+        print("\nExample:")
+        print('  python test_prompt_variety.py "Why The Strait Of Hormuz Is More Valuable Than You Think"')
+        sys.exit(1)
+
+    video_title = sys.argv[1]
+    success = asyncio.run(test_prompt_variety(video_title))
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
… repetition bug

Root cause: pipeline.py was passing visual_style ("dossier"/"schema"/"echo") and composition ("wide"/"medium"/"closeup") to build_prompt(), but build_prompt() expects content_type ("geographic_map"/etc.) and display_format ("war_table"/etc.). Everything fell back to WAR_TABLE default, causing all prompts to start with "Overhead angled view of a holographic war table surface projecting".

Fix: Use sequencer.assign_styles() to pre-generate proper ContentType + DisplayFormat + ColorMood assignments with rotation enforcement. Each image now gets a unique style combo respecting max consecutive constraints.

Changes:
- Import sequencer.assign_styles() in run_styled_image_prompts()
- Pre-generate style assignments for estimated total images (~7 per scene)
- Track global image_index counter across all scenes
- Pass content_type, display_format, color_mood to build_prompt()
- Update reporting to show display format distribution instead of old dossier/schema/echo

Added:
- test_prompt_variety.py: Verifies 4 rotation rules are enforced
- SEQUENCER_INTEGRATION.md: Full documentation of fix and testing

Expected results:
- War Table: 30-40% (was 100%)
- Wall Display: 30-40% (was 0%)
- Floating: 10-20% (was 0%)
- Multi-Panel: 5-10% (was 0%)
- Close-Up: 5-10% (was 0%)