### PR TITLE
Fix prompts command to only run prompts, not images

### DIFF
--- a/skills/video-pipeline/pipeline_control.py
+++ b/skills/video-pipeline/pipeline_control.py
@@ -790,7 +790,7 @@ async def handle_video_generate(message, say):
 @app.message(re.compile(r"run prompts", re.IGNORECASE))
 @app.message(re.compile(r"^prompts(?:\s+[\d,]+)?$", re.IGNORECASE))
 async def handle_prompts(message, say):
-    """Run prompts and start images generation."""
+    """Run image prompt generation only (no image generation)."""
     global current_process
     if current_process:
         await say(f":x: Already running `{current_task_name}`. Use `stop` to cancel it first.")
@@ -798,7 +798,7 @@ async def handle_prompts(message, say):
 
     scene, image = _parse_target(message.get("text", ""), "prompts")
     target_msg = _format_target_msg(scene, image)
-    await say(f":art: Starting prompts and images generation{target_msg}...")
+    await say(f":art: Starting prompt generation{target_msg}...")
 
     try:
         returncode, stdout, stderr = await run_script_async(

--- a/skills/video-pipeline/run_youtube_prompts.py
+++ b/skills/video-pipeline/run_youtube_prompts.py
@@ -1,9 +1,12 @@
 """
-Generate image prompts and images for the YouTube pipeline.
+Generate image prompts for the YouTube pipeline.
 
 Called by: pipeline_control.py (Slack bot)
 Commands: prompts (when used in YouTube pipeline context)
-Supports: --scene N to only generate prompts/images for a specific scene
+Supports: --scene N to only generate prompts for a specific scene
+
+NOTE: This only generates prompts. Use `images` command (run_image_bot.py)
+to generate actual images, or `run` to advance through pipeline steps.
 """
 
 import os
@@ -26,7 +29,7 @@ async def main():
     args = parser.parse_args()
 
     print("=" * 60)
-    print("🎨 RUNNING YOUTUBE PROMPTS & IMAGES")
+    print("🎨 RUNNING YOUTUBE PROMPTS")
     print("=" * 60)
 
     pipeline = VideoPipeline()
@@ -34,17 +37,12 @@ async def main():
     pipeline.image_filter = args.image
 
     try:
-        # First generate image prompts (styled) — resumable: skips scenes with existing prompts
+        # Generate image prompts (styled) — resumable: skips scenes with existing prompts
         prompt_result = await pipeline.run_styled_image_prompts()
 
         if prompt_result.get("error"):
-            # If prompts already completed (idea at "Ready For Images"), skip to image generation
-            if "No idea" in prompt_result["error"]:
-                print(f"\n♻️ Prompts already done — resuming with image generation...")
-                prompt_result = {"prompt_count": 0, "skipped": "all"}
-            else:
-                print(f"\n❌ Prompt generation error: {prompt_result['error']}", file=sys.stderr)
-                sys.exit(1)
+            print(f"\n❌ Prompt generation error: {prompt_result['error']}", file=sys.stderr)
+            sys.exit(1)
 
         skipped = prompt_result.get('scenes_skipped', 0)
         created = prompt_result.get('total_concepts', 0)
@@ -53,23 +51,15 @@ async def main():
         else:
             print(f"\n📝 Image prompts created: {created}")
 
-        # Then generate actual images — resumable: skips images with Status="Done"
-        image_result = await pipeline.run_image_bot()
-
-        if image_result.get("error"):
-            print(f"\n⚠️ Image generation error: {image_result['error']}")
-            # Don't exit — prompts were still created successfully
-
         print("\n" + "=" * 60)
-        print("✅ YOUTUBE PROMPTS & IMAGES COMPLETE!")
+        print("✅ YOUTUBE PROMPTS COMPLETE!")
         print("=" * 60)
-        print(f"\n🎬 Video: {prompt_result.get('video_title', image_result.get('video_title'))}")
+        print(f"\n🎬 Video: {prompt_result.get('video_title', 'N/A')}")
         print(f"📝 Prompts created: {created}")
-        print(f"🖼️  Images generated: {image_result.get('image_count', 0)}")
-        if prompt_result.get("targeted") or image_result.get("targeted"):
+        if prompt_result.get("targeted"):
             print("🎯 Targeted run — status not advanced")
         else:
-            print(f"📋 New status: {image_result.get('new_status', prompt_result.get('new_status'))}")
+            print(f"📋 New status: {prompt_result.get('new_status', 'N/A')}")
 
     except Exception as e:
         print(f"\n❌ Error: {e}")


### PR DESCRIPTION
The prompts command was calling both run_styled_image_prompts() and
run_image_bot() in sequence, double-stacking steps. Each command should
run its own step only — the run command handles multi-step advancement.

https://claude.ai/code/session_01TSNiW3FW59ysWcXCsahhHz