### PR TITLE
Add Story Bible for visual consistency + content-driven prefix detection

### DIFF
--- a/docs/airtable-schema.md
+++ b/docs/airtable-schema.md
@@ -18,6 +18,9 @@ Style override fields (set via Slack `!style` commands):
 - `Image Model Override` (Multiple Select) — hot-swap scene image model. Options: `z-image`, `Nano Banana`. Set via Slack `!model` command.
 - `Visual Style` (Single Select) — visual profile override. Options: `mannequin_storytelling`, `holographic_hud`, `cinematic_dossier`, `clay_mannequin`. Default: `mannequin_storytelling`. Set via Slack `!visualstyle` command.
 
+Visual consistency fields (auto-generated):
+- `Story Bible` (Long Text) — JSON containing character bible, location bible, visual arc, and recurring props for consistent visuals across the video. Generated automatically before image prompts when using mannequin profiles. Structure: `{"characters": [...], "locations": [...], "visual_arc": [...], "recurring_props": [...]}`
+
 Optional fields:
 - `Reference URL`, `Idea Reasoning`, `Source Views`, `Source Channel`
 - `Google Drive Folder ID`, `Thumbnail`, `Pipeline Mode`, `Notes`

--- a/skills/video-pipeline/bots/story_bible.py
+++ b/skills/video-pipeline/bots/story_bible.py
@@ -1,0 +1,294 @@
+"""Story Bible Generation.
+
+Generates character and location bibles for visual consistency across
+an entire video. Run ONCE before generating any image prompts.
+
+The Story Bible provides:
+1. Character Bible: Recurring characters with EXACT clothing/appearance
+2. Location Bible: Recurring locations with EXACT environment details
+3. Visual Arc: Mood and color progression per scene
+
+Claude receives the Story Bible context when writing each visual
+description, ensuring the same character appears identically across
+all their scenes, and locations maintain visual continuity.
+"""
+
+import json
+from typing import Optional
+
+
+# System prompt for generating the Story Bible
+STORY_BIBLE_SYSTEM_PROMPT = """You are a visual story bible creator for a documentary video production.
+
+Your job is to analyze the FULL script and identify recurring visual elements that need to stay consistent across the entire video.
+
+The goal: If the same character appears in scenes 2, 5, and 12, they must wear IDENTICAL clothing and be described EXACTLY the same way in all three scenes. If the same location appears in scenes 3 and 10, it must look EXACTLY the same.
+
+You are creating a reference document that the image prompt writer will consult for EVERY image. When they write a prompt featuring "the Russian leader", they will copy the EXACT description from your character bible.
+
+Be SPECIFIC. Don't write "formal suit" — write "dark charcoal three-button suit with white shirt, dark navy tie, gold watch on left wrist." The image model needs consistent details."""
+
+
+STORY_BIBLE_USER_PROMPT = """Read this entire video script and produce a visual story bible.
+
+FULL SCRIPT:
+{full_script_text}
+
+Produce a JSON response with these sections:
+
+1. "characters": A list of recurring characters/roles. For each:
+   - "id": short snake_case identifier (e.g., "russian_leader", "eu_official", "iranian_general")
+   - "description": EXACT clothing and appearance description to use in EVERY image. Must include:
+     * Specific clothing items with colors (e.g., "dark charcoal suit with white shirt and dark navy tie")
+     * Body position defaults (e.g., "standing with hands behind back" or "seated at desk")
+     * Any distinguishing props (e.g., "gold pen in breast pocket", "military medals on chest")
+   - "scenes_present": list of scene numbers where they appear
+   - "role": protagonist, antagonist, supporting, background
+
+2. "locations": A list of locations. For each:
+   - "id": short snake_case identifier (e.g., "kremlin_office", "tehran_facility", "trading_floor")
+   - "description": EXACT environment description to reuse. Must include:
+     * Architectural details (e.g., "wood-paneled walls with tall bookshelves")
+     * Key objects (e.g., "heavy mahogany desk with brass desk lamp")
+     * Ambient elements (e.g., "large window showing Moscow skyline at dusk")
+   - "scenes_present": list of scene numbers set in this location
+   - "lighting": default lighting mood (e.g., "warm amber single-source from window")
+
+3. "visual_arc": A list defining the emotional progression. For EACH scene number:
+   - "scene": scene number (1, 2, 3, etc.)
+   - "mood": emotional tone (tense, revelatory, escalating, calm, crisis, triumphant, ominous)
+   - "color_temperature": warm/cold/neutral
+   - "intensity": 1-10 (how dramatic/urgent the visuals should feel)
+
+4. "recurring_props": Objects that appear in multiple scenes:
+   - "id": short identifier (e.g., "treaty_document", "satellite_phone", "oil_chart")
+   - "description": EXACT visual description
+   - "scenes_present": list of scene numbers
+
+CRITICAL RULES:
+- Every character that appears MORE THAN ONCE needs an entry
+- Every location that appears MORE THAN ONCE needs an entry
+- Character descriptions MUST include specific clothing — no naked mannequins!
+- If a character's role isn't explicitly stated, infer from context
+- Default clothing if unknown: "dark formal suit with white shirt"
+
+Respond ONLY with valid JSON. No markdown fences, no explanation."""
+
+
+async def generate_story_bible(
+    anthropic_client,
+    full_script_text: str,
+    video_title: str = "",
+) -> dict:
+    """Generate a complete Story Bible from the full script.
+
+    This should be called ONCE per video, BEFORE any image prompts
+    are generated. The resulting bible is stored in Airtable and
+    passed to Claude for every subsequent visual description.
+
+    Args:
+        anthropic_client: AnthropicClient instance with generate() method
+        full_script_text: Combined text of ALL scenes in the video
+        video_title: Video title for logging/context
+
+    Returns:
+        Dict with keys: characters, locations, visual_arc, recurring_props
+        Returns empty dict if generation fails.
+    """
+    if not full_script_text or len(full_script_text.strip()) < 100:
+        print(f"  ⚠️ Script too short for story bible: {len(full_script_text)} chars")
+        return {}
+
+    prompt = STORY_BIBLE_USER_PROMPT.format(full_script_text=full_script_text)
+
+    try:
+        response = await anthropic_client.generate(
+            prompt=prompt,
+            system_prompt=STORY_BIBLE_SYSTEM_PROMPT,
+            model="claude-sonnet-4-5-20250929",
+            max_tokens=8000,
+            temperature=0.3,  # Low temperature for consistency
+        )
+
+        # Parse JSON response
+        bible = _parse_json_response(response)
+
+        if not bible:
+            print(f"  ⚠️ Failed to parse story bible JSON")
+            return {}
+
+        # Validate required sections
+        if "characters" not in bible:
+            bible["characters"] = []
+        if "locations" not in bible:
+            bible["locations"] = []
+        if "visual_arc" not in bible:
+            bible["visual_arc"] = []
+        if "recurring_props" not in bible:
+            bible["recurring_props"] = []
+
+        # Log summary
+        print(f"  📖 Story Bible generated:")
+        print(f"      {len(bible['characters'])} characters")
+        print(f"      {len(bible['locations'])} locations")
+        print(f"      {len(bible['visual_arc'])} scene arcs")
+        print(f"      {len(bible['recurring_props'])} recurring props")
+
+        return bible
+
+    except Exception as e:
+        print(f"  ⚠️ Story bible generation failed: {e}")
+        return {}
+
+
+def _parse_json_response(response_text: str) -> dict:
+    """Extract JSON from LLM response with fallback parsing."""
+    import re
+
+    # Try direct parse first
+    try:
+        return json.loads(response_text)
+    except json.JSONDecodeError:
+        pass
+
+    # Try extracting from markdown code block
+    json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", response_text, re.DOTALL)
+    if json_match:
+        try:
+            return json.loads(json_match.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Try finding raw JSON braces
+    brace_start = response_text.find("{")
+    brace_end = response_text.rfind("}")
+    if brace_start != -1 and brace_end != -1:
+        try:
+            return json.loads(response_text[brace_start:brace_end + 1])
+        except json.JSONDecodeError:
+            pass
+
+    return {}
+
+
+def format_bible_for_prompt(story_bible: dict, current_scene: int) -> str:
+    """Format the Story Bible as context for Claude's image prompt generation.
+
+    Produces a condensed text block that Claude can reference when
+    writing visual descriptions for a specific scene.
+
+    Args:
+        story_bible: The full Story Bible dict
+        current_scene: The scene number being generated (1-indexed)
+
+    Returns:
+        Formatted string to include in Claude's prompt context
+    """
+    if not story_bible:
+        return ""
+
+    lines = []
+
+    # Character Bible section
+    chars = story_bible.get("characters", [])
+    if chars:
+        lines.append("=== CHARACTER BIBLE (use EXACT descriptions) ===")
+        for char in chars:
+            char_id = char.get("id", "unknown")
+            desc = char.get("description", "")
+            scenes = char.get("scenes_present", [])
+            if current_scene in scenes or not scenes:
+                lines.append(f"\n{char_id.upper()}:")
+                lines.append(f"  {desc}")
+                lines.append(f"  [Appears in scenes: {', '.join(map(str, scenes))}]")
+
+    # Location Bible section
+    locs = story_bible.get("locations", [])
+    if locs:
+        lines.append("\n=== LOCATION BIBLE (use EXACT descriptions) ===")
+        for loc in locs:
+            loc_id = loc.get("id", "unknown")
+            desc = loc.get("description", "")
+            lighting = loc.get("lighting", "")
+            scenes = loc.get("scenes_present", [])
+            if current_scene in scenes or not scenes:
+                lines.append(f"\n{loc_id.upper()}:")
+                lines.append(f"  {desc}")
+                if lighting:
+                    lines.append(f"  Lighting: {lighting}")
+                lines.append(f"  [Appears in scenes: {', '.join(map(str, scenes))}]")
+
+    # Visual arc for current scene
+    arcs = story_bible.get("visual_arc", [])
+    current_arc = next((a for a in arcs if a.get("scene") == current_scene), None)
+    if current_arc:
+        lines.append(f"\n=== SCENE {current_scene} VISUAL ARC ===")
+        lines.append(f"  Mood: {current_arc.get('mood', 'neutral')}")
+        lines.append(f"  Color temperature: {current_arc.get('color_temperature', 'neutral')}")
+        lines.append(f"  Intensity: {current_arc.get('intensity', 5)}/10")
+
+    # Recurring props
+    props = story_bible.get("recurring_props", [])
+    if props:
+        lines.append("\n=== RECURRING PROPS ===")
+        for prop in props:
+            prop_id = prop.get("id", "unknown")
+            desc = prop.get("description", "")
+            scenes = prop.get("scenes_present", [])
+            if current_scene in scenes or not scenes:
+                lines.append(f"  {prop_id}: {desc}")
+
+    if not lines:
+        return ""
+
+    return "\n".join(lines)
+
+
+def get_character_description(story_bible: dict, character_hint: str) -> Optional[str]:
+    """Look up a character's exact description from the bible.
+
+    Args:
+        story_bible: The full Story Bible dict
+        character_hint: A term that might identify the character
+            (e.g., "Russian", "leader", "russian_leader")
+
+    Returns:
+        The exact character description if found, None otherwise
+    """
+    if not story_bible:
+        return None
+
+    chars = story_bible.get("characters", [])
+    hint_lower = character_hint.lower().replace(" ", "_")
+
+    for char in chars:
+        char_id = char.get("id", "").lower()
+        if hint_lower in char_id or char_id in hint_lower:
+            return char.get("description")
+
+    return None
+
+
+def get_location_description(story_bible: dict, location_hint: str) -> Optional[str]:
+    """Look up a location's exact description from the bible.
+
+    Args:
+        story_bible: The full Story Bible dict
+        location_hint: A term that might identify the location
+            (e.g., "Kremlin", "office", "kremlin_office")
+
+    Returns:
+        The exact location description if found, None otherwise
+    """
+    if not story_bible:
+        return None
+
+    locs = story_bible.get("locations", [])
+    hint_lower = location_hint.lower().replace(" ", "_")
+
+    for loc in locs:
+        loc_id = loc.get("id", "").lower()
+        if hint_lower in loc_id or loc_id in hint_lower:
+            return loc.get("description")
+
+    return None

--- a/skills/video-pipeline/brief_translator/__init__.py
+++ b/skills/video-pipeline/brief_translator/__init__.py
@@ -16,6 +16,8 @@ Pipeline:
 Scene expansion is a SEPARATE pipeline stage triggered by a different status.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Optional
 

--- a/skills/video-pipeline/brief_translator/scene_expander.py
+++ b/skills/video-pipeline/brief_translator/scene_expander.py
@@ -9,10 +9,13 @@ one big script and re-split them via LLM. The new system processes one
 scene at a time — if one fails, only that scene retries.
 """
 
+from __future__ import annotations
+
 import json
 import re
 from difflib import SequenceMatcher
 from pathlib import Path
+from typing import Optional
 
 PROMPT_TEMPLATE_PATH = Path(__file__).parent / "prompts" / "concept_expand.txt"
 
@@ -679,7 +682,8 @@ async def expand_scene_concepts_deterministic(
     accent_color: str,
     act_number: int,
     total_scenes: int = 14,
-    voice_duration: float | None = None,
+    voice_duration: Optional[float] = None,
+    story_bible: Optional[dict] = None,
 ) -> list[dict]:
     """Expand one scene's narration into visual concepts using deterministic word-duration-aware splitting.
 
@@ -692,6 +696,10 @@ async def expand_scene_concepts_deterministic(
     Still uses LLM for generating visual_description per segment, but the text
     splitting is deterministic and duration-guaranteed.
 
+    Claude writes whatever prompt best tells the story moment. NO scene type
+    constraints are applied — Claude reads the narration, consults the Story
+    Bible for character/location consistency, and writes the best visual.
+
     Args:
         anthropic_client: AnthropicClient instance with generate() method
         scene_number: Scene number from the Script table
@@ -701,13 +709,14 @@ async def expand_scene_concepts_deterministic(
         act_number: Which act this scene belongs to (1-6)
         total_scenes: Total number of scenes in the video
         voice_duration: Optional actual voice duration in seconds (for accurate WPS)
+        story_bible: Optional Story Bible dict with characters, locations, visual_arc
 
     Returns:
         List of concept dicts, each with:
         - concept_index (int, 1-based)
         - sentence_text (str, exact substring of scene_text)
         - visual_description (str, 20-35 word filmable description)
-        - visual_style (str, profile substyle name)
+        - visual_style (str, profile substyle name - DESCRIPTIVE, not prescriptive)
         - composition (str, wide/medium/closeup/etc.)
         - mood (str)
     """
@@ -717,6 +726,12 @@ async def expand_scene_concepts_deterministic(
     # Import deterministic splitter
     sys.path.insert(0, str(Path(__file__).parent.parent / "clients"))
     from deterministic_splitter import segment_scene_deterministic
+
+    # Import Story Bible formatter
+    try:
+        from bots.story_bible import format_bible_for_prompt
+    except ImportError:
+        def format_bible_for_prompt(bible, scene): return ""
 
     # Step 1: Use deterministic splitter to get text segments with guaranteed durations
     segments = segment_scene_deterministic(scene_text, voice_duration)
@@ -732,68 +747,60 @@ async def expand_scene_concepts_deterministic(
             "mood": "neutral",
         }]
 
-    # Step 2: Assign visual styles based on profile or legacy act distribution
+    # Step 2: Get profile for styling decisions
     profile = _get_profile()
     is_holographic = profile is None or profile.profile_id == "holographic_hud"
 
-    if not is_holographic and profile and not profile.style_system.substyles:
-        # Single-style profiles (e.g. clay_mannequin): all concepts use the same style
-        styles_pool = [profile.profile_id] * max(len(segments), 10)
-    else:
-        # Holographic or multi-substyle profiles: use profile act distribution
-        style_dist = get_style_distribution()
-        dist = style_dist.get(act_number, style_dist.get(1, {"dossier": 100}))
-
-        styles_pool = []
-        for style_name, pct in dist.items():
-            if pct > 0:
-                styles_pool.extend([style_name] * pct)
-
-    # Assign styles in rotation
-    import random
-    random.seed(scene_number)  # Deterministic based on scene number
-    random.shuffle(styles_pool)
-
-    # Step 3: Assign compositions using affinity mapping
+    # For non-holographic profiles, we still assign styles for tracking/analytics
+    # but they are DESCRIPTIVE (post-hoc classification), not PRESCRIPTIVE
     default_fallback_style = get_default_style()
     recent_comps: list[str] = []
+
+    # Step 3: Format Story Bible context for this scene
+    bible_context = ""
+    if story_bible:
+        bible_context = format_bible_for_prompt(story_bible, scene_number)
 
     # Step 4: Generate visual_description for each segment using LLM
     concepts = []
 
     for i, seg in enumerate(segments):
-        style_idx = i % len(styles_pool) if styles_pool else 0
-
-        visual_style = styles_pool[style_idx] if styles_pool else default_fallback_style
-        composition = _pick_composition(visual_style, i, recent_comps)
+        composition = _pick_composition(default_fallback_style, i, recent_comps)
         recent_comps.append(composition)
 
-        # Generate visual description via LLM — profile-driven prompt
+        # Generate visual description via LLM — NO SCENE TYPE CONSTRAINTS
         try:
             if not is_holographic and profile and profile.scene_description.system_prompt:
-                # Build scene type guidance so Claude writes content matching the type
-                scene_type_guidance = ""
-                if profile.style_system.substyles and visual_style in profile.style_system.substyles:
-                    substyle_info = profile.style_system.substyles[visual_style]
-                    scene_type_guidance = (
-                        f"\nSCENE TYPE: {substyle_info.name}\n"
-                        f"Description: {substyle_info.description}\n"
-                        f"Write a visual description that fits this scene type. "
-                    )
-
-                # Use the profile's scene description system prompt
+                # Build prompt with Story Bible context but NO scene type constraints
+                # Claude decides what to write based on narration content
                 visual_desc_prompt = (
                     f"{profile.scene_description.system_prompt}\n\n"
-                    f"{scene_type_guidance}\n"
+                )
+
+                # Add Story Bible context if available
+                if bible_context:
+                    visual_desc_prompt += (
+                        f"{bible_context}\n\n"
+                        "CRITICAL: If any character or location from the bible appears in this "
+                        "narration, use their EXACT description from the bible above. "
+                        "Same character = identical clothing. Same location = identical details.\n\n"
+                    )
+
+                # Add clothing requirement for characters
+                visual_desc_prompt += (
+                    "CLOTHING RULE: Every mannequin figure MUST have specific clothing described. "
+                    "Never describe a mannequin without clothing. If unsure, use 'wearing dark formal suit with white shirt.'\n\n"
                     "Write a 20-35 word visual description for this narration segment. "
+                    "You decide whether this moment needs characters, environment, data, or objects — "
+                    "write whatever best tells THIS story moment.\n\n"
                     "Do NOT start with the style prefix (e.g. '3D rendered faceless mannequin...') — "
-                    "that will be added automatically. Just describe the scene content.\n"
+                    "that will be added automatically based on what you write.\n"
                     "Return ONLY the description, nothing else.\n\n"
                     f"Narration: \"{seg['text']}\"\n"
                     f"Visual seeds for context: {visual_seeds[:200] if visual_seeds else 'none'}"
                 )
             else:
-                # Holographic default prompt
+                # Holographic default prompt (unchanged)
                 visual_desc_prompt = (
                     "You are creating visual descriptions for HOLOGRAPHIC DATA DISPLAYS "
                     "in an intelligence operations center — not camera shots of real events.\n\n"
@@ -831,11 +838,13 @@ async def expand_scene_concepts_deterministic(
             # Fallback: use the narration text as placeholder
             visual_description = seg['text']
 
+        # Scene type is now DESCRIPTIVE — assigned based on what Claude wrote
+        # (detected by prompt_builder.py when assembling final prompt)
         concepts.append({
             "concept_index": i + 1,
             "sentence_text": seg['text'],
             "visual_description": visual_description,
-            "visual_style": visual_style,
+            "visual_style": default_fallback_style,  # Default; actual type detected later
             "composition": composition,
             "mood": "tension",  # Default mood, could be enhanced later
         })

--- a/skills/video-pipeline/clients/anthropic_client.py
+++ b/skills/video-pipeline/clients/anthropic_client.py
@@ -1,5 +1,7 @@
 """Anthropic Claude API client for script and prompt generation."""
 
+from __future__ import annotations
+
 import os
 import re
 from anthropic import Anthropic

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -184,6 +184,112 @@ def resolve_scene_color_mood(
     return video_color_mood
 
 
+"""Content-driven prefix detection.
+
+Simplified approach: Claude writes whatever prompt best tells the story moment.
+The system detects whether characters are present by looking for character
+indicator words in the visual description, then:
+
+1. If characters ARE present: prepend mannequin prefix
+2. If characters are NOT present: no prefix (description stands alone)
+3. Universal suffix for ALL scenes
+
+Scene type labels become DESCRIPTIVE (assigned after prompt is written
+based on content) not PRESCRIPTIVE (assigned before, constraining output).
+"""
+
+# Universal prefix for scenes WITH mannequin characters
+_MANNEQUIN_PREFIX = "3D rendered faceless mannequin with smooth white oval head"
+
+# Universal suffix for ALL scenes (mannequin profiles)
+_UNIVERSAL_SUFFIX = ", Cinematic 3D documentary style, no facial features on any figures."
+
+# Words that indicate character presence in the visual description
+# If ANY of these appear, the scene has characters and needs mannequin prefix
+_CHARACTER_INDICATOR_WORDS = [
+    # Direct mannequin references
+    "mannequin", "mannequins", "figure", "figures",
+    # Clothing (implies character wearing it)
+    "wearing", "suit", "suits", "uniform", "uniforms", "robes", "robe",
+    "jacket", "coat", "dress", "shirt", "tie", "turban", "keffiyeh",
+    "thobe", "vest", "costume", "clothes", "clothing", "attire",
+    # Postures (implies character doing action)
+    "standing", "sitting", "seated", "leaning", "kneeling", "crouching",
+    "walking", "running", "pointing", "holding", "reaching", "gesturing",
+    "turning", "facing", "looking", "watching", "signing", "reading",
+    "writing", "typing", "slamming", "pushing", "pulling",
+    # Body parts (implies character presence)
+    "hands", "hand", "gloved", "arm", "arms", "shoulder", "shoulders",
+    "head", "heads", "posture", "stance", "silhouette",
+    # Role/position words (implies character)
+    "leader", "official", "general", "diplomat", "officer", "banker",
+    "trader", "analyst", "soldier", "guard", "agent", "citizen",
+]
+
+# Compile patterns for efficient matching
+import re as _re
+_CHARACTER_PATTERNS = [
+    _re.compile(rf"\b{_re.escape(w)}\b", _re.IGNORECASE)
+    for w in _CHARACTER_INDICATOR_WORDS
+]
+
+
+def _has_character_indicators(description: str) -> bool:
+    """Check if a visual description contains character indicators.
+
+    Returns True if ANY character indicator word is found, meaning
+    the scene has mannequin characters and needs the mannequin prefix.
+    """
+    for pattern in _CHARACTER_PATTERNS:
+        if pattern.search(description):
+            return True
+    return False
+
+
+def _detect_scene_type(description: str) -> str:
+    """Detect scene type from content for analytics/tracking.
+
+    This is DESCRIPTIVE - assigned based on what's in the prompt,
+    not prescriptive.
+
+    Returns one of: power_move, lone_figure, environment, data_hud, object_closeup
+    """
+    desc_lower = description.lower()
+
+    # Check for data/HUD indicators
+    data_words = ["holographic", "chart", "graph", "data", "display", "terminal",
+                  "ticker", "percentage", "statistics", "map overlay", "network"]
+    if any(w in desc_lower for w in data_words) and not _has_character_indicators(description):
+        return "data_hud"
+
+    # Check for object close-up indicators
+    object_words = ["close-up", "closeup", "close up", "document", "treaty",
+                    "weapon", "currency", "stamp", "seal", "key", "phone",
+                    "folder", "photograph", "object"]
+    if any(w in desc_lower for w in object_words) and not _has_character_indicators(description):
+        return "object_closeup"
+
+    # Check for environment indicators
+    env_words = ["wide shot", "establishing", "cityscape", "landscape", "skyline",
+                 "port", "harbor", "street", "building", "architecture", "aerial",
+                 "no people", "empty", "deserted"]
+    if any(w in desc_lower for w in env_words) and not _has_character_indicators(description):
+        return "environment"
+
+    # Character scenes
+    has_chars = _has_character_indicators(description)
+    if has_chars:
+        # Count character indicators to distinguish lone_figure vs power_move
+        multi_char_words = ["figures", "mannequins", "two", "three", "four",
+                           "group", "both", "each other", "confrontation"]
+        if any(w in desc_lower for w in multi_char_words):
+            return "power_move"
+        return "lone_figure"
+
+    # Default: treat as environment if no characters detected
+    return "environment"
+
+
 def build_prompt(
     scene_description: str,
     content_type: str,
@@ -193,26 +299,36 @@ def build_prompt(
 ) -> str:
     """Assemble a complete image generation prompt.
 
-    When a visual profile is active, reads framing, suffix, and figure rules
-    from the profile. Falls back to holographic defaults when no profile is
-    loaded or the profile is ``holographic_hud``.
+    When a visual profile is active, uses content-driven prefix detection:
+    - If characters are present in description: prepend mannequin prefix
+    - If no characters: no prefix (description stands alone)
+    - Universal suffix for all scenes
+
+    Falls back to holographic defaults when no profile is loaded or
+    the profile is ``holographic_hud``.
 
     Template (holographic)::
 
         [DISPLAY FORMAT framing] [DISPLAY CONTENT] [COLOR MOOD] [UNIVERSAL SUFFIX]
 
-    Template (other profiles)::
+    Template (mannequin profiles with characters)::
 
-        [STYLE PREFIX] [DISPLAY CONTENT] [STYLE SUFFIX]
+        [MANNEQUIN PREFIX] [DISPLAY CONTENT] [UNIVERSAL SUFFIX]
+
+    Template (mannequin profiles without characters)::
+
+        [DISPLAY CONTENT] [UNIVERSAL SUFFIX]
 
     Parameters
     ----------
     scene_description : str
-        What the image depicts — the analytical content description.
+        What the image depicts — the visual content description from Claude.
     content_type : str
         Value from ContentType enum (e.g. ``"geographic_map"``).
+        For profile-based systems, may be scene type (now DESCRIPTIVE).
     display_format : str
         Value from DisplayFormat enum (e.g. ``"war_table"``).
+        For profile-based systems, same as content_type.
     color_mood : str
         Value from ColorMood enum (e.g. ``"strategic"``).
     image_style_override : str, optional
@@ -261,25 +377,44 @@ def build_prompt(
         suffix = profile.style_system.style_suffix if profile else HOLOGRAPHIC_SUFFIX
         return f"{framing} {clean_desc}, {mood_language}{suffix}"
     else:
-        # --- Profile path: prefix + content + global suffix ---
-        prefix = profile.style_system.style_prefix if profile.style_system.style_prefix else ""
-        global_suffix = profile.style_system.style_suffix if profile.style_system.style_suffix else ""
+        # --- Profile path: CONTENT-DRIVEN prefix detection ---
 
-        # Strip prefix from description if Claude already included it
-        # (the system prompt instructs Claude to open with the style anchor)
-        if prefix and clean_desc.lower().startswith(prefix.lower()):
-            clean_desc = clean_desc[len(prefix):].strip().lstrip(",").strip()
+        # Check if profile has mannequin-style prefix
+        default_prefix = profile.style_system.style_prefix if profile.style_system.style_prefix else ""
+        is_mannequin_profile = "mannequin" in default_prefix.lower()
 
-        # NOTE: substyle.suffix (e.g. "two or more mannequin figures in tension...")
-        # is intentionally NOT appended here. Those are scene type INSTRUCTIONS
-        # that guide Claude's prompt writing (via system prompt), not literal
-        # text for the image model. Scene type is classified BEFORE writing
-        # and passed to Claude as guidance in scene_expander.py.
+        # Strip any existing prefix from description if Claude already included it
+        if default_prefix and clean_desc.lower().startswith(default_prefix.lower()):
+            clean_desc = clean_desc[len(default_prefix):].strip().lstrip(",").strip()
+        # Also strip our standard mannequin prefix
+        if clean_desc.lower().startswith(_MANNEQUIN_PREFIX.lower()):
+            clean_desc = clean_desc[len(_MANNEQUIN_PREFIX):].strip().lstrip(",").strip()
+
+        if is_mannequin_profile:
+            # Content-driven: detect if characters are present
+            has_characters = _has_character_indicators(clean_desc)
+
+            if has_characters:
+                # Characters present: use mannequin prefix
+                prefix = _MANNEQUIN_PREFIX
+            else:
+                # No characters: no prefix needed
+                prefix = ""
+
+            suffix = _UNIVERSAL_SUFFIX
+        else:
+            # Non-mannequin profile: use profile defaults
+            prefix = default_prefix
+            suffix = profile.style_system.style_suffix if profile.style_system.style_suffix else ""
 
         if image_style_override and image_style_override.strip():
-            global_suffix = _apply_style_override(global_suffix, image_style_override)
+            suffix = _apply_style_override(suffix, image_style_override)
 
-        return f"{prefix} {clean_desc}{global_suffix}"
+        # Build final prompt
+        if prefix:
+            return f"{prefix} {clean_desc}{suffix}"
+        else:
+            return f"{clean_desc}{suffix}"
 
 
 def assign_profile_styles(

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -2117,6 +2117,72 @@ class VideoPipeline:
         print(f"  ✓ Style rotation configured: {len(style_assignments)} assignments ready")
 
         # ---------------------------------------------------------------
+        # Generate or load Story Bible for visual consistency
+        # ---------------------------------------------------------------
+        story_bible = None
+        is_mannequin_profile = (
+            _active_profile is not None
+            and _active_profile.profile_id not in ("holographic_hud",)
+            and _active_profile.figure_rules.allow_mannequins
+        )
+
+        if is_mannequin_profile:
+            # Check if Story Bible already exists in Airtable
+            existing_bible_json = (self.current_idea.get("Story Bible") or "").strip()
+            if existing_bible_json:
+                try:
+                    story_bible = json.loads(existing_bible_json)
+                    char_count = len(story_bible.get("characters", []))
+                    loc_count = len(story_bible.get("locations", []))
+                    print(f"  📖 Loaded existing Story Bible: {char_count} characters, {loc_count} locations")
+                    self.slack.notify(
+                        f"📖 Using existing Story Bible for *{self.video_title}*:\n"
+                        f"• {char_count} characters, {loc_count} locations"
+                    )
+                except json.JSONDecodeError:
+                    print(f"  ⚠️ Could not parse existing Story Bible, regenerating...")
+                    story_bible = None
+
+            # Generate new Story Bible if not found
+            if not story_bible:
+                print(f"  📖 Generating Story Bible for visual consistency...")
+                try:
+                    from bots.story_bible import generate_story_bible
+
+                    # Combine all script text for bible generation
+                    full_script_text = "\n\n".join(
+                        f"[SCENE {s.get('scene', 0)}]\n{s.get('Scene text', '') or s.get('Script', '')}"
+                        for s in scripts
+                    )
+
+                    story_bible = await generate_story_bible(
+                        anthropic_client=self.anthropic,
+                        full_script_text=full_script_text,
+                        video_title=self.video_title,
+                    )
+
+                    # Store in Airtable for future runs
+                    if story_bible:
+                        self.airtable.update_idea_fields(
+                            self.current_idea_id,
+                            {"Story Bible": json.dumps(story_bible, ensure_ascii=False)}
+                        )
+                        print(f"  📖 Story Bible saved to Airtable")
+                        # Notify Slack that Story Bible was generated
+                        char_count = len(story_bible.get("characters", []))
+                        loc_count = len(story_bible.get("locations", []))
+                        arc_count = len(story_bible.get("visual_arc", []))
+                        self.slack.notify(
+                            f"📖 Story Bible generated for *{self.video_title}*:\n"
+                            f"• {char_count} characters\n"
+                            f"• {loc_count} locations\n"
+                            f"• {arc_count} scene arcs"
+                        )
+                except Exception as e:
+                    print(f"  ⚠️ Story Bible generation failed (non-blocking): {e}")
+                    story_bible = {}
+
+        # ---------------------------------------------------------------
         # Expand each script record into visual concepts + styled prompts
         # ---------------------------------------------------------------
         # Apply scene filter if set
@@ -2184,6 +2250,7 @@ class VideoPipeline:
                 act_number=act_number,
                 total_scenes=total_scripts,
                 voice_duration=voice_duration,
+                story_bible=story_bible,  # Pass Story Bible for character/location consistency
             )
 
             # Note: deterministic splitter doesn't set needs_new_prompt since it
@@ -2193,7 +2260,7 @@ class VideoPipeline:
             if needs_regen:
                 print(f"    Regenerating {len(needs_regen)} visual descriptions "
                       f"(duration-adjusted concepts)...")
-                # Build profile-driven regen prompt
+                # Build profile-driven regen prompt with Story Bible context
                 try:
                     from visual_profiles import load_profile as _load_vp
                     _regen_profile = _load_vp()
@@ -2203,25 +2270,38 @@ class VideoPipeline:
                     _regen_profile is None
                     or _regen_profile.profile_id == "holographic_hud"
                 )
+
+                # Format Story Bible context for regen
+                _regen_bible_context = ""
+                if story_bible and not _regen_is_holographic:
+                    try:
+                        from bots.story_bible import format_bible_for_prompt
+                        _regen_bible_context = format_bible_for_prompt(story_bible, scene_num)
+                    except ImportError:
+                        pass
+
                 for concept in needs_regen:
                     try:
                         if not _regen_is_holographic and _regen_profile and _regen_profile.scene_description.system_prompt:
-                            # Include scene type guidance if available
-                            _regen_type_guidance = ""
-                            _vs = concept.get("visual_style", "")
-                            if _regen_profile.style_system.substyles and _vs in _regen_profile.style_system.substyles:
-                                _sub = _regen_profile.style_system.substyles[_vs]
-                                _regen_type_guidance = (
-                                    f"\nSCENE TYPE: {_sub.name}\n"
-                                    f"Description: {_sub.description}\n"
-                                    f"Write a visual description that fits this scene type. "
+                            # NO scene type constraints — Claude decides what to write
+                            regen_prompt = f"{_regen_profile.scene_description.system_prompt}\n\n"
+
+                            # Add Story Bible context if available
+                            if _regen_bible_context:
+                                regen_prompt += (
+                                    f"{_regen_bible_context}\n\n"
+                                    "CRITICAL: If any character or location from the bible appears in this "
+                                    "narration, use their EXACT description from the bible above.\n\n"
                                 )
-                            regen_prompt = (
-                                f"{_regen_profile.scene_description.system_prompt}\n\n"
-                                f"{_regen_type_guidance}\n"
+
+                            # Add clothing requirement and instructions
+                            regen_prompt += (
+                                "CLOTHING RULE: Every mannequin figure MUST have specific clothing described. "
+                                "Never describe a mannequin without clothing. If unsure, use 'wearing dark formal suit with white shirt.'\n\n"
                                 "Write a 20-35 word visual description for this narration segment. "
+                                "You decide whether this moment needs characters, environment, data, or objects.\n\n"
                                 "Do NOT start with the style prefix (e.g. '3D rendered faceless mannequin...') — "
-                                "that will be added automatically. Just describe the scene content.\n"
+                                "that will be added automatically based on what you write.\n"
                                 "Return ONLY the description, nothing else.\n\n"
                                 f"Narration: \"{concept['sentence_text']}\""
                             )


### PR DESCRIPTION
## Summary
- **Story Bible**: Generates character/location/visual_arc from full script BEFORE image prompts
- **Content-driven prefix**: Mannequin prefix applied only to scenes with characters (detected via keyword matching)
- **Clothing requirement**: Claude prompts now require specific clothing for all mannequin figures
- **Slack notifications**: Notifies when Story Bible is generated or reused

## Changes
| File | Change |
|------|--------|
| `bots/story_bible.py` | **NEW** - Story Bible generator |
| `prompt_builder.py` | Content-driven prefix detection |
| `scene_expander.py` | Story Bible context injection |
| `pipeline.py` | Story Bible generation/loading + Slack |
| `*/__init__.py`, `anthropic_client.py` | Python 3.9 fixes |
| `airtable-schema.md` | Documented Story Bible field |

## Test plan
- [ ] Create `Story Bible` field in Airtable Idea Concepts (Long Text)
- [ ] Run pipeline on a script at "Ready For Image Prompts" status
- [ ] Verify Slack notification shows character/location counts
- [ ] Check generated prompts: character scenes have mannequin prefix, environment scenes don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)