### PR TITLE
Add post-generation prompt validation step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,20 @@ Python 3.11+ (async) · TypeScript · Remotion · Airtable (orchestration DB) Cl
 * tasks/ — Task scripts
 
 ## Architecture
-Status-driven pipeline where Airtable Status fields gate each stage: Research → Script → Voice → Image Prompts → Images → Video Scripts → Video Generation → Thumbnail → Render → Upload
+Status-driven pipeline where Airtable Status fields gate each stage: Research → Script → Voice → Image Prompts → **Validation** → Images → Video Scripts → Video Generation → Thumbnail → Render → Upload
 
 CRITICAL: Never skip a status. Always update via Airtable client. Check status before processing.
+
+### Prompt Validation (between Image Prompts and Images)
+After prompts are generated, `bots/prompt_validator.py` validates sequencing rules:
+- **Camera distance**: Max 2 consecutive same shot type (wide/medium/closeup)
+- **Location clustering**: Max 2 consecutive same location
+- **Data scene clustering**: Max 2 consecutive data/chart scenes
+- **Naked mannequins**: Character scenes must have clothing descriptions
+
+Auto-fixes: Camera distance swaps, mannequin hand reinforcement
+Critical violations (naked mannequins) block status advancement.
+Results logged to `/tmp/pipeline-validation.log`.
 
 ## Execution Protocol
 1. UNDERSTAND: Read relevant files. If requirements are ambiguous, ASK.

--- a/docs/file-map.md
+++ b/docs/file-map.md
@@ -23,6 +23,7 @@
 | `script_bot.py` | Scriptwriting | Concept from Ideas table | 6-act, 3000-4500 word script |
 | `voice_bot.py` | Voice synthesis | Script text | MP3 narration via ElevenLabs |
 | `image_prompt_bot.py` | Prompt engineering | Script scenes | 6 image prompts per scene (120 total) |
+| `prompt_validator.py` | Post-prompt validation | Generated prompts | Auto-fixes + violation report (blocks critical issues) |
 | `image_bot.py` | Image generation | Image prompts | PNG images via Seed Dream 4.5 |
 | `video_script_bot.py` | Motion prompts | Images + script | Animation motion descriptions |
 | `video_bot.py` | Animation | Images + motion prompts | Video clips via Veo 3.1 Fast |
@@ -35,7 +36,7 @@
 | Client | Service | Key Methods |
 |--------|---------|-------------|
 | `anthropic_client.py` | Claude AI | `generate()`, `generate_beat_sheet()`, `write_scene()`, `generate_image_prompts()`, `generate_video_prompt()`, `segment_scene_into_concepts()` |
-| `airtable_client.py` | Airtable | `get_ideas_by_status()`, `create_idea()`, `create_script_record()`, `update_image_record()`, `update_image_animation_fields()` |
+| `airtable_client.py` | Airtable | `get_ideas_by_status()`, `create_idea()`, `create_script_record()`, `update_image_record()`, `update_image_animation_fields()`, `update_image_prompt_fields()`, `get_all_images_for_video()` |
 | `elevenlabs_client.py` | ElevenLabs (via Wavespeed) | `generate_and_wait()` (create task + poll + return audio URL) |
 | `image_client.py` | Kie.ai | `generate_scene_image()` (Seed Dream 4.5), `generate_video()` (Grok Imagine), `generate_video_veo()` (Veo 3.1), `upgrade_veo_to_1080p()` |
 | `google_client.py` | Drive & Docs | `upload_file()`, `create_folder()`, `download_file_to_local()`, `make_file_public()`, `create_document()` |

--- a/skills/video-pipeline/bots/prompt_validator.py
+++ b/skills/video-pipeline/bots/prompt_validator.py
@@ -1,0 +1,513 @@
+"""
+Post-generation validation for image prompts.
+
+Runs AFTER all prompts are written to Airtable, BEFORE status advances to "Ready For Images".
+Checks sequencing rules and auto-fixes simple violations.
+
+Violations checked:
+- Camera distance clustering (3+ consecutive same shot type)
+- Consecutive same location (3+ in same location)
+- Consecutive data/chart scenes (3+ data visualizations)
+- Mannequin hands without reinforcement (closeups with hands but no mannequin qualifier)
+- Naked mannequins (character scenes without clothing descriptions)
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Violation:
+    """A validation violation found in the prompts."""
+
+    type: str  # camera_distance, consecutive_location, consecutive_data, realistic_hands, naked_mannequin
+    image_index: int
+    record_id: str
+    issue: str
+    fix: str  # swap_camera_distance, add_mannequin_hand_description, needs_regeneration
+    severity: str  # low, medium, high, critical
+
+
+class PromptValidator:
+    """Validate and fix sequencing issues in generated image prompts."""
+
+    MAX_CONSECUTIVE_SAME_DISTANCE = 2
+    MAX_CONSECUTIVE_SAME_LOCATION = 2
+    MAX_CONSECUTIVE_DATA_SCENES = 2
+
+    # Location markers for detection
+    LOCATION_MARKERS = {
+        "data_room": ["operations room", "projected display", "holographic", "control room monitors"],
+        "kremlin": ["kremlin", "mahogany desk", "red square"],
+        "treaty_room": ["treaty", "signing", "crossed flags", "ceremonial hall"],
+        "eu_press": ["eu flag", "european union", "press conference"],
+        "gas_station": ["gas station", "fuel pump", "gallon"],
+        "kitchen": ["kitchen", "bills", "receipts", "coffee mug", "breakfast table"],
+        "trading_floor": ["trading floor", "dow", "traders", "stock exchange"],
+        "hormuz": ["strait", "hormuz", "tanker"],
+        "afghanistan": ["afghanistan", "soviet", "command post"],
+        "opec_1973": ["1973", "opec", "embargo", "arab ministers"],
+        "boardroom": ["boardroom", "conference table", "executive"],
+        "white_house": ["white house", "oval", "presidential"],
+        "shipyard": ["shipyard", "container", "cargo"],
+        "factory": ["factory floor", "assembly line", "industrial"],
+        "refinery": ["refinery", "oil rig", "pipeline"],
+    }
+
+    # Data scene indicators
+    DATA_INDICATORS = [
+        "operations room",
+        "projected display",
+        "holographic",
+        "bar chart",
+        "line graph",
+        "data visualization",
+        "glowing digits",
+        "percentage numbers",
+        "financial dashboard",
+        "stock ticker",
+        "floating numbers",
+        "data overlay",
+        "pie chart",
+        "trend line",
+    ]
+
+    # Hand words that need mannequin reinforcement
+    HAND_WORDS = [
+        "hand resting",
+        "hands resting",
+        "hand reaching",
+        "hands reaching",
+        "hand gripping",
+        "hands gripping",
+        "fingers",
+        "holding pen",
+        "holding document",
+        "hand on",
+        "hands on",
+    ]
+
+    # Mannequin hand descriptors
+    MANNEQUIN_HAND_WORDS = [
+        "plastic",
+        "white mannequin hand",
+        "joint seam",
+        "smooth white hand",
+        "mannequin hand",
+        "articulated joint",
+        "plastic hand",
+    ]
+
+    # Character indicators (phrases that indicate a human figure is present, excluding "mannequin"
+    # which is always in the prefix). Use multi-word phrases to avoid false positives like
+    # "official seals" being detected as "official" (person).
+    CHARACTER_INDICATORS = [
+        "standing",
+        "sitting",
+        "leaning",
+        "seated",
+        "walking",
+        "gesturing",
+        "arms crossed",
+        "hands clasped",
+        "suited mannequin",
+        "official seated",
+        "official standing",
+        "official at",
+        "leader at",
+        "leader seated",
+        "trader at",
+        "trader standing",
+    ]
+
+    # Standard mannequin prefix to strip before checking for character content
+    MANNEQUIN_PREFIX = "3D rendered faceless mannequin with smooth white oval head"
+
+    # Standard mannequin suffix that should be stripped before checking
+    MANNEQUIN_SUFFIX = ", Cinematic 3D documentary style, no facial features on any figures."
+
+    # Clothing descriptors
+    CLOTHING_INDICATORS = [
+        "wearing",
+        "suit",
+        "uniform",
+        "robes",
+        "dress shirt",
+        "tie",
+        "jacket",
+        "vest",
+        "shirt",
+        "three-piece",
+        "costume",
+        "clerical",
+        "thobe",
+        "business attire",
+        "formal wear",
+        "coat",
+        "blazer",
+        "overalls",
+        "coveralls",
+        "military uniform",
+        "lab coat",
+        "hard hat",
+    ]
+
+    def validate(self, prompts: list[dict]) -> list[Violation]:
+        """Run all validation checks.
+
+        Args:
+            prompts: List of image records from Airtable, each with:
+                - id: Record ID
+                - Image Index: 1-based index
+                - Image Prompt: The styled prompt text
+                - Shot Type: Camera composition (wide/medium/closeup)
+                - Scene: Scene number
+
+        Returns:
+            List of Violation objects
+        """
+        violations = []
+        violations.extend(self._check_camera_distance(prompts))
+        violations.extend(self._check_consecutive_locations(prompts))
+        violations.extend(self._check_consecutive_data_scenes(prompts))
+        violations.extend(self._check_mannequin_hands(prompts))
+        violations.extend(self._check_naked_mannequins(prompts))
+        return violations
+
+    def _check_camera_distance(self, prompts: list[dict]) -> list[Violation]:
+        """Flag runs of 3+ same camera distance."""
+        violations = []
+        consecutive = 1
+        run_start_idx = 0
+
+        for i in range(1, len(prompts)):
+            current_type = prompts[i].get("Shot Type", "").lower()
+            prev_type = prompts[i - 1].get("Shot Type", "").lower()
+
+            if current_type == prev_type and current_type:
+                consecutive += 1
+                if consecutive > self.MAX_CONSECUTIVE_SAME_DISTANCE:
+                    violations.append(
+                        Violation(
+                            type="camera_distance",
+                            image_index=prompts[i].get("Image Index", i + 1),
+                            record_id=prompts[i].get("id", ""),
+                            issue=f"{consecutive}+ consecutive '{current_type}' shots (images {prompts[run_start_idx].get('Image Index', run_start_idx+1)}-{prompts[i].get('Image Index', i+1)})",
+                            fix="swap_camera_distance",
+                            severity="medium",
+                        )
+                    )
+            else:
+                consecutive = 1
+                run_start_idx = i
+
+        return violations
+
+    def _check_consecutive_locations(self, prompts: list[dict]) -> list[Violation]:
+        """Flag runs of 3+ same location."""
+        violations = []
+        consecutive = 1
+        run_start_idx = 0
+
+        for i in range(1, len(prompts)):
+            prompt_text = prompts[i].get("Image Prompt", "")
+            prev_prompt_text = prompts[i - 1].get("Image Prompt", "")
+
+            loc_current = self._detect_location(prompt_text)
+            loc_prev = self._detect_location(prev_prompt_text)
+
+            if loc_current == loc_prev and loc_current != "unknown":
+                consecutive += 1
+                if consecutive > self.MAX_CONSECUTIVE_SAME_LOCATION:
+                    violations.append(
+                        Violation(
+                            type="consecutive_location",
+                            image_index=prompts[i].get("Image Index", i + 1),
+                            record_id=prompts[i].get("id", ""),
+                            issue=f"{consecutive}+ consecutive scenes in '{loc_current}' (images {prompts[run_start_idx].get('Image Index', run_start_idx+1)}-{prompts[i].get('Image Index', i+1)})",
+                            fix="needs_regeneration",
+                            severity="high",
+                        )
+                    )
+            else:
+                consecutive = 1
+                run_start_idx = i
+
+        return violations
+
+    def _check_consecutive_data_scenes(self, prompts: list[dict]) -> list[Violation]:
+        """Flag runs of 3+ data/chart scenes."""
+        violations = []
+        consecutive = 1
+        run_start_idx = 0
+
+        for i in range(1, len(prompts)):
+            prompt_text = prompts[i].get("Image Prompt", "").lower()
+            prev_prompt_text = prompts[i - 1].get("Image Prompt", "").lower()
+
+            is_data_current = any(ind in prompt_text for ind in self.DATA_INDICATORS)
+            is_data_prev = any(ind in prev_prompt_text for ind in self.DATA_INDICATORS)
+
+            if is_data_current and is_data_prev:
+                consecutive += 1
+                if consecutive > self.MAX_CONSECUTIVE_DATA_SCENES:
+                    violations.append(
+                        Violation(
+                            type="consecutive_data",
+                            image_index=prompts[i].get("Image Index", i + 1),
+                            record_id=prompts[i].get("id", ""),
+                            issue=f"{consecutive}+ consecutive data/chart scenes (images {prompts[run_start_idx].get('Image Index', run_start_idx+1)}-{prompts[i].get('Image Index', i+1)})",
+                            fix="needs_regeneration",
+                            severity="high",
+                        )
+                    )
+            else:
+                consecutive = 1
+                run_start_idx = i
+
+        return violations
+
+    def _check_mannequin_hands(self, prompts: list[dict]) -> list[Violation]:
+        """Flag closeup shots that describe hands without mannequin reinforcement."""
+        violations = []
+
+        for p in prompts:
+            prompt_text = p.get("Image Prompt", "").lower()
+            shot_type = p.get("Shot Type", "").lower()
+
+            has_hands = any(hw in prompt_text for hw in self.HAND_WORDS)
+            has_mannequin_hands = any(mhw in prompt_text for mhw in self.MANNEQUIN_HAND_WORDS)
+            is_closeup = shot_type in ["closeup", "close-up", "extreme-close-up"]
+
+            if has_hands and is_closeup and not has_mannequin_hands:
+                violations.append(
+                    Violation(
+                        type="realistic_hands",
+                        image_index=p.get("Image Index", 0),
+                        record_id=p.get("id", ""),
+                        issue="Closeup with hand description but no mannequin hand reinforcement",
+                        fix="add_mannequin_hand_description",
+                        severity="medium",
+                    )
+                )
+
+        return violations
+
+    def _check_naked_mannequins(self, prompts: list[dict]) -> list[Violation]:
+        """Flag character prompts without clothing descriptions."""
+        violations = []
+
+        for p in prompts:
+            prompt_text = p.get("Image Prompt", "")
+
+            # Only check prompts that have the mannequin prefix (character scenes)
+            if not prompt_text.startswith("3D rendered faceless mannequin"):
+                continue
+
+            # Strip the standard prefix and suffix before checking for character content
+            # This prevents false positives from words like "mannequin" in the prefix
+            # and "figures" in the standard suffix
+            content = prompt_text
+            if content.startswith(self.MANNEQUIN_PREFIX):
+                content = content[len(self.MANNEQUIN_PREFIX):].strip()
+            if content.endswith(self.MANNEQUIN_SUFFIX):
+                content = content[:-len(self.MANNEQUIN_SUFFIX)].strip()
+
+            content_lower = content.lower()
+
+            # Check if this is a data/environment scene (not a character scene)
+            is_data_scene = any(ind in content_lower for ind in self.DATA_INDICATORS)
+
+            # Check for character presence and clothing
+            has_character = any(ci in content_lower for ci in self.CHARACTER_INDICATORS)
+            has_clothing = any(cl in content_lower for cl in self.CLOTHING_INDICATORS)
+
+            # Only flag if it's a character scene without clothing
+            # Skip data/environment scenes that incorrectly have the mannequin prefix
+            if has_character and not has_clothing and not is_data_scene:
+                violations.append(
+                    Violation(
+                        type="naked_mannequin",
+                        image_index=p.get("Image Index", 0),
+                        record_id=p.get("id", ""),
+                        issue="Character scene with no clothing description",
+                        fix="needs_regeneration",
+                        severity="critical",
+                    )
+                )
+
+        return violations
+
+    def _detect_location(self, prompt_text: str) -> str:
+        """Detect location from prompt text."""
+        prompt_lower = prompt_text.lower()
+        for loc_id, markers in self.LOCATION_MARKERS.items():
+            if any(m in prompt_lower for m in markers):
+                return loc_id
+        return "unknown"
+
+    # =========================================================================
+    # AUTO-FIX METHODS
+    # =========================================================================
+
+    def auto_fix_camera_distance(
+        self, prompts: list[dict], violation: Violation
+    ) -> Optional[dict]:
+        """Swap camera distance on the violating prompt.
+
+        Returns:
+            Dict with {record_id, new_shot_type} if fixed, None if not fixable
+        """
+        # Find the prompt by image index
+        target_idx = None
+        for i, p in enumerate(prompts):
+            if p.get("Image Index") == violation.image_index:
+                target_idx = i
+                break
+
+        if target_idx is None:
+            return None
+
+        current = prompts[target_idx].get("Shot Type", "medium").lower()
+
+        # Pick a different distance that contrasts with neighbors
+        alternatives = {
+            "closeup": ["wide", "medium"],
+            "close-up": ["wide", "medium"],
+            "medium": ["closeup", "wide"],
+            "wide": ["medium", "closeup"],
+            "environmental": ["closeup", "medium"],
+            "portrait": ["wide", "environmental"],
+            "overhead": ["medium", "closeup"],
+            "low_angle": ["medium", "wide"],
+        }
+
+        prev_type = prompts[target_idx - 1].get("Shot Type", "").lower() if target_idx > 0 else None
+        next_type = (
+            prompts[target_idx + 1].get("Shot Type", "").lower()
+            if target_idx < len(prompts) - 1
+            else None
+        )
+
+        for alt in alternatives.get(current, ["medium"]):
+            if alt != prev_type and alt != next_type:
+                return {
+                    "record_id": prompts[target_idx].get("id"),
+                    "new_shot_type": alt,
+                    "old_shot_type": current,
+                    "image_index": violation.image_index,
+                }
+
+        return None
+
+    def auto_fix_mannequin_hands(
+        self, prompts: list[dict], violation: Violation
+    ) -> Optional[dict]:
+        """Insert mannequin hand description into prompt.
+
+        Returns:
+            Dict with {record_id, new_prompt} if fixed, None if not fixable
+        """
+        # Find the prompt by image index
+        target = None
+        for p in prompts:
+            if p.get("Image Index") == violation.image_index:
+                target = p
+                break
+
+        if target is None:
+            return None
+
+        prompt = target.get("Image Prompt", "")
+        original_prompt = prompt
+
+        # Find hand description and add mannequin qualifier
+        hand_replacements = {
+            "hand resting": "smooth white plastic mannequin hand resting",
+            "hands resting": "smooth white plastic mannequin hands resting",
+            "hand reaching": "smooth white plastic mannequin hand reaching",
+            "hands reaching": "smooth white plastic mannequin hands reaching",
+            "hand gripping": "smooth white plastic mannequin hand gripping",
+            "hands gripping": "smooth white plastic mannequin hands gripping",
+            "hand on": "smooth white plastic mannequin hand on",
+            "hands on": "smooth white plastic mannequin hands on",
+            "holding pen": "plastic mannequin fingers holding pen",
+            "holding document": "plastic mannequin hand holding document",
+        }
+
+        for original, replacement in hand_replacements.items():
+            if original in prompt.lower():
+                # Case-insensitive replacement
+                import re
+                prompt = re.sub(
+                    re.escape(original),
+                    replacement,
+                    prompt,
+                    flags=re.IGNORECASE,
+                )
+                break
+
+        if prompt != original_prompt:
+            return {
+                "record_id": target.get("id"),
+                "new_prompt": prompt,
+                "image_index": violation.image_index,
+            }
+
+        return None
+
+
+def format_validation_report(
+    video_title: str,
+    total_prompts: int,
+    violations: list[Violation],
+    auto_fixed: list[dict],
+    needs_regen: list[Violation],
+) -> str:
+    """Format a Slack-ready validation report."""
+    lines = [
+        f"*Prompt Validation Report*",
+        f"Video: {video_title}",
+        f"Total prompts: {total_prompts}",
+        "",
+    ]
+
+    if auto_fixed:
+        lines.append(f"*Auto-fixed: {len(auto_fixed)}*")
+        for fix in auto_fixed:
+            if "new_shot_type" in fix:
+                lines.append(
+                    f"  \u2022 Image {fix['image_index']}: camera distance {fix['old_shot_type']} \u2192 {fix['new_shot_type']}"
+                )
+            elif "new_prompt" in fix:
+                lines.append(
+                    f"  \u2022 Image {fix['image_index']}: added mannequin hand reinforcement"
+                )
+        lines.append("")
+
+    if needs_regen:
+        lines.append(f"*Needs regeneration: {len(needs_regen)}*")
+        for v in needs_regen:
+            lines.append(f"  \u2022 Image {v.image_index}: {v.issue}")
+        lines.append("")
+
+    if not violations:
+        lines.append("*All prompts passed validation*")
+
+    # Summary line with emoji
+    critical = [v for v in needs_regen if v.severity == "critical"]
+    if critical:
+        lines.insert(0, f"\u26a0\ufe0f *{len(critical)} critical violations need manual review*\n")
+    elif needs_regen:
+        lines.insert(0, f"\u26a0\ufe0f *{len(needs_regen)} prompts flagged for review*\n")
+    elif auto_fixed:
+        lines.insert(0, f"\u2705 *Validation passed ({len(auto_fixed)} auto-fixed)*\n")
+    else:
+        lines.insert(0, "\u2705 *Validation passed - no issues found*\n")
+
+    return "\n".join(lines)

--- a/skills/video-pipeline/clients/airtable_client.py
+++ b/skills/video-pipeline/clients/airtable_client.py
@@ -841,6 +841,36 @@ class AirtableClient:
                 return {"id": record_id, "warning": "Animation fields not found in Airtable"}
             raise
 
+    def update_image_prompt_fields(
+        self,
+        record_id: str,
+        image_prompt: str = None,
+        shot_type: str = None,
+    ) -> dict:
+        """Update prompt-related fields on an image record.
+
+        Used by prompt_validator to auto-fix issues before image generation.
+
+        Args:
+            record_id: Airtable record ID
+            image_prompt: Updated prompt text
+            shot_type: Camera composition (wide/medium/closeup)
+
+        Returns:
+            Updated record dict
+        """
+        updates = {}
+        if image_prompt is not None:
+            updates["Image Prompt"] = image_prompt
+        if shot_type is not None:
+            updates["Shot Type"] = shot_type
+
+        if not updates:
+            return {"id": record_id}
+
+        record = self.images_table.update(record_id, updates, typecast=True)
+        return {"id": record["id"], **record["fields"]}
+
     def get_images_ready_for_video_generation(self, video_title: str) -> list[dict]:
         """Get image records that are Done but missing a Video URL."""
         from pyairtable.formulas import match, AND

--- a/skills/video-pipeline/clients/slack_client.py
+++ b/skills/video-pipeline/clients/slack_client.py
@@ -196,6 +196,14 @@ class SlackClient:
             "✅ Image prompts are Done!\n\n"
             "Now generating images... 🖼️"
         )
+
+    def notify_prompt_validation(self, report: str) -> dict:
+        """Notify prompt validation results.
+
+        Args:
+            report: Formatted validation report from prompt_validator.format_validation_report()
+        """
+        return self.send_message(f"🔍 {report}")
     
     def notify_images_start(self) -> dict:
         """Notify that image generation has started."""

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -48,6 +48,7 @@ from bots.idea_bot import IdeaBot
 from bots.trending_idea_bot import TrendingIdeaBot
 from bots.sound_prompt_bot import SoundPromptBot
 from bots.sound_bot import SoundBot
+from bots.prompt_validator import PromptValidator, format_validation_report
 from pipeline_config import VideoConfig
 from segmentation_engine import enforce_duration_caps, recalculate_durations
 from image_prompt_engine.prompt_builder import (
@@ -2451,6 +2452,110 @@ class VideoPipeline:
                 print(f"  Audio sync failed (non-blocking): {e}")
                 audio_sync_summary = f" | Audio sync error: {e}"
 
+        # ---------------------------------------------------------------
+        # Prompt Validation: Check sequencing rules before image generation
+        # ---------------------------------------------------------------
+        validation_summary = ""
+        has_critical_violations = False
+        if not self._is_targeted_run:
+            try:
+                print(f"\n  Running prompt validation...")
+                prompts = self.airtable.get_all_images_for_video(self.video_title)
+
+                if prompts:
+                    validator = PromptValidator()
+                    violations = validator.validate(prompts)
+
+                    if violations:
+                        auto_fixed = []
+                        needs_regen = []
+
+                        for v in violations:
+                            if v.fix == "swap_camera_distance":
+                                fix = validator.auto_fix_camera_distance(prompts, v)
+                                if fix:
+                                    # Write fix to Airtable
+                                    self.airtable.update_image_prompt_fields(
+                                        record_id=fix["record_id"],
+                                        shot_type=fix["new_shot_type"],
+                                    )
+                                    auto_fixed.append(fix)
+                                    print(f"    Auto-fixed: Image {fix['image_index']} camera distance {fix['old_shot_type']} → {fix['new_shot_type']}")
+                                else:
+                                    needs_regen.append(v)
+                            elif v.fix == "add_mannequin_hand_description":
+                                fix = validator.auto_fix_mannequin_hands(prompts, v)
+                                if fix:
+                                    # Write fix to Airtable
+                                    self.airtable.update_image_prompt_fields(
+                                        record_id=fix["record_id"],
+                                        image_prompt=fix["new_prompt"],
+                                    )
+                                    auto_fixed.append(fix)
+                                    print(f"    Auto-fixed: Image {fix['image_index']} added mannequin hand reinforcement")
+                                else:
+                                    needs_regen.append(v)
+                            else:
+                                needs_regen.append(v)
+
+                        # Report to Slack
+                        report = format_validation_report(
+                            video_title=self.video_title,
+                            total_prompts=len(prompts),
+                            violations=violations,
+                            auto_fixed=auto_fixed,
+                            needs_regen=needs_regen,
+                        )
+                        self.slack.notify_prompt_validation(report)
+
+                        # Log to file for debugging
+                        try:
+                            with open("/tmp/pipeline-validation.log", "a") as f:
+                                from datetime import datetime
+                                f.write(f"\n{'='*60}\n")
+                                f.write(f"[{datetime.now().isoformat()}] {self.video_title}\n")
+                                f.write(f"{'='*60}\n")
+                                f.write(f"Total prompts: {len(prompts)}\n")
+                                f.write(f"Violations: {len(violations)}\n")
+                                f.write(f"Auto-fixed: {len(auto_fixed)}\n")
+                                f.write(f"Needs regeneration: {len(needs_regen)}\n\n")
+                                for v in violations:
+                                    f.write(f"  [{v.severity.upper()}] {v.type}: Image {v.image_index} - {v.issue}\n")
+                        except Exception as log_err:
+                            print(f"    Warning: Could not write to validation log: {log_err}")
+
+                        # Check for critical violations
+                        critical = [v for v in needs_regen if v.severity == "critical"]
+                        if critical:
+                            has_critical_violations = True
+                            print(f"  ⚠️ {len(critical)} critical violations need manual review")
+                            validation_summary = f" | ⚠️ {len(critical)} critical violations"
+                        elif needs_regen:
+                            print(f"  ⚠️ {len(needs_regen)} prompts flagged for review")
+                            validation_summary = f" | ⚠️ {len(needs_regen)} flagged"
+                        else:
+                            print(f"  ✅ Validation passed ({len(auto_fixed)} auto-fixed)")
+                            validation_summary = f" | ✅ {len(auto_fixed)} auto-fixed"
+                    else:
+                        print(f"  ✅ Validation passed - no issues found")
+                else:
+                    print(f"  ⚠️ No prompts found for validation")
+            except Exception as e:
+                print(f"  Prompt validation failed (non-blocking): {e}")
+                validation_summary = f" | Validation error: {e}"
+
+        # If critical violations exist, don't advance status
+        if has_critical_violations:
+            print(f"\n  ❌ Cannot advance status - critical violations need manual review")
+            return {
+                "bot": "Styled Image Prompt Engine",
+                "video_title": self.video_title,
+                "scenes_expanded": scenes_expanded,
+                "total_concepts": total_concepts,
+                "validation_blocked": True,
+                "error": "Critical violations need manual review before image generation",
+            }
+
         # Update status (skip if targeted run)
         if self._is_targeted_run:
             print(f"  🎯 Targeted run — status NOT advanced")
@@ -2476,6 +2581,7 @@ class VideoPipeline:
             f"for *{self.video_title}*\n"
             f"{style_summary}"
             f"{audio_sync_summary}"
+            f"{validation_summary}"
         )
 
         return {


### PR DESCRIPTION
## Summary
- Validates prompts AFTER generation, BEFORE image creation
- Checks: camera distance clustering, location clustering, data scene clustering, naked mannequins
- Auto-fixes camera distance swaps and mannequin hand reinforcement
- Critical violations (naked mannequins) block status advancement
- Results logged to `/tmp/pipeline-validation.log`

## Test plan
- [x] Tested on Russia Oil Trap prompts (92 prompts, found 14 violations, 1 auto-fixed)
- [x] Verified false positive fixes for "official seals" and "Goldman" edge cases
- [x] Import verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)