### PR TITLE
Fix sequencer rotation resetting at scene boundaries

### DIFF
--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2100,7 +2100,11 @@ class VideoPipeline:
                 continue
 
             if scene_num in existing_scenes:
+                # Scene already has images - count them and advance image_index
+                existing_image_count = sum(1 for img in existing_images if img.get("Scene") == scene_num)
+                image_index += existing_image_count
                 scenes_skipped += 1
+                print(f"  Scene {scene_num}: Skipped (has {existing_image_count} images), advanced index to {image_index}")
                 continue
 
             act_number = min(6, (scene_num - 1) * 6 // total_scripts + 1) if total_scripts > 0 else 1


### PR DESCRIPTION
BUG: Display format variety worked for first ~3 images per scene, then every scene reverted to "Overhead angled view of holographic war table." Rotation history was resetting at each scene boundary instead of persisting across the full video.

ROOT CAUSE: When scenes were skipped (because they already had images), image_index didn't advance to account for those existing images. This caused later scenes to restart from early style_assignments indices.

Example bug scenario:
- Scene 1: 7 images (existing, skipped) → image_index stays at 0
- Scene 2: starts → uses assignments[0], [1], [2]... (WRONG! should start at [7])
- Result: Every new scene after skipped scenes restarted rotation from war_table

FIX: When skipping scenes with existing images, count those images and advance image_index by that amount. This preserves rotation continuity across the entire video.

Added:
- Count existing images per skipped scene
- Advance image_index += existing_image_count before continue
- Debug print showing skip and index advancement

VERIFY: Display formats now rotate across ALL scenes with no resets. Max 2 consecutive same format enforced across entire video, not per-scene.