### PR TITLE
Fix 3 prompt assembly bugs: double prefix, raw scene type instructions, scene type mismatch

### DIFF
--- a/skills/video-pipeline/brief_translator/scene_expander.py
+++ b/skills/video-pipeline/brief_translator/scene_expander.py
@@ -771,10 +771,23 @@ async def expand_scene_concepts_deterministic(
         # Generate visual description via LLM — profile-driven prompt
         try:
             if not is_holographic and profile and profile.scene_description.system_prompt:
+                # Build scene type guidance so Claude writes content matching the type
+                scene_type_guidance = ""
+                if profile.style_system.substyles and visual_style in profile.style_system.substyles:
+                    substyle_info = profile.style_system.substyles[visual_style]
+                    scene_type_guidance = (
+                        f"\nSCENE TYPE: {substyle_info.name}\n"
+                        f"Description: {substyle_info.description}\n"
+                        f"Write a visual description that fits this scene type. "
+                    )
+
                 # Use the profile's scene description system prompt
                 visual_desc_prompt = (
                     f"{profile.scene_description.system_prompt}\n\n"
+                    f"{scene_type_guidance}\n"
                     "Write a 20-35 word visual description for this narration segment. "
+                    "Do NOT start with the style prefix (e.g. '3D rendered faceless mannequin...') — "
+                    "that will be added automatically. Just describe the scene content.\n"
                     "Return ONLY the description, nothing else.\n\n"
                     f"Narration: \"{seg['text']}\"\n"
                     f"Visual seeds for context: {visual_seeds[:200] if visual_seeds else 'none'}"

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -261,20 +261,25 @@ def build_prompt(
         suffix = profile.style_system.style_suffix if profile else HOLOGRAPHIC_SUFFIX
         return f"{framing} {clean_desc}, {mood_language}{suffix}"
     else:
-        # --- Profile path: prefix + content + substyle suffix + global suffix ---
+        # --- Profile path: prefix + content + global suffix ---
         prefix = profile.style_system.style_prefix if profile.style_system.style_prefix else ""
         global_suffix = profile.style_system.style_suffix if profile.style_system.style_suffix else ""
 
-        # Look up substyle-specific suffix (e.g. power_move, lone_figure)
-        substyle_suffix = ""
-        substyle = profile.style_system.substyles.get(display_format)
-        if substyle and substyle.suffix:
-            substyle_suffix = f", {substyle.suffix}"
+        # Strip prefix from description if Claude already included it
+        # (the system prompt instructs Claude to open with the style anchor)
+        if prefix and clean_desc.lower().startswith(prefix.lower()):
+            clean_desc = clean_desc[len(prefix):].strip().lstrip(",").strip()
+
+        # NOTE: substyle.suffix (e.g. "two or more mannequin figures in tension...")
+        # is intentionally NOT appended here. Those are scene type INSTRUCTIONS
+        # that guide Claude's prompt writing (via system prompt), not literal
+        # text for the image model. Scene type is classified BEFORE writing
+        # and passed to Claude as guidance in scene_expander.py.
 
         if image_style_override and image_style_override.strip():
             global_suffix = _apply_style_override(global_suffix, image_style_override)
 
-        return f"{prefix} {clean_desc}{substyle_suffix}{global_suffix}"
+        return f"{prefix} {clean_desc}{global_suffix}"
 
 
 def assign_profile_styles(

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2206,9 +2206,22 @@ class VideoPipeline:
                 for concept in needs_regen:
                     try:
                         if not _regen_is_holographic and _regen_profile and _regen_profile.scene_description.system_prompt:
+                            # Include scene type guidance if available
+                            _regen_type_guidance = ""
+                            _vs = concept.get("visual_style", "")
+                            if _regen_profile.style_system.substyles and _vs in _regen_profile.style_system.substyles:
+                                _sub = _regen_profile.style_system.substyles[_vs]
+                                _regen_type_guidance = (
+                                    f"\nSCENE TYPE: {_sub.name}\n"
+                                    f"Description: {_sub.description}\n"
+                                    f"Write a visual description that fits this scene type. "
+                                )
                             regen_prompt = (
                                 f"{_regen_profile.scene_description.system_prompt}\n\n"
+                                f"{_regen_type_guidance}\n"
                                 "Write a 20-35 word visual description for this narration segment. "
+                                "Do NOT start with the style prefix (e.g. '3D rendered faceless mannequin...') — "
+                                "that will be added automatically. Just describe the scene content.\n"
                                 "Return ONLY the description, nothing else.\n\n"
                                 f"Narration: \"{concept['sentence_text']}\""
                             )
@@ -2288,6 +2301,13 @@ class VideoPipeline:
                     color_mood=color_mood,
                     image_style_override=image_style_override,
                 )
+
+                # Diagnostic: print first 3 assembled prompts for format verification
+                if image_index < 3:
+                    print(f"\n  📋 PROMPT DIAGNOSTIC [{image_index + 1}/3] "
+                          f"(scene {scene_num}, type={display_format}):")
+                    print(f"     {prompt}")
+                    print()
 
                 self.airtable.create_concept_record(
                     scene_number=scene_num,


### PR DESCRIPTION
1. DOUBLE PREFIX: build_prompt() now strips the style prefix from Claude's
   output before prepending it, preventing "3D rendered faceless mannequin..."
   from appearing twice.

2. RAW SCENE TYPE INSTRUCTIONS: Removed substyle.suffix from final prompt
   assembly. Scene type descriptions like "two or more mannequin figures in
   tension..." are writing guidelines for Claude, not literal image prompt
   text.

3. SCENE TYPE MISMATCH: Scene type is now classified BEFORE writing the
   visual description. expand_scene_concepts_deterministic() and the regen
   prompt in pipeline.py now pass scene type name + description to Claude
   as guidance, so prompt content matches the assigned type.

Also tells Claude NOT to include the style prefix in visual descriptions
(it's added automatically by build_prompt), and adds a diagnostic that
prints the first 3 assembled prompts for format verification.

Final format: [prefix] + [Claude scene description] + [suffix]
No raw instructions. No double prefix. No contradictions.

302 tests passing (145 + 131 + 26).

https://claude.ai/code/session_01JmKGgWVYi4rgbi9ThD9YEm