### PR TITLE
Osiris Phase 1: Competitor video scraper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ AIRTABLE_SCRIPT_TABLE_ID=tbluGSepeZNgb0NxG
 # Create this table with columns: Channel Name, Channel URL, Category, Active, Last Scraped, Notes
 AIRTABLE_COMPETITOR_CHANNELS_TABLE_ID=tblXXXXXXXXXXXXXX
 
+# Competitor Videos table — Osiris training data (ALL scraped videos, not just winners)
+# Persists every video for long-term topic/title performance analysis
+# Create this table with columns: Video ID, Title, URL, Channel, Views, VPH, Published Date, Scrape Date, Modeled
+AIRTABLE_COMPETITOR_VIDEOS_TABLE_ID=tblXXXXXXXXXXXXXX
+
 # ============================================
 # GOOGLE (Drive & Docs)
 # ============================================

--- a/docs/airtable-schema.md
+++ b/docs/airtable-schema.md
@@ -72,6 +72,31 @@ Example channels to add:
 - Economics Explained (2.5M subs) — Economy
 - PolyMatter (2M subs) — Economy
 
+## Competitor Videos Table (Osiris Training Data)
+
+Stores ALL scraped competitor videos (not just winners) for long-term performance analysis. This is Osiris's training data — after 3 months you'll have thousands of videos with VPH scores showing which topics/titles perform best in your niche.
+
+Required fields:
+- `Video ID` (Single Line Text) — YouTube video ID (used for deduplication)
+- `Title` (Single Line Text) — Video title
+- `URL` (URL) — Full YouTube video URL
+- `Channel` (Single Line Text) — Channel name
+- `Channel URL` (URL) — Channel URL
+- `Views` (Number) — View count at scrape time
+- `VPH` (Number, decimal) — Views per hour at scrape time
+- `Hours Old` (Number, decimal) — Age in hours when scraped
+- `Published Date` (Date) — Video publish date
+- `Scrape Date` (Date) — When we scraped this video
+- `Modeled` (Checkbox) — Whether we've created an idea from this video
+- `Our Video` (Single Line Text) — Title of our video if we modeled it (optional)
+- `Topic Cluster` (Single Select) — Auto-categorized topic (Phase 2, optional)
+
+Setup:
+1. Create the table in Airtable with name "Competitor Videos"
+2. Add the fields above
+3. Set `AIRTABLE_COMPETITOR_VIDEOS_TABLE_ID` in `.env` to the table ID
+4. Run `python -m osiris.competitor_scraper --dry-run` to verify setup
+
 ## Known Schema Issues (See ANIMATION_SYSTEM_REVIEW.md Feature 4)
 
 - **CRITICAL**: Tables joined by string matching (`Title` = `Video Title`), NOT linked records. Typos break relationships.

--- a/skills/video-pipeline/clients/airtable_client.py
+++ b/skills/video-pipeline/clients/airtable_client.py
@@ -184,6 +184,9 @@ class AirtableClient:
     # Competitor Channels — tracks competitor YouTube channels for scraping
     COMPETITOR_CHANNELS_TABLE_ID = "tblXXXXXXXXXXXXXX"  # Set in .env after table creation
 
+    # Competitor Videos — Osiris training data (all scraped videos, not just winners)
+    COMPETITOR_VIDEOS_TABLE_ID = "tblXXXXXXXXXXXXXX"  # Set in .env after table creation
+
     def __init__(self, api_key: Optional[str] = None, base_id: Optional[str] = None):
         self.api_key = api_key or os.getenv("AIRTABLE_API_KEY")
         if not self.api_key:
@@ -204,6 +207,7 @@ class AirtableClient:
         self._script_table = None
         self._images_table = None
         self._competitor_channels_table = None
+        self._competitor_videos_table = None
 
     @property
     def idea_concepts_table(self) -> Table:
@@ -554,6 +558,142 @@ class AirtableClient:
             typecast=True,
         )
         return {"id": record["id"], **record["fields"]}
+
+    # ==================== COMPETITOR VIDEOS TABLE (Osiris) ====================
+
+    @property
+    def competitor_videos_table(self) -> Table:
+        """Get the Competitor Videos table (Osiris training data)."""
+        if self._competitor_videos_table is None:
+            table_id = os.getenv(
+                "AIRTABLE_COMPETITOR_VIDEOS_TABLE_ID",
+                self.COMPETITOR_VIDEOS_TABLE_ID,
+            )
+            self._competitor_videos_table = self.api.table(self.base_id, table_id)
+        return self._competitor_videos_table
+
+    def get_all_competitor_video_ids(self) -> set[str]:
+        """Get all video IDs from Competitor Videos table for deduplication.
+
+        Returns:
+            Set of YouTube video IDs already in the table.
+        """
+        try:
+            records = self.competitor_videos_table.all(
+                fields=["Video ID"],
+            )
+            return {r["fields"].get("Video ID") for r in records if r["fields"].get("Video ID")}
+        except Exception as e:
+            print(f"    ⚠️ Could not fetch existing video IDs: {e}")
+            return set()
+
+    def create_competitor_video(self, video_data: dict) -> dict:
+        """Create a new competitor video record in the Osiris training table.
+
+        Args:
+            video_data: Dict with video fields from Apify scrape + VPH calculation:
+                - video_id: YouTube video ID (required, used for deduplication)
+                - title: Video title
+                - url: Full YouTube URL
+                - channel: Channel name
+                - channel_url: Channel URL
+                - views: View count at scrape time
+                - vph: Views per hour
+                - hours_old: Age in hours
+                - published_at: ISO date string
+
+        Returns:
+            Created record dict with id + fields
+        """
+        from datetime import date
+
+        fields = {
+            "Video ID": video_data.get("video_id", ""),
+            "Title": video_data.get("title", ""),
+            "URL": video_data.get("url", ""),
+            "Channel": video_data.get("channel", ""),
+            "Channel URL": video_data.get("channel_url", ""),
+            "Views": video_data.get("views", 0),
+            "VPH": round(video_data.get("vph", 0), 1),
+            "Hours Old": round(video_data.get("hours_old", 0), 1),
+            "Published Date": video_data.get("published_at", "")[:10] if video_data.get("published_at") else "",
+            "Scrape Date": date.today().isoformat(),
+            "Modeled": False,
+        }
+
+        try:
+            record = self.competitor_videos_table.create(fields, typecast=True)
+            return {"id": record["id"], **record["fields"]}
+        except Exception as e:
+            error_msg = str(e)
+            if "UNKNOWN_FIELD_NAME" not in error_msg:
+                raise
+            # Graceful degradation: drop unknown field and retry
+            bad_field = self._extract_bad_field(error_msg)
+            if bad_field and bad_field in fields:
+                print(f"    ⚠️ Field '{bad_field}' not in Competitor Videos table, dropping it")
+                del fields[bad_field]
+                record = self.competitor_videos_table.create(fields, typecast=True)
+                return {"id": record["id"], **record["fields"]}
+            raise
+
+    def batch_create_competitor_videos(self, videos: list[dict]) -> list[dict]:
+        """Batch create competitor video records (more efficient than individual creates).
+
+        Uses Airtable batch API for efficiency (up to 10 records per call).
+
+        Args:
+            videos: List of video data dicts (same format as create_competitor_video)
+
+        Returns:
+            List of created record dicts
+        """
+        from datetime import date
+
+        if not videos:
+            return []
+
+        # Build field dicts for all videos
+        records_to_create = []
+        today = date.today().isoformat()
+
+        for video_data in videos:
+            fields = {
+                "Video ID": video_data.get("video_id", ""),
+                "Title": video_data.get("title", ""),
+                "URL": video_data.get("url", ""),
+                "Channel": video_data.get("channel", ""),
+                "Channel URL": video_data.get("channel_url", ""),
+                "Views": video_data.get("views", 0),
+                "VPH": round(video_data.get("vph", 0), 1),
+                "Hours Old": round(video_data.get("hours_old", 0), 1),
+                "Published Date": video_data.get("published_at", "")[:10] if video_data.get("published_at") else "",
+                "Scrape Date": today,
+                "Modeled": False,
+            }
+            records_to_create.append({"fields": fields})
+
+        # Use batch_create (handles chunking into groups of 10)
+        try:
+            created = self.competitor_videos_table.batch_create(
+                [r["fields"] for r in records_to_create],
+                typecast=True,
+            )
+            return [{"id": r["id"], **r["fields"]} for r in created]
+        except Exception as e:
+            error_msg = str(e)
+            if "UNKNOWN_FIELD_NAME" not in error_msg:
+                raise
+            # Fallback to individual creates with graceful degradation
+            print(f"    ⚠️ Batch create failed, falling back to individual creates")
+            results = []
+            for video_data in videos:
+                try:
+                    result = self.create_competitor_video(video_data)
+                    results.append(result)
+                except Exception as ind_err:
+                    print(f"    ⚠️ Failed to create video {video_data.get('video_id')}: {ind_err}")
+            return results
 
     # ==================== SCRIPT TABLE ====================
     

--- a/skills/video-pipeline/osiris/__init__.py
+++ b/skills/video-pipeline/osiris/__init__.py
@@ -1,0 +1,23 @@
+"""
+Osiris v2 - Competitor Intelligence Module.
+
+A read-only intelligence layer that collects competitor video data,
+builds a growing knowledge base, and provides recommendations.
+
+Phase 1: Competitor Intelligence
+  - Scrapes ALL competitor videos (not just winners)
+  - Persists to Competitor Videos table for long-term learning
+  - Calculates VPH (views per hour) for performance scoring
+
+Usage:
+    python -m osiris.competitor_scraper
+    python -m osiris.competitor_scraper --dry-run
+
+Design Principles:
+  - READ ONLY: Never writes to pipeline tables (Ideas, Scripts, Images)
+  - SONNET ONLY: No Opus API calls (cost control)
+  - NON-BLOCKING: Failures don't kill the pipeline
+  - IDEMPOTENT: Safe to run multiple times (deduplicates by video_id)
+"""
+
+__version__ = "2.0.0"

--- a/skills/video-pipeline/osiris/__main__.py
+++ b/skills/video-pipeline/osiris/__main__.py
@@ -1,0 +1,7 @@
+"""Allow running osiris package directly: python -m osiris"""
+
+import asyncio
+from osiris.competitor_scraper import _cli_main
+
+if __name__ == "__main__":
+    asyncio.run(_cli_main())

--- a/skills/video-pipeline/osiris/competitor_scraper.py
+++ b/skills/video-pipeline/osiris/competitor_scraper.py
@@ -1,0 +1,376 @@
+"""
+Osiris Competitor Scraper - Scrapes and persists ALL competitor videos.
+
+Unlike discovery_scanner which only processes "winners" (high VPH videos),
+Osiris persists EVERY scraped video to build training data over time.
+
+After 3 months of daily scrapes, you'll have thousands of data points showing:
+- Which topics consistently get high VPH
+- Which channels are outperforming
+- Seasonal patterns in topic performance
+
+Usage:
+    python -m osiris.competitor_scraper
+    python -m osiris.competitor_scraper --dry-run
+
+Cron (5 AM PT):
+    0 5 * * * cd $PROJECT && python -m osiris.competitor_scraper
+"""
+
+import asyncio
+import logging
+import sys
+from datetime import date
+from typing import Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Reuse existing VPH calculation
+from bots.competitor_scraper import calculate_vph
+
+
+class OsirisCompetitorScraper:
+    """Scrapes competitor channels and persists ALL videos to Airtable.
+
+    This is the data collection layer for Osiris. Every video scraped
+    gets saved to the Competitor Videos table, not just winners.
+
+    Usage:
+        scraper = OsirisCompetitorScraper(apify_client, airtable_client)
+        result = await scraper.scrape_and_persist()
+        print(f"Saved {result['new_videos_saved']} new videos")
+    """
+
+    def __init__(
+        self,
+        apify_client,
+        airtable_client,
+        slack_client=None,
+        max_videos_per_channel: int = 20,
+    ):
+        """Initialize the Osiris scraper.
+
+        Args:
+            apify_client: ApifyYouTubeClient instance for scraping
+            airtable_client: AirtableClient instance for persistence
+            slack_client: Optional SlackClient for notifications
+            max_videos_per_channel: Videos to fetch per channel (default 20)
+        """
+        self.apify = apify_client
+        self.airtable = airtable_client
+        self.slack = slack_client
+        self.max_videos_per_channel = max_videos_per_channel
+
+    async def scrape_and_persist(
+        self,
+        dry_run: bool = False,
+    ) -> dict:
+        """Full pipeline: scrape all channels -> dedupe -> persist.
+
+        Args:
+            dry_run: If True, prints what would be saved without writing
+
+        Returns:
+            {
+                "channels_scraped": int,
+                "videos_scraped": int,
+                "new_videos_saved": int,
+                "duplicates_skipped": int,
+                "errors": list[str],
+            }
+        """
+        result = {
+            "channels_scraped": 0,
+            "videos_scraped": 0,
+            "new_videos_saved": 0,
+            "duplicates_skipped": 0,
+            "errors": [],
+        }
+
+        # Step 1: Get active channels
+        logger.info("Fetching active competitor channels...")
+        try:
+            channels = self.airtable.get_active_competitor_channels()
+        except Exception as e:
+            error = f"Failed to fetch channels: {e}"
+            logger.error(error)
+            result["errors"].append(error)
+            return result
+
+        if not channels:
+            logger.info("No active competitor channels found")
+            return result
+
+        channel_urls = [
+            c.get("Channel URL") for c in channels if c.get("Channel URL")
+        ]
+        result["channels_scraped"] = len(channel_urls)
+        logger.info(f"Found {len(channel_urls)} active channels to scrape")
+
+        # Step 2: Scrape videos via Apify
+        logger.info("Scraping videos via Apify...")
+        try:
+            videos = await self.apify.scrape_channel_videos(
+                channel_urls=channel_urls,
+                max_videos_per_channel=self.max_videos_per_channel,
+            )
+        except Exception as e:
+            error = f"Apify scrape failed: {e}"
+            logger.error(error)
+            result["errors"].append(error)
+            return result
+
+        result["videos_scraped"] = len(videos)
+        logger.info(f"Scraped {len(videos)} videos")
+
+        if not videos:
+            return result
+
+        # Step 3: Calculate VPH for each video
+        logger.info("Calculating VPH metrics...")
+        for video in videos:
+            vph, hours_old = calculate_vph(
+                video.get("views", 0),
+                video.get("published_at", ""),
+            )
+            video["vph"] = round(vph, 1)
+            video["hours_old"] = round(hours_old, 1)
+
+        # Step 4: Get existing video IDs for deduplication
+        logger.info("Fetching existing video IDs for deduplication...")
+        existing_ids = await self._get_existing_video_ids()
+        logger.info(f"Found {len(existing_ids)} existing videos in table")
+
+        # Step 5: Filter to new videos only
+        new_videos = [
+            v for v in videos
+            if v.get("video_id") and v.get("video_id") not in existing_ids
+        ]
+        result["duplicates_skipped"] = len(videos) - len(new_videos)
+        logger.info(
+            f"New videos: {len(new_videos)}, duplicates: {result['duplicates_skipped']}"
+        )
+
+        if not new_videos:
+            logger.info("No new videos to save")
+            return result
+
+        # Step 6: Persist new videos
+        if dry_run:
+            logger.info(f"DRY RUN: Would save {len(new_videos)} videos:")
+            for v in new_videos[:10]:  # Show first 10
+                logger.info(
+                    f"  - {v.get('title', '?')[:50]} | {v.get('channel', '?')} | "
+                    f"{v.get('views', 0):,} views | {v.get('vph', 0):.0f} VPH"
+                )
+            if len(new_videos) > 10:
+                logger.info(f"  ... and {len(new_videos) - 10} more")
+            result["new_videos_saved"] = len(new_videos)
+        else:
+            logger.info(f"Persisting {len(new_videos)} new videos...")
+            saved, failed = await self._persist_videos(new_videos)
+            result["new_videos_saved"] = saved
+            if failed:
+                result["errors"].append(f"{failed} videos failed to save")
+            logger.info(f"Saved {saved} videos, {failed} failed")
+
+        # Step 7: Update Last Scraped on channels
+        if not dry_run:
+            for channel in channels:
+                try:
+                    self.airtable.update_channel_last_scraped(channel["id"])
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to update Last Scraped for {channel.get('Channel Name')}: {e}"
+                    )
+
+        # Step 8: Send Slack notification (non-blocking)
+        if self.slack and not dry_run:
+            try:
+                self._send_summary_notification(result)
+            except Exception as e:
+                logger.warning(f"Slack notification failed: {e}")
+
+        return result
+
+    async def _get_existing_video_ids(self) -> set[str]:
+        """Fetch all existing video_ids from Competitor Videos table."""
+        # Run sync method in executor to avoid blocking
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None,
+            self.airtable.get_all_competitor_video_ids,
+        )
+
+    async def _persist_videos(self, videos: list[dict]) -> tuple[int, int]:
+        """Persist new videos to Airtable.
+
+        Returns:
+            (saved_count, failed_count)
+        """
+        loop = asyncio.get_event_loop()
+
+        try:
+            # Use batch create for efficiency
+            created = await loop.run_in_executor(
+                None,
+                self.airtable.batch_create_competitor_videos,
+                videos,
+            )
+            return len(created), 0
+        except Exception as e:
+            logger.error(f"Batch create failed: {e}")
+            # Fallback to individual creates
+            saved = 0
+            failed = 0
+            for video in videos:
+                try:
+                    await loop.run_in_executor(
+                        None,
+                        self.airtable.create_competitor_video,
+                        video,
+                    )
+                    saved += 1
+                except Exception as ind_err:
+                    logger.warning(f"Failed to save {video.get('video_id')}: {ind_err}")
+                    failed += 1
+            return saved, failed
+
+    def _send_summary_notification(self, result: dict):
+        """Send Slack summary of the scrape."""
+        msg = (
+            f"*Osiris Competitor Scrape Complete*\n"
+            f"Channels: {result['channels_scraped']}\n"
+            f"Videos scraped: {result['videos_scraped']}\n"
+            f"New saved: {result['new_videos_saved']}\n"
+            f"Duplicates skipped: {result['duplicates_skipped']}"
+        )
+        if result["errors"]:
+            msg += f"\nErrors: {len(result['errors'])}"
+
+        self.slack.send_message(msg)
+
+
+async def run_osiris_scraper(
+    apify_client=None,
+    airtable_client=None,
+    slack_client=None,
+    dry_run: bool = False,
+    max_videos_per_channel: int = 20,
+) -> dict:
+    """Convenience function to run the Osiris competitor scraper.
+
+    Creates clients if not provided, runs the full scrape pipeline.
+
+    Args:
+        apify_client: Optional ApifyYouTubeClient (created if None)
+        airtable_client: Optional AirtableClient (created if None)
+        slack_client: Optional SlackClient (created if None)
+        dry_run: If True, prints without saving
+        max_videos_per_channel: Videos per channel (default 20)
+
+    Returns:
+        Result dict with scrape statistics
+    """
+    # Create clients if not provided
+    if apify_client is None:
+        from clients.apify_client import ApifyYouTubeClient
+        apify_client = ApifyYouTubeClient()
+
+    if airtable_client is None:
+        from clients.airtable_client import AirtableClient
+        airtable_client = AirtableClient()
+
+    if slack_client is None and not dry_run:
+        try:
+            from clients.slack_client import SlackClient
+            slack_client = SlackClient()
+        except Exception:
+            slack_client = None
+
+    scraper = OsirisCompetitorScraper(
+        apify_client=apify_client,
+        airtable_client=airtable_client,
+        slack_client=slack_client,
+        max_videos_per_channel=max_videos_per_channel,
+    )
+
+    return await scraper.scrape_and_persist(dry_run=dry_run)
+
+
+async def _cli_main():
+    """CLI entry point for `python -m osiris.competitor_scraper`."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Osiris Competitor Scraper - Scrape and persist competitor videos"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be saved without writing to Airtable",
+    )
+    parser.add_argument(
+        "--max-videos",
+        type=int,
+        default=20,
+        help="Max videos per channel (default: 20)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    print("=" * 60)
+    print("OSIRIS COMPETITOR SCRAPER")
+    print("=" * 60)
+    print(f"  Date: {date.today().isoformat()}")
+    print(f"  Dry run: {args.dry_run}")
+    print(f"  Max videos/channel: {args.max_videos}")
+    print("=" * 60)
+    print()
+
+    result = await run_osiris_scraper(
+        dry_run=args.dry_run,
+        max_videos_per_channel=args.max_videos,
+    )
+
+    print()
+    print("=" * 60)
+    print("RESULTS")
+    print("=" * 60)
+    print(f"  Channels scraped:    {result['channels_scraped']}")
+    print(f"  Videos scraped:      {result['videos_scraped']}")
+    print(f"  New videos saved:    {result['new_videos_saved']}")
+    print(f"  Duplicates skipped:  {result['duplicates_skipped']}")
+
+    if result["errors"]:
+        print(f"  Errors:              {len(result['errors'])}")
+        for err in result["errors"]:
+            print(f"    - {err}")
+
+    print("=" * 60)
+
+    # Exit with error code if there were errors
+    if result["errors"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(_cli_main())

--- a/skills/video-pipeline/setup_cron.sh
+++ b/skills/video-pipeline/setup_cron.sh
@@ -3,12 +3,13 @@
 #
 # Usage: bash setup_cron.sh
 #
-# This installs five cron jobs:
-#   1. 5:00 AM  — Daily idea discovery scan (posts ideas to Slack for approval)
-#   2. 7:00 AM  — Daily YouTube performance tracker (syncs analytics to Airtable)
-#   3. 8:00 AM  — Daily pipeline queue run (processes all stages through to Ready To Render)
-#   4. Every 15 min — Bot health check (restarts Slack bot if it died, notifies you)
-#   5. Every 30 min — Approval watcher (catches manual Airtable approvals)
+# This installs six cron jobs:
+#   1. 5:00 AM  — Osiris competitor scraper (persists ALL competitor videos to training table)
+#   2. 9:00 AM  — Daily idea discovery scan (posts ideas to Slack for approval)
+#   3. 7:00 AM  — Daily YouTube performance tracker (syncs analytics to Airtable)
+#   4. 12:00 PM — Daily pipeline queue run (processes all stages through to Ready To Render)
+#   5. Every 15 min — Bot health check (restarts Slack bot if it died, notifies you)
+#   6. Every 30 min — Approval watcher (catches manual Airtable approvals)
 #
 # Times are in US/Pacific (America/Los_Angeles) via TZ env var.
 # Logs are written to /tmp/pipeline-*.log
@@ -50,6 +51,7 @@ SYS_TZ=$(cat /etc/timezone 2>/dev/null || timedatectl show --property=Timezone -
 # Check if system timezone is Pacific — if so, use times as-is
 if echo "$SYS_TZ" | grep -qiE "america/los_angeles|US/Pacific"; then
     TZ_MODE="pacific"
+    OSIRIS_HOUR=5
     DISCOVER_HOUR=9
     PERF_HOUR=7
     QUEUE_HOUR=12
@@ -57,12 +59,14 @@ elif echo "$SYS_TZ" | grep -qiE "UTC|Etc/UTC|Etc/GMT"; then
     TZ_MODE="utc"
     # Pacific to UTC: PST = UTC-8, PDT = UTC-7
     # Use PST offsets (conservative — jobs run 1h later in summer)
+    OSIRIS_HOUR=13     # 5 AM PT = 1 PM UTC (PST)
     DISCOVER_HOUR=17   # 9 AM PT = 5 PM UTC (PST)
     PERF_HOUR=15       # 7 AM PT = 3 PM UTC (PST)
     QUEUE_HOUR=20      # 12 PM PT = 8 PM UTC (PST)
 else
     # Unknown timezone — default to UTC offsets and warn
     TZ_MODE="other ($SYS_TZ)"
+    OSIRIS_HOUR=13
     DISCOVER_HOUR=17
     PERF_HOUR=15
     QUEUE_HOUR=20
@@ -105,6 +109,12 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # TZ for log timestamps — shows Pacific time in logs regardless of system tz
 TZ=America/Los_Angeles
 
+# $OSIRIS_HOUR:00 (~5 AM PT) — Osiris competitor video scraper
+# Scrapes ALL competitor videos and persists to Competitor Videos table
+# Builds training data for topic/title performance analysis over time
+# Timeout: 10 min max | Lock expires after 15 min
+0 $OSIRIS_HOUR * * * MAX_LOCK_AGE=900 $WRAPPER osiris /tmp/osiris-scraper.log timeout 600 python -m osiris.competitor_scraper
+
 # $DISCOVER_HOUR:00 (~9 AM PT) — Daily idea discovery scan
 # Scans world news headlines + competitor top performers (50/50 split)
 # Posts interactive Slack message with both idea types for approval
@@ -133,7 +143,7 @@ EOF
 )
 
 # Preserve any existing cron entries not from this script
-EXISTING=$(crontab -l 2>/dev/null | grep -v "pipeline-discover\|pipeline-queue\|pipeline-bot-health\|pipeline-approval\|performance-tracker\|pipeline\.log\|Pipeline Cron\|setup_cron\|Daily idea\|Daily pipeline\|performance tracker\|bot health\|Approval watcher\|run-queue\|--discover\|performance_tracker\|cron_wrapper" || true)
+EXISTING=$(crontab -l 2>/dev/null | grep -v "pipeline-discover\|pipeline-queue\|pipeline-bot-health\|pipeline-approval\|performance-tracker\|osiris-scraper\|pipeline\.log\|Pipeline Cron\|setup_cron\|Daily idea\|Daily pipeline\|performance tracker\|bot health\|Approval watcher\|run-queue\|--discover\|performance_tracker\|cron_wrapper\|osiris\.competitor" || true)
 
 # Install combined crontab
 if [ -n "$EXISTING" ]; then
@@ -145,6 +155,7 @@ fi
 echo "  Cron jobs installed!"
 echo ""
 echo "  Scheduled (system time $SYS_TZ → ~Pacific equivalent):"
+echo "    $OSIRIS_HOUR:00 daily (~5 AM PT)    ->  Osiris scraper (persist competitor videos)"
 echo "    $DISCOVER_HOUR:00 daily (~9 AM PT)  ->  Discovery scan (news + competitors → Slack)"
 echo "    $PERF_HOUR:00 daily (~7 AM PT)      ->  YouTube performance tracker (sync analytics)"
 echo "    $QUEUE_HOUR:00 daily (~12 PM PT)    ->  Pipeline queue (process all stages to render)"
@@ -156,12 +167,14 @@ echo "    All jobs (except healthcheck) send Slack notifications on failure."
 echo "    Check your Slack channel if you don't see morning activity."
 echo ""
 echo "  Timeouts:"
+echo "    Osiris:       10 min max"
 echo "    Discovery:    15 min max (includes competitor scrape)"
 echo "    Performance:  10 min max"
 echo "    Pipeline:     4 hours max"
 echo "    Approval:     10 min max"
 echo ""
 echo "  Logs:"
+echo "    /tmp/osiris-scraper.log"
 echo "    /tmp/pipeline-discover.log"
 echo "    /tmp/performance-tracker.log"
 echo "    /tmp/pipeline-queue.log"


### PR DESCRIPTION
## Summary
- Adds Osiris intelligence layer Phase 1: competitor video data collection
- Scrapes ALL competitor videos (not just winners) and persists to Airtable
- Builds training data for long-term topic/title performance analysis
- Runs daily at 5 AM PT before discovery scanner

## New Files
- `osiris/__init__.py` - Package init
- `osiris/__main__.py` - CLI entry point
- `osiris/competitor_scraper.py` - Main scraper module

## Changes
- `airtable_client.py` - Added Competitor Videos table support (property + CRUD methods)
- `setup_cron.sh` - Added 5 AM Osiris cron job
- `.env.example` - Added `AIRTABLE_COMPETITOR_VIDEOS_TABLE_ID`
- `docs/airtable-schema.md` - Added Competitor Videos table schema

## New Airtable Table Required
Create "Competitor Videos" table with:
- `Video ID` (Single Line Text) — YouTube video ID
- `Title` (Single Line Text)
- `URL` (URL)
- `Channel` (Single Line Text)
- `Channel URL` (URL)
- `Views` (Number)
- `VPH` (Number, decimal)
- `Hours Old` (Number, decimal)
- `Published Date` (Date)
- `Scrape Date` (Date)
- `Modeled` (Checkbox)
- `Our Video` (Single Line Text, optional)
- `Topic Cluster` (Single Select, optional)

Then add table ID to `.env` as `AIRTABLE_COMPETITOR_VIDEOS_TABLE_ID`

## Test plan
- [ ] Create Competitor Videos table in Airtable
- [ ] Add table ID to `.env`
- [ ] Run `python -m osiris.competitor_scraper --dry-run` to verify
- [ ] Run without `--dry-run` to persist real data
- [ ] Run `bash setup_cron.sh` on VPS to install cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)