### PR TITLE
Merge competitor top performers into discovery scanner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ AIRTABLE_SCRIPT_TABLE_ID=tbluGSepeZNgb0NxG
 # Defaults to tblrAsJglokZSkC8m if not set.
 # AIRTABLE_IDEA_CONCEPTS_TABLE_ID=tblrAsJglokZSkC8m
 
+# Competitor Channels table — tracks competitor YouTube channels for scraping
+# Used by the discovery scanner to find top-performing competitor videos
+# Create this table with columns: Channel Name, Channel URL, Category, Active, Last Scraped, Notes
+AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID=tblXXXXXXXXXXXXXX
+
 # ============================================
 # GOOGLE (Drive & Docs)
 # ============================================

--- a/docs/airtable-schema.md
+++ b/docs/airtable-schema.md
@@ -47,6 +47,31 @@ Performance fields (written by `performance_tracker.py`, daily cron):
 - `Image` (attachment), `Video`, `Video Prompt`
 - Animation: `Hero Shot`, `Video Clip URL`, `Animation Status`, `Video Duration`
 
+## Competitor Channels Table
+
+Used by the discovery scanner to scrape competitor YouTube videos and generate ideas from top performers.
+
+Required fields:
+- `Channel Name` (Single Line Text) — Name of the competitor channel
+- `Channel URL` (URL) — YouTube channel URL (e.g., `https://www.youtube.com/@CaspianReport`)
+- `Category` (Single Select) — Channel category. Options: `Geopolitics`, `Finance`, `Economy`, `Tech`
+- `Active` (Checkbox) — Include in discovery scraping (only active channels are scraped)
+- `Last Scraped` (Date) — Auto-updated when channel is scraped by the discovery scanner
+- `Notes` (Long Text) — Optional notes about the channel
+
+Setup:
+1. Create the table in Airtable with name "Competitor Channels"
+2. Add the fields above
+3. Set `AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID` in `.env` to the table ID
+4. Run `python setup_competitor_channels.py` to verify setup
+5. Add competitor channels and check the `Active` checkbox
+
+Example channels to add:
+- CaspianReport (1.8M subs) — Geopolitics
+- AiTelly (2M subs) — Geopolitics/Finance
+- Economics Explained (2.5M subs) — Economy
+- PolyMatter (2M subs) — Economy
+
 ## Known Schema Issues (See ANIMATION_SYSTEM_REVIEW.md Feature 4)
 
 - **CRITICAL**: Tables joined by string matching (`Title` = `Video Title`), NOT linked records. Typos break relationships.

--- a/skills/video-pipeline/discovery_scanner.py
+++ b/skills/video-pipeline/discovery_scanner.py
@@ -1,10 +1,13 @@
 """
-Discovery Scanner — Scans headlines, filters through Machiavellian lens,
-and generates title variants using the pattern library.
+Discovery Scanner — Scans headlines AND competitor videos, filters through
+Machiavellian lens, and generates title variants using the pattern library.
 
-Scans current headlines across geopolitics, finance, tech, and economic
-policy, filters them through the channel's dark power dynamics lens, and
-formats the top 2-3 stories into proven title structures.
+Two idea sources (50/50 split):
+  1. WORLD NEWS: Current headlines across geopolitics, finance, tech, economic policy
+  2. COMPETITORS: Top-performing videos from competitor channels (past 7 days)
+
+Both sources are filtered through the channel's dark power dynamics lens and
+formatted into proven MF (Master Formula) title structures.
 
 Usage (standalone):
     python discovery_scanner.py
@@ -14,7 +17,7 @@ Usage (standalone):
 Usage (imported):
     from discovery_scanner import DiscoveryScanner, run_discovery
 
-    scanner = DiscoveryScanner(anthropic_client)
+    scanner = DiscoveryScanner(anthropic_client, apify_client, airtable_client)
     ideas = await scanner.scan()
 """
 
@@ -23,11 +26,14 @@ import json
 import logging
 import os
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# Import competitor VPH calculation
+from bots.competitor_scraper import calculate_vph
 
 # Source categories for headline scanning
 SCAN_SOURCES = {
@@ -273,27 +279,85 @@ def _parse_scanner_output(response_text: str) -> dict:
     return result
 
 
+def _parse_competitor_output(response_text: str) -> dict:
+    """Parse the JSON output from the competitor idea generator.
+
+    Similar to _parse_scanner_output but expects 'competitor_ideas' key.
+    """
+    text = response_text.strip()
+
+    # Strip markdown code block if present
+    if text.startswith("```"):
+        first_newline = text.index("\n")
+        text = text[first_newline + 1:]
+    if text.endswith("```"):
+        text = text[:-3].rstrip()
+
+    # Find JSON object
+    brace_start = text.find("{")
+    brace_end = text.rfind("}")
+    if brace_start != -1 and brace_end != -1:
+        text = text[brace_start:brace_end + 1]
+
+    result = json.loads(text)
+
+    # Validate structure
+    ideas = result.get("competitor_ideas", [])
+    if not ideas:
+        logger.warning("Competitor output contains no ideas")
+        result["competitor_ideas"] = []
+        return result
+
+    # Validate each idea has required fields
+    required_fields = [
+        "competitor_title",
+        "title_options",
+    ]
+    for i, idea in enumerate(ideas):
+        missing = [f for f in required_fields if f not in idea]
+        if missing:
+            logger.warning(f"Competitor idea {i+1} missing fields: {missing}")
+
+        # Ensure title_options exist
+        if not idea.get("title_options"):
+            logger.warning(f"Competitor idea {i+1} has no title_options")
+
+    return result
+
+
 class DiscoveryScanner:
-    """Scans headlines and generates video ideas through the Machiavellian lens.
+    """Scans headlines AND competitor videos, generates ideas through Machiavellian lens.
 
     Usage:
-        scanner = DiscoveryScanner(anthropic_client)
+        scanner = DiscoveryScanner(anthropic_client, apify_client, airtable_client)
         result = await scanner.scan()
-        # result["ideas"] contains 2-3 curated ideas with title variants
+        # result["news_ideas"] contains 2-3 ideas from world news headlines
+        # result["competitor_ideas"] contains 3-5 ideas from competitor top performers
     """
+
+    # Competitor scanning config
+    COMPETITOR_VPH_THRESHOLD = 50  # Min views per hour
+    COMPETITOR_MAX_AGE_HOURS = 168  # 7 days
+    COMPETITOR_MAX_IDEAS = 5  # Max competitor ideas to present
 
     def __init__(
         self,
         anthropic_client,
+        apify_client=None,
+        airtable_client=None,
         model: str = "claude-sonnet-4-5-20250929",
     ):
         """Initialize the discovery scanner.
 
         Args:
             anthropic_client: AnthropicClient instance for LLM calls
+            apify_client: Optional ApifyYouTubeClient for competitor scraping
+            airtable_client: Optional AirtableClient for competitor channels
             model: Model to use (Sonnet 4.5 for cost efficiency)
         """
         self.anthropic = anthropic_client
+        self.apify = apify_client
+        self.airtable = airtable_client
         self.model = model
         self.title_patterns = _load_title_patterns()
         self.system_prompt = _load_discovery_prompt()
@@ -379,67 +443,294 @@ purely domestic politics without global economic implications.
 
         return headlines
 
+    async def _gather_competitor_winners(self) -> list[dict]:
+        """Gather top-performing videos from competitor channels.
+
+        Scrapes competitor channels via Apify and filters to winners
+        (high VPH videos from the past 7 days).
+
+        Returns:
+            List of winner video dicts with: title, url, channel, views, vph
+        """
+        if not self.apify or not self.airtable:
+            logger.info("Competitor scanning skipped (no apify/airtable client)")
+            return []
+
+        logger.info("Gathering competitor top performers...")
+
+        # Get active channels from Airtable
+        try:
+            channels = self.airtable.get_active_competitor_channels()
+        except Exception as e:
+            logger.warning(f"Could not fetch competitor channels: {e}")
+            return []
+
+        if not channels:
+            logger.info("No active competitor channels found")
+            return []
+
+        channel_urls = [
+            c.get("Channel URL") for c in channels if c.get("Channel URL")
+        ]
+        logger.info(f"Scraping {len(channel_urls)} competitor channels...")
+
+        # Scrape videos via Apify
+        try:
+            videos = await self.apify.scrape_channel_videos(
+                channel_urls=channel_urls,
+                max_videos_per_channel=10,
+            )
+        except Exception as e:
+            logger.warning(f"Competitor scrape failed: {e}")
+            return []
+
+        # Calculate VPH and filter to winners
+        winners = []
+        for video in videos:
+            vph, hours_old = calculate_vph(
+                video.get("views", 0),
+                video.get("published_at", ""),
+            )
+            video["vph"] = round(vph, 1)
+            video["hours_old"] = round(hours_old, 1)
+
+            # Apply filters
+            if vph >= self.COMPETITOR_VPH_THRESHOLD and hours_old <= self.COMPETITOR_MAX_AGE_HOURS:
+                winners.append(video)
+
+        # Sort by VPH descending
+        winners.sort(key=lambda v: v.get("vph", 0), reverse=True)
+
+        logger.info(f"Found {len(winners)} competitor winners (VPH >= {self.COMPETITOR_VPH_THRESHOLD})")
+        return winners
+
+    async def _generate_competitor_ideas(self, winners: list[dict]) -> list[dict]:
+        """Generate MF-formatted ideas from competitor winners.
+
+        Takes top competitor videos and generates our own angle + MF titles,
+        preserving the original title and URL for reference.
+
+        Args:
+            winners: List of high-VPH competitor videos
+
+        Returns:
+            List of idea dicts with title_options, original title, url, etc.
+        """
+        if not winners:
+            return []
+
+        # Limit to top performers
+        top_winners = winners[:self.COMPETITOR_MAX_IDEAS]
+
+        logger.info(f"Generating MF titles for {len(top_winners)} competitor videos...")
+
+        # Build context for Claude
+        winners_context = "\n".join(
+            f"{i+1}. \"{v.get('title', '')}\" — {v.get('channel', '')} "
+            f"({v.get('views', 0):,} views, {v.get('vph', 0):.0f} VPH)\n"
+            f"   URL: {v.get('url', '')}"
+            for i, v in enumerate(top_winners)
+        )
+
+        # Extract master formulas for the prompt
+        master_formulas = self.title_patterns.get("master_formulas", [])
+        if not master_formulas:
+            master_formulas = self.title_patterns.get("formulas", [])
+        formulas_summary = "\n".join(
+            f"- {f['id']}: {f['name']} — Template: \"{f['template']}\""
+            for f in master_formulas
+        )
+
+        prompt = f"""\
+These are the TOP PERFORMING videos from competitor YouTube channels in the past 7 days.
+For EACH video, create an Economy FastForward angle with 3 MF title options.
+
+=== COMPETITOR TOP PERFORMERS ===
+{winners_context}
+
+=== TITLE FORMULA LIBRARY (MF system — use ONLY these) ===
+{formulas_summary}
+
+=== INSTRUCTIONS ===
+For EACH competitor video above, generate:
+1. Three title options using DIFFERENT MF formulas
+2. A 2-word thumbnail verdict (ALL CAPS strategic judgment)
+3. Our unique Machiavellian/power dynamics angle
+4. A hook (first 15 seconds)
+5. The best-fit analytical framework
+
+TITLE RULES (STRICT):
+- MAXIMUM 55 characters
+- Start with "How" or "Why" (or MF-6 possessive format)
+- First word after How/Why MUST be a proper noun
+- NO "YOU" or "YOUR"
+- NO ALL CAPS except acronyms
+
+Return ONLY a JSON object with this structure:
+{{
+  "competitor_ideas": [
+    {{
+      "competitor_title": "The EXACT original competitor title",
+      "competitor_channel": "Channel name",
+      "competitor_url": "Video URL",
+      "competitor_views": 123456,
+      "competitor_vph": 500,
+      "our_angle": "Our unique Machiavellian/power dynamics spin",
+      "title_options": [
+        {{
+          "title": "How China Is Weaponizing Rare Earth Exports",
+          "formula_id": "MF-0",
+          "thumbnail_text": "CHOKE POINT",
+          "score": 85
+        }}
+      ],
+      "hook": "Opening 15 seconds creating curiosity gap",
+      "framework": "One of: 48 Laws, Sun Tzu, Machiavelli, Thucydides Trap, etc.",
+      "estimated_appeal": 8
+    }}
+  ]
+}}
+
+Generate ideas for ALL {len(top_winners)} videos. Raw JSON only, no markdown."""
+
+        response = await self.anthropic.generate(
+            prompt=prompt,
+            system_prompt=self.system_prompt,
+            model=self.model,
+            max_tokens=6000,
+            temperature=0.7,
+        )
+
+        # Parse response
+        try:
+            result = _parse_competitor_output(response)
+            ideas = result.get("competitor_ideas", [])
+
+            # Enrich with source data
+            for i, idea in enumerate(ideas):
+                idea["source_type"] = "competitor"
+                # Map back to original winner data if available
+                if i < len(top_winners):
+                    winner = top_winners[i]
+                    idea["competitor_url"] = idea.get("competitor_url") or winner.get("url", "")
+                    idea["competitor_views"] = idea.get("competitor_views") or winner.get("views", 0)
+                    idea["competitor_vph"] = idea.get("competitor_vph") or winner.get("vph", 0)
+                    idea["competitor_channel"] = idea.get("competitor_channel") or winner.get("channel", "")
+                    idea["competitor_title"] = idea.get("competitor_title") or winner.get("title", "")
+
+            logger.info(f"Generated {len(ideas)} competitor ideas")
+            return ideas
+
+        except Exception as e:
+            logger.warning(f"Failed to parse competitor ideas: {e}")
+            return []
+
     async def scan(
         self,
         focus: Optional[str] = None,
         headlines: Optional[str] = None,
+        include_competitors: bool = True,
     ) -> dict:
-        """Run the full discovery scan.
+        """Run the full discovery scan (news + competitors).
 
-        Gathers headlines (or uses provided ones), filters through the
-        Machiavellian lens, and generates title variants.
+        Gathers headlines AND competitor top performers, filters through the
+        Machiavellian lens, and generates title variants for both.
 
         Args:
-            focus: Optional niche keyword to focus the scan
-            headlines: Optional pre-gathered headlines (skips gathering step)
+            focus: Optional niche keyword to focus the news scan
+            headlines: Optional pre-gathered headlines (skips headline gathering)
+            include_competitors: Whether to include competitor scanning (default True)
 
         Returns:
-            Dict with "ideas" list containing 2-3 curated video ideas,
-            each with title_options, hook, appeal score, etc.
+            Dict with:
+              - "ideas": news headline ideas (2-3)
+              - "competitor_ideas": competitor video ideas (3-5)
+              - "_metadata": scan metadata
         """
         logger.info(
             f"Starting discovery scan"
             + (f" (focus: {focus})" if focus else "")
+            + (" (with competitors)" if include_competitors else "")
         )
 
-        # Step 1: Gather headlines
-        if headlines is None:
-            logger.info("Gathering current headlines...")
-            headlines = await self._gather_headlines(focus)
-            logger.info(
-                f"Gathered {len(headlines.splitlines())} headline lines"
+        # Run news headlines and competitor scraping in parallel
+        tasks = []
+
+        # Task 1: Gather and analyze news headlines
+        async def _news_pipeline():
+            nonlocal headlines
+            if headlines is None:
+                logger.info("Gathering current headlines...")
+                headlines = await self._gather_headlines(focus)
+                logger.info(f"Gathered {len(headlines.splitlines())} headline lines")
+
+            analysis_prompt = _build_headline_scan_prompt(
+                headlines=headlines,
+                title_patterns=self.title_patterns,
+                focus=focus,
             )
+            logger.info("Analyzing headlines through Machiavellian lens...")
+            response = await self.anthropic.generate(
+                prompt=analysis_prompt,
+                system_prompt=self.system_prompt,
+                model=self.model,
+                max_tokens=4000,
+                temperature=0.7,
+            )
+            return _parse_scanner_output(response), headlines
 
-        # Step 2: Build analysis prompt
-        analysis_prompt = _build_headline_scan_prompt(
-            headlines=headlines,
-            title_patterns=self.title_patterns,
-            focus=focus,
-        )
+        tasks.append(_news_pipeline())
 
-        # Step 3: Run through Machiavellian lens
-        logger.info("Analyzing headlines through Machiavellian lens...")
-        response = await self.anthropic.generate(
-            prompt=analysis_prompt,
-            system_prompt=self.system_prompt,
-            model=self.model,
-            max_tokens=4000,
-            temperature=0.7,
-        )
+        # Task 2: Gather and analyze competitor videos (if enabled)
+        async def _competitor_pipeline():
+            if not include_competitors:
+                return []
+            winners = await self._gather_competitor_winners()
+            if not winners:
+                return []
+            return await self._generate_competitor_ideas(winners)
 
-        # Step 4: Parse and validate output
-        result = _parse_scanner_output(response)
-        idea_count = len(result.get("ideas", []))
+        tasks.append(_competitor_pipeline())
+
+        # Run both in parallel
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Process news results
+        news_result, gathered_headlines = ({"ideas": []}, headlines)
+        if not isinstance(results[0], Exception):
+            news_result, gathered_headlines = results[0]
+        else:
+            logger.error(f"News pipeline failed: {results[0]}")
+
+        # Process competitor results
+        competitor_ideas = []
+        if not isinstance(results[1], Exception):
+            competitor_ideas = results[1]
+        else:
+            logger.error(f"Competitor pipeline failed: {results[1]}")
+
+        # Mark news ideas with source type
+        for idea in news_result.get("ideas", []):
+            idea["source_type"] = "news"
+
+        news_count = len(news_result.get("ideas", []))
+        comp_count = len(competitor_ideas)
         logger.info(
-            f"Discovery scan complete: {idea_count} ideas generated"
+            f"Discovery scan complete: {news_count} news ideas, {comp_count} competitor ideas"
         )
 
-        # Add metadata
-        result["_metadata"] = {
-            "focus": focus,
-            "model": self.model,
-            "headline_count": len(headlines.splitlines()),
-            "source_categories": list(SCAN_SOURCES.keys()),
+        # Build combined result
+        result = {
+            "ideas": news_result.get("ideas", []),
+            "competitor_ideas": competitor_ideas,
+            "_metadata": {
+                "focus": focus,
+                "model": self.model,
+                "headline_count": len(gathered_headlines.splitlines()) if gathered_headlines else 0,
+                "source_categories": list(SCAN_SOURCES.keys()),
+                "competitor_ideas_count": comp_count,
+                "include_competitors": include_competitors,
+            },
         }
 
         return result
@@ -447,35 +738,52 @@ purely domestic politics without global economic implications.
 
 async def run_discovery(
     anthropic_client,
+    apify_client=None,
+    airtable_client=None,
     focus: Optional[str] = None,
     headlines: Optional[str] = None,
+    include_competitors: bool = True,
     model: str = "claude-sonnet-4-5-20250929",
 ) -> dict:
-    """Convenience function to run discovery scan.
+    """Convenience function to run discovery scan (news + competitors).
 
     This is the main entry point for external callers (Slack bot, pipeline).
 
     Args:
         anthropic_client: AnthropicClient instance
-        focus: Optional niche keyword to focus the scan
+        apify_client: Optional ApifyYouTubeClient for competitor scraping
+        airtable_client: Optional AirtableClient for competitor channels
+        focus: Optional niche keyword to focus the news scan
         headlines: Optional pre-gathered headlines
+        include_competitors: Whether to include competitor top performers (default True)
         model: LLM model to use (default: Sonnet 4.5)
 
     Returns:
-        Dict with "ideas" list containing 2-3 curated video ideas
+        Dict with:
+          - "ideas": news headline ideas (2-3)
+          - "competitor_ideas": competitor video ideas (3-5)
     """
-    scanner = DiscoveryScanner(anthropic_client, model=model)
-    return await scanner.scan(focus=focus, headlines=headlines)
+    scanner = DiscoveryScanner(
+        anthropic_client,
+        apify_client=apify_client,
+        airtable_client=airtable_client,
+        model=model,
+    )
+    return await scanner.scan(
+        focus=focus,
+        headlines=headlines,
+        include_competitors=include_competitors,
+    )
 
 
 def format_ideas_for_slack(result: dict) -> str:
     """Format discovery results as a readable Slack message.
 
-    Each idea shows 3 title options (one per MF formula) with thumbnail
-    text. Each title option gets its own number so the user can select
-    both the idea AND the specific title they want.
+    Shows two sections:
+      1. NEWS IDEAS: From world headlines (2-3 ideas)
+      2. COMPETITOR IDEAS: From competitor top performers (3-5 ideas)
 
-    For 3 ideas with 3 titles each, generates up to 9 numbered options.
+    Each idea shows title options with emoji reactions for selection.
 
     Args:
         result: Output from DiscoveryScanner.scan()
@@ -483,87 +791,133 @@ def format_ideas_for_slack(result: dict) -> str:
     Returns:
         Formatted Slack message string
     """
-    ideas = result.get("ideas", [])
-    if not ideas:
+    news_ideas = result.get("ideas", [])
+    competitor_ideas = result.get("competitor_ideas", [])
+
+    if not news_ideas and not competitor_ideas:
         return "No ideas found. Try running with a different focus keyword."
 
-    # Number emojis for up to 9 options (3 ideas x 3 titles)
-    number_emojis = [
-        "1\ufe0f\u20e3", "2\ufe0f\u20e3", "3\ufe0f\u20e3",
-        "4\ufe0f\u20e3", "5\ufe0f\u20e3", "6\ufe0f\u20e3",
-        "7\ufe0f\u20e3", "8\ufe0f\u20e3", "9\ufe0f\u20e3",
+    # Letter emojis for A-Z options (extends beyond 9)
+    letter_emojis = [
+        "\U0001F1E6", "\U0001F1E7", "\U0001F1E8", "\U0001F1E9", "\U0001F1EA",  # A-E
+        "\U0001F1EB", "\U0001F1EC", "\U0001F1ED", "\U0001F1EE", "\U0001F1EF",  # F-J
+        "\U0001F1F0", "\U0001F1F1", "\U0001F1F2", "\U0001F1F3", "\U0001F1F4",  # K-O
+        "\U0001F1F5", "\U0001F1F6", "\U0001F1F7", "\U0001F1F8", "\U0001F1F9",  # P-T
     ]
 
-    lines = ["*Discovery Scanner Results*\n"]
-    option_num = 0  # Running count across all ideas
+    lines = []
+    option_num = 0  # Running count across ALL ideas (both sections)
 
-    for i, idea in enumerate(ideas, 1):
-        appeal = idea.get("estimated_appeal", "?")
-        source = idea.get("headline_source", "Unknown source")
+    # === NEWS IDEAS SECTION ===
+    if news_ideas:
+        lines.append("*" + "=" * 40 + "*")
+        lines.append("*NEWS IDEAS* (from world headlines)")
+        lines.append("*" + "=" * 40 + "*\n")
 
-        lines.append(f"*--- Idea {i} ---* (Appeal: {appeal}/10)")
-        lines.append(f"_{source}_\n")
+        for i, idea in enumerate(news_ideas, 1):
+            appeal = idea.get("estimated_appeal", "?")
+            source = idea.get("headline_source", "Unknown source")
 
-        # Each title option gets its own selectable number
-        for j, title_opt in enumerate(idea.get("title_options", []), 1):
-            if option_num < len(number_emojis):
-                emoji = number_emojis[option_num]
-            else:
-                emoji = f"({option_num + 1})"
-            formula_id = title_opt.get("formula_id", "?")
-            title = title_opt.get("title", "Untitled")
-            thumbnail = title_opt.get("thumbnail_text", "")
-            lines.append(f"{emoji}  *{title}*")
-            thumb_display = f" | Thumbnail: {thumbnail}" if thumbnail else ""
-            lines.append(f"      _Formula: {formula_id}{thumb_display}_")
-            option_num += 1
+            lines.append(f"*--- News {i} ---* (Appeal: {appeal}/10)")
+            lines.append(f"_{source}_\n")
 
-        lines.append("")
+            # Each title option gets its own selectable letter
+            for j, title_opt in enumerate(idea.get("title_options", []), 1):
+                if option_num < len(letter_emojis):
+                    emoji = letter_emojis[option_num]
+                else:
+                    emoji = f"({option_num + 1})"
+                formula_id = title_opt.get("formula_id", "?")
+                title = title_opt.get("title", "Untitled")
+                thumbnail = title_opt.get("thumbnail_text", "")
+                lines.append(f"{emoji}  *{title}*")
+                thumb_display = f" | {thumbnail}" if thumbnail else ""
+                lines.append(f"      _Formula: {formula_id}{thumb_display}_")
+                option_num += 1
 
-        # Hook
-        hook = idea.get("hook", "")
-        if hook:
-            lines.append(f"  *Hook:* {hook}")
+            lines.append("")
 
-        # Angle
-        angle = idea.get("our_angle", "")
-        if angle:
-            lines.append(f"  *Angle:* {angle}")
+            # Hook (truncated)
+            hook = idea.get("hook", "")
+            if hook:
+                lines.append(f"  *Hook:* {hook[:150]}...")
 
-        # Framework
-        framework = idea.get("framework", "")
-        if framework:
-            lines.append(f"  *Framework:* {framework}")
+            lines.append("\n" + "-" * 40 + "\n")
 
-        # Historical parallel hint
-        parallel = idea.get("historical_parallel_hint", "")
-        if parallel:
-            lines.append(f"  *Parallel:* {parallel}")
+    # === COMPETITOR IDEAS SECTION ===
+    if competitor_ideas:
+        lines.append("*" + "=" * 40 + "*")
+        lines.append("*COMPETITOR IDEAS* (proven performers)")
+        lines.append("*" + "=" * 40 + "*\n")
 
-        lines.append("\n" + "-" * 40 + "\n")
+        for i, idea in enumerate(competitor_ideas, 1):
+            comp_title = idea.get("competitor_title", "Unknown")
+            comp_channel = idea.get("competitor_channel", "?")
+            comp_views = idea.get("competitor_views", 0)
+            comp_vph = idea.get("competitor_vph", 0)
+            comp_url = idea.get("competitor_url", "")
+            appeal = idea.get("estimated_appeal", "?")
 
+            lines.append(f"*--- Competitor {i} ---* (Appeal: {appeal}/10)")
+            lines.append(f"_Original:_ \"{comp_title}\"")
+            lines.append(f"_Channel:_ {comp_channel} | {comp_views:,} views | {comp_vph:.0f} VPH")
+            if comp_url:
+                lines.append(f"_Link:_ {comp_url}")
+            lines.append("")
+
+            # Our MF title options
+            lines.append("*Our Angles:*")
+            for j, title_opt in enumerate(idea.get("title_options", []), 1):
+                if option_num < len(letter_emojis):
+                    emoji = letter_emojis[option_num]
+                else:
+                    emoji = f"({option_num + 1})"
+                formula_id = title_opt.get("formula_id", "?")
+                title = title_opt.get("title", "Untitled")
+                thumbnail = title_opt.get("thumbnail_text", "")
+                lines.append(f"{emoji}  *{title}*")
+                thumb_display = f" | {thumbnail}" if thumbnail else ""
+                lines.append(f"      _Formula: {formula_id}{thumb_display}_")
+                option_num += 1
+
+            lines.append("")
+
+            # Our angle
+            angle = idea.get("our_angle", "")
+            if angle:
+                lines.append(f"  *Angle:* {angle[:150]}...")
+
+            lines.append("\n" + "-" * 40 + "\n")
+
+    # Instructions
+    news_count = len(news_ideas)
+    comp_count = len(competitor_ideas)
     lines.append(
-        f"React with a number to pick your idea *and* title.\n"
-        f"I'll auto-research it and queue it for the pipeline."
+        f"*{news_count} news ideas + {comp_count} competitor ideas*\n"
+        f"React with a letter to pick your idea. "
+        f"I'll auto-research it and queue it for the 12 PM pipeline run."
     )
 
     return "\n".join(lines)
 
 
-def build_option_map(ideas: list[dict]) -> list[dict]:
-    """Build a flat list mapping option numbers to (idea_index, title_index).
+def build_option_map(result: dict) -> list[dict]:
+    """Build a flat list mapping option indices to idea + title combinations.
 
     Used by both the Slack bot and cron discovery to map emoji reactions
-    to the correct idea + title combination.
+    to the correct idea + title combination. Handles both news and competitor ideas.
 
     Args:
-        ideas: List of idea dicts from discovery scanner
+        result: Full result dict from DiscoveryScanner.scan() with 'ideas' and 'competitor_ideas'
 
     Returns:
-        List of dicts with 'idea_index', 'title_index', 'idea', 'title'
+        List of dicts with 'idea_index', 'title_index', 'idea', 'title', 'source_type'
     """
     options = []
-    for i, idea in enumerate(ideas):
+
+    # Process news ideas first
+    news_ideas = result.get("ideas", [])
+    for i, idea in enumerate(news_ideas):
         for j, title_opt in enumerate(idea.get("title_options", [])):
             options.append({
                 "idea_index": i,
@@ -572,7 +926,26 @@ def build_option_map(ideas: list[dict]) -> list[dict]:
                 "title": title_opt.get("title", "Untitled"),
                 "formula_id": title_opt.get("formula_id", ""),
                 "thumbnail_text": title_opt.get("thumbnail_text", ""),
+                "source_type": "news",
             })
+
+    # Process competitor ideas
+    competitor_ideas = result.get("competitor_ideas", [])
+    for i, idea in enumerate(competitor_ideas):
+        for j, title_opt in enumerate(idea.get("title_options", [])):
+            options.append({
+                "idea_index": i,
+                "title_index": j,
+                "idea": idea,
+                "title": title_opt.get("title", "Untitled"),
+                "formula_id": title_opt.get("formula_id", ""),
+                "thumbnail_text": title_opt.get("thumbnail_text", ""),
+                "source_type": "competitor",
+                "competitor_title": idea.get("competitor_title", ""),
+                "competitor_url": idea.get("competitor_url", ""),
+                "competitor_channel": idea.get("competitor_channel", ""),
+            })
+
     return options
 
 
@@ -679,6 +1052,7 @@ def build_idea_record_from_discovery(
     idea_number: int = 1,
     title_override: str = "",
     thumbnail_text_override: str = "",
+    source_type: str = "news",
 ) -> dict:
     """Build a full Airtable record from a discovery scanner idea.
 
@@ -688,11 +1062,14 @@ def build_idea_record_from_discovery(
     Uses the title scoring system to pick the best title from the options
     (highest score wins, falling back to first option if no scores).
 
+    Handles both news ideas (from headlines) and competitor ideas (from YouTube).
+
     Args:
         idea: Single idea dict from discovery scanner output
-        idea_number: Which idea was selected (1, 2, or 3)
+        idea_number: Which idea was selected
         title_override: If set, use this title instead of auto-selecting
         thumbnail_text_override: If set, use this thumbnail text instead of auto-selecting
+        source_type: "news" or "competitor" to indicate idea source
 
     Returns:
         Dict ready for AirtableClient.create_idea()
@@ -721,9 +1098,27 @@ def build_idea_record_from_discovery(
     # Extract appeal scores
     appeal_breakdown = idea.get("appeal_breakdown", {})
 
-    # Build source URLs from headline_source
-    headline_source = idea.get("headline_source", "")
-    source_urls = headline_source  # includes source publication and URL if available
+    # Handle different source types
+    is_competitor = source_type == "competitor" or idea.get("source_type") == "competitor"
+
+    if is_competitor:
+        # Competitor idea - use competitor fields
+        headline_source = idea.get("competitor_title", "")
+        source_urls = idea.get("competitor_url", "")
+        reference_url = idea.get("competitor_url", "")
+        source_channel = idea.get("competitor_channel", "")
+        source_views = idea.get("competitor_views", 0)
+        source_vph = idea.get("competitor_vph", 0)
+        dna_source = "competitor_scanner"
+    else:
+        # News idea - use headline fields
+        headline_source = idea.get("headline_source", "")
+        source_urls = headline_source
+        reference_url = ""
+        source_channel = ""
+        source_views = 0
+        source_vph = 0
+        dna_source = "discovery_scanner"
 
     record = {
         "viral_title": best_title or f"Discovery Idea {idea_number}",
@@ -750,14 +1145,29 @@ def build_idea_record_from_discovery(
         "Title Candidates": json.dumps(title_options) if title_options else "",
         # Store full discovery data as Original DNA for downstream use
         "original_dna": json.dumps({
-            "source": "discovery_scanner",
+            "source": dna_source,
             "idea_number": idea_number,
             "title_options": title_options,
             "appeal_breakdown": appeal_breakdown,
             "historical_parallel_hint": idea.get("historical_parallel_hint", ""),
             "headline_source": headline_source,
+            # Competitor-specific fields
+            "competitor_title": idea.get("competitor_title", "") if is_competitor else "",
+            "competitor_url": idea.get("competitor_url", "") if is_competitor else "",
+            "competitor_channel": idea.get("competitor_channel", "") if is_competitor else "",
+            "competitor_views": source_views,
+            "competitor_vph": source_vph,
         }),
     }
+
+    # Add reference URL for competitor ideas
+    if reference_url:
+        record["reference_url"] = reference_url
+
+    # Add source channel and views for competitor ideas
+    if is_competitor:
+        record["Source Channel"] = source_channel
+        record["Source Views"] = source_views
 
     return record
 

--- a/skills/video-pipeline/pipeline.py
+++ b/skills/video-pipeline/pipeline.py
@@ -4938,7 +4938,7 @@ async def main():
         )
         return
 
-    # === DISCOVERY SCANNER ===
+    # === DISCOVERY SCANNER (News + Competitors) ===
     if len(sys.argv) > 1 and sys.argv[1] == "--discover":
         from discovery_scanner import run_discovery, format_ideas_for_slack, build_option_map, build_idea_record_from_discovery
         from discovery_tracker import save_discovery_message
@@ -4947,20 +4947,23 @@ async def main():
         focus_msg = f" (focus: {focus})" if focus else ""
 
         print("=" * 60)
-        print(f"🔍 DISCOVERY SCANNER — Scanning headlines{focus_msg}")
+        print(f"🔍 DISCOVERY SCANNER — Headlines + Competitors{focus_msg}")
         print("=" * 60)
 
         try:
             result = await run_discovery(
                 anthropic_client=pipeline.anthropic,
+                apify_client=pipeline.apify,
+                airtable_client=pipeline.airtable,
                 focus=focus,
+                include_competitors=True,
             )
         except Exception as e:
             error_msg = f"Discovery scanner crashed: {e}"
             print(f"\n❌ {error_msg}")
             try:
                 pipeline.slack.send_message(
-                    f"❌ *5 AM Discovery Scan FAILED*\n"
+                    f"❌ *9 AM Discovery Scan FAILED*\n"
                     f"```{error_msg}```\n"
                     f"No ideas were generated. Run `discover` manually to retry."
                 )
@@ -4968,62 +4971,98 @@ async def main():
                 pass
             return
 
-        ideas = result.get("ideas", [])
-        if not ideas:
+        news_ideas = result.get("ideas", [])
+        competitor_ideas = result.get("competitor_ideas", [])
+        all_ideas = news_ideas + competitor_ideas
+
+        if not all_ideas:
             print("\n⚠️ No ideas found. Try with a different focus keyword.")
             try:
                 pipeline.slack.send_message(
-                    "🔍 *Daily Discovery Scan* ran at 5 AM but found no strong ideas today.\n"
+                    "🔍 *Daily Discovery Scan* ran at 9 AM but found no strong ideas today.\n"
                     "Try running `discover [focus]` manually with a specific topic."
                 )
             except Exception:
                 pass
             return
 
-        print(f"\nFound {len(ideas)} ideas:\n")
-        for i, idea in enumerate(ideas, 1):
-            title_opts = idea.get("title_options", [])
-            title = title_opts[0]["title"] if title_opts else "Untitled"
-            appeal = idea.get("estimated_appeal", "?")
-            print(f"  {i}. {title} (appeal: {appeal}/10)")
-            hook = idea.get("hook", "")
-            if hook:
-                print(f"     Hook: {hook[:120]}")
-            print()
+        # Print summary
+        print(f"\nFound {len(news_ideas)} news ideas + {len(competitor_ideas)} competitor ideas:\n")
 
-        # Save to Airtable
-        print("Saving to Airtable (Idea Concepts)...")
+        if news_ideas:
+            print("NEWS IDEAS:")
+            for i, idea in enumerate(news_ideas, 1):
+                title_opts = idea.get("title_options", [])
+                title = title_opts[0]["title"] if title_opts else "Untitled"
+                appeal = idea.get("estimated_appeal", "?")
+                print(f"  {i}. {title} (appeal: {appeal}/10)")
+
+        if competitor_ideas:
+            print("\nCOMPETITOR IDEAS:")
+            for i, idea in enumerate(competitor_ideas, 1):
+                title_opts = idea.get("title_options", [])
+                title = title_opts[0]["title"] if title_opts else "Untitled"
+                comp_title = idea.get("competitor_title", "?")[:50]
+                comp_vph = idea.get("competitor_vph", 0)
+                print(f"  {i}. {title}")
+                print(f"     From: \"{comp_title}...\" ({comp_vph:.0f} VPH)")
+
+        # Save ALL ideas to Airtable (both news and competitor)
+        print("\nSaving to Airtable (Idea Concepts)...")
         saved_record_ids = []
-        for i, idea in enumerate(ideas, 1):
-            idea_data = build_idea_record_from_discovery(idea, idea_number=i)
+
+        # Save news ideas
+        for i, idea in enumerate(news_ideas, 1):
+            idea_data = build_idea_record_from_discovery(idea, idea_number=i, source_type="news")
             title = idea_data.get("viral_title", "Untitled")
             try:
                 record = pipeline.airtable.create_idea(idea_data, source="discovery_scanner")
-                saved_record_ids.append(record.get("id"))
-                print(f"  ✅ Saved idea {i}: {record.get('id')} — {title}")
+                saved_record_ids.append({"id": record.get("id"), "type": "news"})
+                print(f"  ✅ [News {i}] {record.get('id')} — {title}")
             except Exception as e:
                 saved_record_ids.append(None)
-                print(f"  ❌ Failed to save idea {i}: {e}")
+                print(f"  ❌ [News {i}] Failed: {e}")
 
-        # Post interactive Slack message with emoji reactions for idea selection
-        # This lets the user wake up and click to choose an idea
-        # Always target production-agent channel — cron runs unattended so we
-        # can't rely on SLACK_CHANNEL_ID env var which may point elsewhere.
+        # Save competitor ideas
+        for i, idea in enumerate(competitor_ideas, 1):
+            idea_data = build_idea_record_from_discovery(idea, idea_number=i, source_type="competitor")
+            title = idea_data.get("viral_title", "Untitled")
+            try:
+                record = pipeline.airtable.create_idea(idea_data, source="competitor_scanner")
+                saved_record_ids.append({"id": record.get("id"), "type": "competitor"})
+                print(f"  ✅ [Competitor {i}] {record.get('id')} — {title}")
+            except Exception as e:
+                saved_record_ids.append(None)
+                print(f"  ❌ [Competitor {i}] Failed: {e}")
+
+        # Post interactive Slack message with letter emoji reactions
+        # Always target production-agent channel — cron runs unattended
         production_channel = SlackClient.DEFAULT_CHANNEL_ID
         try:
             slack_msg = (
                 "☀️ *Good Morning! Daily Discovery Scan Complete*\n"
-                "React with 1️⃣ 2️⃣ or 3️⃣ to approve an idea — I'll auto-research it and queue it for the 8 AM pipeline run.\n\n"
+                "React with a letter emoji to approve an idea — "
+                "I'll auto-research it and queue it for the 12 PM pipeline run.\n\n"
             )
             slack_msg += format_ideas_for_slack(result)
 
             response = pipeline.slack.send_message(slack_msg, production_channel)
             msg_ts = response["ts"]
 
-            # Build option map: one emoji per title option (idea + title)
-            option_map = build_option_map(ideas)
-            emoji_names = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
-            emojis_to_add = emoji_names[:len(option_map)]
+            # Build option map: one letter per title option (news + competitor)
+            option_map = build_option_map(result)
+
+            # Regional indicator letters A-T for emoji reactions
+            letter_emojis = [
+                "regional_indicator_a", "regional_indicator_b", "regional_indicator_c",
+                "regional_indicator_d", "regional_indicator_e", "regional_indicator_f",
+                "regional_indicator_g", "regional_indicator_h", "regional_indicator_i",
+                "regional_indicator_j", "regional_indicator_k", "regional_indicator_l",
+                "regional_indicator_m", "regional_indicator_n", "regional_indicator_o",
+                "regional_indicator_p", "regional_indicator_q", "regional_indicator_r",
+                "regional_indicator_s", "regional_indicator_t",
+            ]
+            emojis_to_add = letter_emojis[:len(option_map)]
 
             for emoji in emojis_to_add:
                 try:
@@ -5031,22 +5070,17 @@ async def main():
                 except Exception as e:
                     print(f"  ⚠️ Failed to add reaction {emoji}: {e}")
 
-            # Persist tracking data so the Slack bot (pipeline_control.py)
-            # can handle the reaction when the user clicks
-            save_discovery_message(msg_ts, ideas, saved_record_ids)
+            # Persist tracking data for the Slack bot to handle reactions
+            # Store the full result (with both news and competitor ideas)
+            save_discovery_message(msg_ts, all_ideas, [r.get("id") if r else None for r in saved_record_ids])
             print(f"\n✅ Interactive Slack message posted (ts={msg_ts})")
-            print(f"   {len(option_map)} options with emoji reactions — waiting for your choice!")
+            print(f"   {len(option_map)} options with letter reactions — waiting for your choice!")
 
         except Exception as e:
             print(f"\n❌ Slack notification FAILED: {e}")
             # Fallback: try a shorter plain message (no reactions/tracking)
             try:
-                # Send a compact version in case the full message was too long
-                short_msg = "☀️ *Discovery Scan Complete* — ideas saved to Airtable.\n"
-                for i, idea in enumerate(ideas, 1):
-                    title_opts = idea.get("title_options", [])
-                    title = title_opts[0]["title"] if title_opts else "Untitled"
-                    short_msg += f"{i}. {title}\n"
+                short_msg = f"☀️ *Discovery Scan Complete* — {len(news_ideas)} news + {len(competitor_ideas)} competitor ideas saved to Airtable.\n"
                 short_msg += "\nCheck Airtable to approve."
                 pipeline.slack.send_message(short_msg, production_channel)
                 print("   Sent short fallback message to Slack")

--- a/skills/video-pipeline/pipeline_control.py
+++ b/skills/video-pipeline/pipeline_control.py
@@ -1294,17 +1294,24 @@ async def handle_discover(message, say, client):
     channel = message.get("channel", "")
 
     focus_msg = f" (focus: {focus})" if focus else ""
-    await say(f":mag: Scanning headlines{focus_msg}... This may take a moment.")
+    await say(f":mag: Scanning headlines + competitors{focus_msg}... This may take a moment.")
 
     try:
         from clients.anthropic_client import AnthropicClient
+        from clients.airtable_client import AirtableClient
+        from clients.apify_client import ApifyYouTubeClient
         from discovery_scanner import run_discovery, format_ideas_for_slack, build_option_map
 
         anthropic = AnthropicClient()
+        airtable = AirtableClient()
+        apify = ApifyYouTubeClient() if os.getenv("APIFY_API_KEY") else None
 
         result = await run_discovery(
             anthropic_client=anthropic,
+            apify_client=apify,
+            airtable_client=airtable,
             focus=focus or None,
+            include_competitors=True,
         )
 
         slack_msg = format_ideas_for_slack(result)
@@ -1314,20 +1321,30 @@ async def handle_discover(message, say, client):
         ts = response.get("ts", "")
 
         if ts:
-            # Track this message for emoji reaction approval
-            _discovery_messages[ts] = result.get("ideas", [])
+            # Track this message for emoji reaction approval (store full result)
+            _discovery_messages[ts] = result
 
-            # Add one reaction emoji per title option (not per idea)
-            option_map = build_option_map(result.get("ideas", []))
-            emoji_names = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
-            emojis_to_add = emoji_names[:len(option_map)]
+            # Add letter reaction emojis for all options (news + competitor)
+            option_map = build_option_map(result)
+            letter_emojis = [
+                "regional_indicator_a", "regional_indicator_b", "regional_indicator_c",
+                "regional_indicator_d", "regional_indicator_e", "regional_indicator_f",
+                "regional_indicator_g", "regional_indicator_h", "regional_indicator_i",
+                "regional_indicator_j", "regional_indicator_k", "regional_indicator_l",
+                "regional_indicator_m", "regional_indicator_n", "regional_indicator_o",
+                "regional_indicator_p", "regional_indicator_q", "regional_indicator_r",
+                "regional_indicator_s", "regional_indicator_t",
+            ]
+            emojis_to_add = letter_emojis[:len(option_map)]
             for emoji in emojis_to_add:
                 try:
                     await client.reactions_add(channel=channel, name=emoji, timestamp=ts)
                 except Exception as e:
                     log.error(f"Failed to add reaction {emoji}: {e}")
 
-            log.info(f"Discovery posted: {len(option_map)} options across {len(result.get('ideas', []))} ideas, message_ts={ts}")
+            news_count = len(result.get("ideas", []))
+            comp_count = len(result.get("competitor_ideas", []))
+            log.info(f"Discovery posted: {len(option_map)} options ({news_count} news + {comp_count} competitor), message_ts={ts}")
 
     except Exception as e:
         await say(f":x: Discovery scan failed: {e}")
@@ -1425,10 +1442,20 @@ async def handle_reaction_added(event, client):
     channel = item.get("channel", "")
 
     # Map reaction emoji names to 0-based option index
+    # Support both old number emojis and new letter emojis (regional indicators)
     reaction_to_index = {
+        # Legacy number emojis (for backward compatibility)
         "one": 0, "two": 1, "three": 2,
         "four": 3, "five": 4, "six": 5,
         "seven": 6, "eight": 7, "nine": 8,
+        # New letter emojis (A-T for news + competitor ideas)
+        "regional_indicator_a": 0, "regional_indicator_b": 1, "regional_indicator_c": 2,
+        "regional_indicator_d": 3, "regional_indicator_e": 4, "regional_indicator_f": 5,
+        "regional_indicator_g": 6, "regional_indicator_h": 7, "regional_indicator_i": 8,
+        "regional_indicator_j": 9, "regional_indicator_k": 10, "regional_indicator_l": 11,
+        "regional_indicator_m": 12, "regional_indicator_n": 13, "regional_indicator_o": 14,
+        "regional_indicator_p": 15, "regional_indicator_q": 16, "regional_indicator_r": 17,
+        "regional_indicator_s": 18, "regional_indicator_t": 19,
     }
     if reaction not in reaction_to_index:
         return
@@ -1442,14 +1469,18 @@ async def handle_reaction_added(event, client):
 
     # Check in-memory tracking first (from Slack bot discover command)
     if item_ts in _discovery_messages:
-        ideas = _discovery_messages[item_ts]
-        option_map = build_option_map(ideas)
+        result = _discovery_messages[item_ts]
+        # Handle both old format (list) and new format (dict with ideas + competitor_ideas)
+        if isinstance(result, list):
+            result = {"ideas": result}
+        option_map = build_option_map(result)
         if option_index >= len(option_map):
             return
         selected = option_map[option_index]
+        source_type = selected.get("source_type", "news")
         log.info(
             f"Discovery reaction (in-memory): {reaction} from {user} "
-            f"on {item_ts} -> idea {selected['idea_index'] + 1}, title: {selected['title']}"
+            f"on {item_ts} -> {source_type} idea {selected['idea_index'] + 1}, title: {selected['title']}"
         )
         # Mark as processed BEFORE starting work (prevents race with double-click)
         mark_reaction_processed(item_ts, reaction, selected["title"])
@@ -1459,6 +1490,7 @@ async def handle_reaction_added(event, client):
             selected_title=selected["title"],
             selected_formula_id=selected.get("formula_id", ""),
             selected_thumbnail_text=selected.get("thumbnail_text", ""),
+            source_type=source_type,
         )
         return
 
@@ -1467,13 +1499,22 @@ async def handle_reaction_added(event, client):
     if tracked:
         ideas = tracked.get("ideas", [])
         airtable_ids = tracked.get("airtable_record_ids", [])
-        option_map = build_option_map(ideas)
+        # Reconstruct result dict for build_option_map
+        # Note: The cron job stores a flat list, so we need to handle the source_type per-idea
+        result = {"ideas": [], "competitor_ideas": []}
+        for idea in ideas:
+            if idea.get("source_type") == "competitor":
+                result["competitor_ideas"].append(idea)
+            else:
+                result["ideas"].append(idea)
+        option_map = build_option_map(result)
         if option_index >= len(option_map):
             return
         selected = option_map[option_index]
+        source_type = selected.get("source_type", "news")
         log.info(
             f"Discovery reaction (cron-tracked): {reaction} from {user} "
-            f"on {item_ts} -> idea {selected['idea_index'] + 1}, title: {selected['title']}"
+            f"on {item_ts} -> {source_type} idea {selected['idea_index'] + 1}, title: {selected['title']}"
         )
         # Mark as processed BEFORE starting work
         mark_reaction_processed(item_ts, reaction, selected["title"])
@@ -1483,6 +1524,7 @@ async def handle_reaction_added(event, client):
             selected_title=selected["title"],
             selected_formula_id=selected.get("formula_id", ""),
             selected_thumbnail_text=selected.get("thumbnail_text", ""),
+            source_type=source_type,
         )
         remove_discovery_message(item_ts)
         return
@@ -1493,6 +1535,7 @@ async def _handle_discovery_approval(
     selected_title: str = None,
     selected_formula_id: str = "",
     selected_thumbnail_text: str = "",
+    source_type: str = "news",
 ):
     """Approve a discovery idea and auto-trigger deep research.
 
@@ -1505,8 +1548,18 @@ async def _handle_discovery_approval(
         ts: Message timestamp of the discovery results
         idea_index: 0-based index of the chosen idea
         selected_title: Specific title chosen by user (if None, uses first title)
+        source_type: "news" or "competitor" to indicate idea source
     """
-    ideas = _discovery_messages.get(ts, [])
+    result = _discovery_messages.get(ts, {})
+    # Handle both old format (list) and new format (dict)
+    if isinstance(result, list):
+        ideas = result
+    else:
+        # Get ideas from correct list based on source_type
+        if source_type == "competitor":
+            ideas = result.get("competitor_ideas", [])
+        else:
+            ideas = result.get("ideas", [])
     if not ideas or idea_index >= len(ideas):
         log.warning(f"No ideas found for message ts={ts} index={idea_index}")
         return
@@ -1538,9 +1591,11 @@ async def _handle_discovery_approval(
             idea,
             title_override=title,
             thumbnail_text_override=selected_thumbnail_text,
+            source_type=source_type,
         )
 
-        record = airtable.create_idea(idea_data, source="discovery_scanner")
+        source_name = "competitor_scanner" if source_type == "competitor" else "discovery_scanner"
+        record = airtable.create_idea(idea_data, source=source_name)
         record_id = record["id"]
 
         # Set status to Approved
@@ -1608,6 +1663,7 @@ async def _handle_cron_discovery_approval(
     selected_title: str = None,
     selected_formula_id: str = "",
     selected_thumbnail_text: str = "",
+    source_type: str = "news",
 ):
     """Approve a discovery idea from the cron job's tracked messages.
 
@@ -1623,6 +1679,7 @@ async def _handle_cron_discovery_approval(
         ideas: List of idea dicts from discovery scanner
         airtable_record_ids: List of Airtable record IDs (parallel to ideas)
         selected_title: Specific title chosen by user (if None, uses first title)
+        source_type: "news" or "competitor" to indicate idea source
     """
     if not ideas or idea_index >= len(ideas):
         log.warning(f"No ideas found for cron message ts={ts} index={idea_index}")
@@ -1682,8 +1739,10 @@ async def _handle_cron_discovery_approval(
                 idea,
                 title_override=title,
                 thumbnail_text_override=selected_thumbnail_text,
+                source_type=source_type,
             )
-            record = airtable.create_idea(idea_data, source="discovery_scanner")
+            source_name = "competitor_scanner" if source_type == "competitor" else "discovery_scanner"
+            record = airtable.create_idea(idea_data, source=source_name)
             record_id = record["id"]
             airtable.update_idea_status(record_id, "Approved")
             if selected_formula_id:

--- a/skills/video-pipeline/setup_competitor_channels.py
+++ b/skills/video-pipeline/setup_competitor_channels.py
@@ -1,0 +1,191 @@
+"""
+Setup Competitor Channels Table in Airtable.
+
+Creates the Competitor Channels table with the required fields for
+competitor video scraping integration with the discovery scanner.
+
+Required fields:
+  - Channel Name (Single Line Text) - Name of the competitor channel
+  - Channel URL (URL) - YouTube channel URL
+  - Category (Single Select) - Channel category (e.g., Geopolitics, Finance, Economy)
+  - Active (Checkbox) - Include in discovery scraping
+  - Last Scraped (Date) - Auto-updated when channel is scraped
+  - Notes (Long Text) - Optional notes about the channel
+
+Usage:
+    1. Create the table manually in Airtable with name "Competitor Channels"
+    2. Add the table ID to .env as AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID
+    3. Run this script to verify the setup
+
+    python setup_competitor_channels.py
+
+Or just verify manually that your table has these columns.
+
+Example competitor channels to add:
+  - CaspianReport (https://www.youtube.com/@CaspianReport) - Geopolitics
+  - AiTelly (https://www.youtube.com/@AiTelly) - Geopolitics/Finance
+  - PolyMatter (https://www.youtube.com/@PolyMatter) - Economics
+  - Economics Explained (https://www.youtube.com/@EconomicsExplained) - Economics
+  - TLDR News (https://www.youtube.com/@TLDRNews) - Current Events
+"""
+
+import os
+import sys
+from datetime import date
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def verify_setup():
+    """Verify Competitor Channels table is set up correctly."""
+    from clients.airtable_client import AirtableClient
+
+    print("=" * 60)
+    print("COMPETITOR CHANNELS TABLE SETUP")
+    print("=" * 60)
+
+    # Check env var
+    table_id = os.getenv("AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID")
+    if not table_id or table_id == "tblXXXXXXXXXXXXXX":
+        print("\n  ERROR: AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID not set in .env")
+        print("\n  To fix:")
+        print("    1. Create a table called 'Competitor Channels' in your Airtable base")
+        print("    2. Copy the table ID from the URL (starts with 'tbl')")
+        print("    3. Add to .env: AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID=tblYOUR_TABLE_ID")
+        print("\n  Required columns:")
+        print("    - Channel Name (Single Line Text)")
+        print("    - Channel URL (URL)")
+        print("    - Category (Single Select: Geopolitics, Finance, Economy, Tech)")
+        print("    - Active (Checkbox)")
+        print("    - Last Scraped (Date)")
+        print("    - Notes (Long Text)")
+        return False
+
+    print(f"\n  Table ID: {table_id}")
+
+    try:
+        airtable = AirtableClient()
+
+        # Try to fetch channels
+        channels = airtable.get_active_competitor_channels()
+        print(f"\n  Found {len(channels)} active competitor channels")
+
+        if channels:
+            print("\n  Active channels:")
+            for ch in channels:
+                name = ch.get("Channel Name", "?")
+                url = ch.get("Channel URL", "?")
+                category = ch.get("Category", "?")
+                last_scraped = ch.get("Last Scraped", "Never")
+                print(f"    - {name} ({category}) - Last scraped: {last_scraped}")
+                print(f"      {url}")
+        else:
+            print("\n  No active channels found. Add some channels to get started:")
+            print("    1. Go to your Competitor Channels table in Airtable")
+            print("    2. Add competitor channel URLs")
+            print("    3. Check the 'Active' checkbox for channels to include")
+
+        # Try to update Last Scraped (tests write access)
+        if channels:
+            test_record = channels[0]
+            print(f"\n  Testing write access with '{test_record.get('Channel Name')}'...")
+            try:
+                airtable.update_channel_last_scraped(test_record["id"])
+                print("    Write access: OK")
+            except Exception as e:
+                print(f"    Write access: FAILED - {e}")
+
+        print("\n  SETUP VERIFIED")
+        return True
+
+    except Exception as e:
+        print(f"\n  ERROR: {e}")
+        print("\n  Make sure:")
+        print("    1. The table exists in your Airtable base")
+        print("    2. The table ID is correct")
+        print("    3. All required fields are created")
+        return False
+
+
+def add_sample_channels():
+    """Add sample competitor channels (for testing)."""
+    from clients.airtable_client import AirtableClient
+
+    sample_channels = [
+        {
+            "Channel Name": "CaspianReport",
+            "Channel URL": "https://www.youtube.com/@CaspianReport",
+            "Category": "Geopolitics",
+            "Active": True,
+            "Notes": "1.8M subs, documentary-style geopolitical analysis",
+        },
+        {
+            "Channel Name": "AiTelly",
+            "Channel URL": "https://www.youtube.com/@AiTelly",
+            "Category": "Geopolitics",
+            "Active": True,
+            "Notes": "2M subs, military/geopolitical analysis",
+        },
+        {
+            "Channel Name": "Economics Explained",
+            "Channel URL": "https://www.youtube.com/@EconomicsExplained",
+            "Category": "Economy",
+            "Active": True,
+            "Notes": "2.5M subs, economics explainers",
+        },
+        {
+            "Channel Name": "PolyMatter",
+            "Channel URL": "https://www.youtube.com/@PolyMatter",
+            "Category": "Economy",
+            "Active": True,
+            "Notes": "2M subs, business/economics analysis",
+        },
+        {
+            "Channel Name": "TLDR News Global",
+            "Channel URL": "https://www.youtube.com/@TLDRNewsGlobal",
+            "Category": "Geopolitics",
+            "Active": True,
+            "Notes": "1.5M subs, current events explainers",
+        },
+    ]
+
+    print("\n  Adding sample competitor channels...")
+
+    airtable = AirtableClient()
+
+    for channel in sample_channels:
+        try:
+            airtable.competitor_channels_table.create(channel, typecast=True)
+            print(f"    Added: {channel['Channel Name']}")
+        except Exception as e:
+            if "DUPLICATE_VALUE" in str(e) or "already exists" in str(e).lower():
+                print(f"    Skipped (exists): {channel['Channel Name']}")
+            else:
+                print(f"    Failed: {channel['Channel Name']} - {e}")
+
+    print("\n  Done adding sample channels")
+
+
+if __name__ == "__main__":
+    if "--add-samples" in sys.argv:
+        add_sample_channels()
+    else:
+        success = verify_setup()
+
+        if not success:
+            sys.exit(1)
+
+        if len(sys.argv) > 1 and sys.argv[1] == "--verbose":
+            print("\n" + "=" * 60)
+            print("COLUMN REFERENCE")
+            print("=" * 60)
+            print("""
+  Channel Name     | Single Line Text | Name of the channel
+  Channel URL      | URL              | YouTube channel URL
+  Category         | Single Select    | Geopolitics, Finance, Economy, Tech
+  Active           | Checkbox         | Include in discovery scraping
+  Last Scraped     | Date             | Auto-updated when scraped
+  Notes            | Long Text        | Optional notes
+            """)

--- a/skills/video-pipeline/setup_cron.sh
+++ b/skills/video-pipeline/setup_cron.sh
@@ -50,22 +50,22 @@ SYS_TZ=$(cat /etc/timezone 2>/dev/null || timedatectl show --property=Timezone -
 # Check if system timezone is Pacific — if so, use times as-is
 if echo "$SYS_TZ" | grep -qiE "america/los_angeles|US/Pacific"; then
     TZ_MODE="pacific"
-    DISCOVER_HOUR=5
+    DISCOVER_HOUR=9
     PERF_HOUR=7
-    QUEUE_HOUR=8
+    QUEUE_HOUR=12
 elif echo "$SYS_TZ" | grep -qiE "UTC|Etc/UTC|Etc/GMT"; then
     TZ_MODE="utc"
     # Pacific to UTC: PST = UTC-8, PDT = UTC-7
     # Use PST offsets (conservative — jobs run 1h later in summer)
-    DISCOVER_HOUR=13   # 5 AM PT = 1 PM UTC (PST)
+    DISCOVER_HOUR=17   # 9 AM PT = 5 PM UTC (PST)
     PERF_HOUR=15       # 7 AM PT = 3 PM UTC (PST)
-    QUEUE_HOUR=16      # 8 AM PT = 4 PM UTC (PST)
+    QUEUE_HOUR=20      # 12 PM PT = 8 PM UTC (PST)
 else
     # Unknown timezone — default to UTC offsets and warn
     TZ_MODE="other ($SYS_TZ)"
-    DISCOVER_HOUR=13
+    DISCOVER_HOUR=17
     PERF_HOUR=15
-    QUEUE_HOUR=16
+    QUEUE_HOUR=20
 fi
 
 echo "=================================================="
@@ -105,22 +105,18 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # TZ for log timestamps — shows Pacific time in logs regardless of system tz
 TZ=America/Los_Angeles
 
-# $DISCOVER_HOUR:00 (~5 AM PT) — Daily idea discovery scan
-# Finds new video ideas and posts interactive Slack message for approval
-# Timeout: 10 min max | Lock expires after 15 min
-0 $DISCOVER_HOUR * * * MAX_LOCK_AGE=900 $WRAPPER discovery /tmp/pipeline-discover.log timeout 600 python pipeline.py --discover
-
-# $DISCOVER_HOUR:30 (~5:30 AM PT) — Daily competitor channel scraper
-# Scrapes competitor YouTube channels, identifies winners by VPH, generates modeled ideas
-# Timeout: 10 min max | Lock expires after 15 min
-30 $DISCOVER_HOUR * * * MAX_LOCK_AGE=900 $WRAPPER competitors /tmp/pipeline-competitors.log timeout 600 python pipeline.py --competitors
+# $DISCOVER_HOUR:00 (~9 AM PT) — Daily idea discovery scan
+# Scans world news headlines + competitor top performers (50/50 split)
+# Posts interactive Slack message with both idea types for approval
+# Timeout: 15 min max | Lock expires after 20 min (includes competitor scrape)
+0 $DISCOVER_HOUR * * * MAX_LOCK_AGE=1200 $WRAPPER discovery /tmp/pipeline-discover.log timeout 900 python pipeline.py --discover
 
 # $PERF_HOUR:00 (~7 AM PT) — Daily YouTube performance tracker
 # Syncs YouTube metrics (views, CTR, retention, snapshots) to Airtable
 # Timeout: 10 min max | Lock expires after 15 min
 0 $PERF_HOUR * * * MAX_LOCK_AGE=900 $WRAPPER performance /tmp/performance-tracker.log timeout 600 python performance_tracker.py --recent
 
-# $QUEUE_HOUR:00 (~8 AM PT) — Daily pipeline queue run
+# $QUEUE_HOUR:00 (~12 PM PT) — Daily pipeline queue run
 # Processes all stages: Script → Voice → Image Prompts → Images → Thumbnail → Render → Upload
 # Timeout: 4 hours max | Lock expires after 5 hours
 0 $QUEUE_HOUR * * * MAX_LOCK_AGE=18000 $WRAPPER pipeline-queue /tmp/pipeline-queue.log timeout 14400 python pipeline.py --run-queue
@@ -149,18 +145,18 @@ fi
 echo "  Cron jobs installed!"
 echo ""
 echo "  Scheduled (system time $SYS_TZ → ~Pacific equivalent):"
-echo "    $DISCOVER_HOUR:00 daily (~5 AM PT) ->  Discovery scan (post ideas to Slack)"
-echo "    $PERF_HOUR:00 daily (~7 AM PT)     ->  YouTube performance tracker (sync analytics)"
-echo "    $QUEUE_HOUR:00 daily (~8 AM PT)    ->  Pipeline queue (process all stages to render)"
-echo "    Every 15 min            ->  Bot health check (auto-restart if down)"
-echo "    Every 30 min            ->  Approval watcher (catch manual approvals)"
+echo "    $DISCOVER_HOUR:00 daily (~9 AM PT)  ->  Discovery scan (news + competitors → Slack)"
+echo "    $PERF_HOUR:00 daily (~7 AM PT)      ->  YouTube performance tracker (sync analytics)"
+echo "    $QUEUE_HOUR:00 daily (~12 PM PT)    ->  Pipeline queue (process all stages to render)"
+echo "    Every 15 min             ->  Bot health check (auto-restart if down)"
+echo "    Every 30 min             ->  Approval watcher (catch manual approvals)"
 echo ""
 echo "  Failure alerts:"
 echo "    All jobs (except healthcheck) send Slack notifications on failure."
 echo "    Check your Slack channel if you don't see morning activity."
 echo ""
 echo "  Timeouts:"
-echo "    Discovery:    10 min max"
+echo "    Discovery:    15 min max (includes competitor scrape)"
 echo "    Performance:  10 min max"
 echo "    Pipeline:     4 hours max"
 echo "    Approval:     10 min max"


### PR DESCRIPTION
## Summary

- Discovery scanner now fetches **both** world news headlines AND competitor top-performing videos in parallel (50/50 split)
- Updated cron schedule: discovery **9 AM PST**, pipeline **12 PM PST**
- Competitor videos filtered to past 7 days with VPH >= 50
- Generates MF titles for competitor videos via Claude
- Slack message shows two sections: **NEWS IDEAS** and **COMPETITOR IDEAS**
- Uses letter emojis (A-T) instead of numbers to support more options

## Files Changed

| File | Change |
|------|--------|
| `discovery_scanner.py` | Added competitor scanning, parallel execution, new Slack format |
| `pipeline.py` | Updated `--discover` to pass apify/airtable clients |
| `pipeline_control.py` | Added letter emoji support, source_type tracking |
| `setup_cron.sh` | Discovery 9 AM, pipeline 12 PM, removed separate competitor cron |
| `setup_competitor_channels.py` | New setup script for Airtable table |
| `airtable-schema.md` | Documented Competitor Channels table |
| `.env.example` | Added AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID |

## Setup Required

1. Create "Competitor Channels" table in Airtable with columns:
   - Channel Name (Single Line Text)
   - Channel URL (URL)
   - Category (Single Select)
   - Active (Checkbox)
   - Last Scraped (Date)
   - Notes (Long Text)
2. Set `AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID` in `.env`
3. Add competitor channels and check Active
4. Deploy cron changes: `bash setup_cron.sh`

## Test plan

- [ ] Run `python setup_competitor_channels.py` to verify table setup
- [ ] Run `python pipeline.py --discover` to test combined scanner
- [ ] Verify Slack message shows both NEWS and COMPETITOR sections
- [ ] Test emoji reactions (letter emojis A-T)
- [ ] Deploy cron changes on VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)