### PR TITLE
fix: prompt Scene uses narration_excerpt, duration from word count, character integration

### DIFF
--- a/skills/video-pipeline/brief_translator/scene_expander.py
+++ b/skills/video-pipeline/brief_translator/scene_expander.py
@@ -682,6 +682,7 @@ async def _expand_with_scene_blocks(
     visual_seeds: str,
     accent_color: str,
     act_number: int,
+    voice_duration: Optional[float] = None,
 ) -> list[dict]:
     """Expand scene using V2 scene_blocks format.
 
@@ -698,6 +699,7 @@ async def _expand_with_scene_blocks(
         visual_seeds: Visual seeds for context
         accent_color: Accent color for video
         act_number: Which act this scene belongs to
+        voice_duration: Optional voice duration in seconds for WPS calculation
 
     Returns:
         List of concept dicts with block context (block_id, block_location, etc.)
@@ -737,6 +739,15 @@ async def _expand_with_scene_blocks(
     print(f"    Scene {scene_number}: {len(matched_images)} images matched from scene_blocks "
           f"(blocks: {', '.join(set(img['block_id'] for img in matched_images))})")
 
+    # Calculate words-per-second for duration estimation
+    # Same logic as deterministic_splitter.py: voice_duration → WPS, or default 2.5
+    DEFAULT_WPS = 2.5
+    total_word_count = len(scene_text.split())
+    if voice_duration and voice_duration > 0:
+        wps = total_word_count / voice_duration
+    else:
+        wps = DEFAULT_WPS
+
     # Convert matched images to concept dicts
     concepts = []
     for i, img in enumerate(matched_images):
@@ -757,23 +768,33 @@ async def _expand_with_scene_blocks(
         # (NOT the Story Bible's narration_excerpt which may be a paraphrase)
         verbatim_text = img.get("verbatim_text", "").strip()
 
-        # NARRATION CONTENT: Used for visual_description to drive image generation
-        # Prefer verbatim_text if available, fall back to narration_excerpt
-        narration_content = verbatim_text if verbatim_text else img.get("narration_excerpt", "").strip()
+        # VISUAL CONTENT: Story Bible narration_excerpt describes what to SHOW
+        # This drives the image prompt — it's a visual description, not spoken words
+        visual_content = img.get("narration_excerpt", "").strip()
 
         # Get camera/composition direction from Story Bible action field
         # This is NOT story content - it's cinematography guidance
         camera_direction = img.get("action", "").strip()
 
+        # Duration from word count of sentence_text (verbatim script words)
+        sentence = verbatim_text if verbatim_text else visual_content
+        word_count = len(sentence.split()) if sentence else 0
+        duration = round(word_count / wps, 1) if wps > 0 else round(word_count / DEFAULT_WPS, 1)
+        # Clamp to reasonable range: min 4s, max 10s (same as deterministic_splitter)
+        duration = max(4.0, min(10.0, duration))
+
         concept = {
             "concept_index": i + 1,
             # sentence_text = VERBATIM script words for Airtable Sentence Text field
-            "sentence_text": verbatim_text if verbatim_text else narration_content,
-            # visual_description = what the image should depict
-            "visual_description": narration_content if narration_content else "Scene continues",
+            "sentence_text": verbatim_text if verbatim_text else visual_content,
+            # visual_description = Story Bible narration_excerpt (what to SHOW)
+            # NOT verbatim script text (what the narrator SAYS)
+            "visual_description": visual_content if visual_content else "Scene continues",
             "visual_style": get_default_style(),
             "composition": composition,
             "mood": img.get("block_mood", "neutral"),
+            # Duration calculated from word count (pre-Whisper estimate)
+            "duration": duration,
             # Block context for prompt builder
             "block_id": img.get("block_id"),
             "block_location": img.get("block_location", ""),
@@ -976,6 +997,7 @@ async def expand_scene_concepts_deterministic(
             visual_seeds=visual_seeds,
             accent_color=accent_color,
             act_number=act_number,
+            voice_duration=voice_duration,
         )
 
     # V1 path: Use deterministic splitter + LLM visual descriptions

--- a/skills/video-pipeline/image_prompt_engine/prompt_builder.py
+++ b/skills/video-pipeline/image_prompt_engine/prompt_builder.py
@@ -632,20 +632,29 @@ def build_prompt_from_block(
     if not story_content:
         story_content = concept.get("sentence_text", "Scene continues").strip()
 
-    # CAMERA DIRECTION: From Story Bible action field (composition guidance, NOT content)
-    camera_direction = concept.get("camera_direction", "").strip()
-
     camera = concept.get("composition", "medium")
     mood = concept.get("block_mood", concept.get("mood", "neutral"))
 
-    # Get character costume descriptions from Story Bible
+    # Build character descriptions: integrate costume + action in context
+    # NOT raw costume dumps — characters should be DOING something
+    # camera_direction = Story Bible "action" field (what's happening in this shot)
+    camera_direction = concept.get("camera_direction", "").strip()
     char_descriptions = []
     for char_id in block_characters:
         char = get_character_by_id(story_bible, char_id)
         if char:
+            name = char.get("id", "figure").replace("_", " ")
             costume = char.get("costume") or char.get("description", "")
             if costume:
-                char_descriptions.append(costume)
+                # Integrate: "figure in [costume], [action from camera_direction]"
+                if camera_direction:
+                    char_descriptions.append(f"{name} in {costume}, {camera_direction}")
+                else:
+                    pose = char.get("signature_pose", "")
+                    if pose:
+                        char_descriptions.append(f"{name} in {costume}, {pose}")
+                    else:
+                        char_descriptions.append(f"{name} wearing {costume}")
 
     # Determine prefix based on character presence
     if block_characters and char_descriptions:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -90,6 +90,13 @@
 - **Profile detection changed.** Pipeline uses `uses_story_bible` (any profile except holographic_hud) instead of `is_mannequin_profile`. This is more accurate now that mannequin style is deprecated.
 - **Legacy code remnants cause phantom failures.** After ANY style/profile swap, do a full codebase grep to catch stragglers. Dead type hints, comments referencing removed values, and deprecated aliases will confuse validators and cause false positives. Run: `grep -rn "old_style_name" skills/video-pipeline/ --include="*.py"`
 
+### Prompt Builder Data Paths (4 separate concerns)
+- **`visual_description` = narration_excerpt** (Story Bible visual content — what to SHOW). NEVER use verbatim script text here. The 9f0093d commit accidentally set `visual_description` to `verbatim_text`, which put raw narrator dialogue into the Scene field of prompts.
+- **`sentence_text` = verbatim script text** (exact words from Script table). Used for Airtable Sentence Text field and duration calculation.
+- **Characters = costume + action, integrated.** Don't dump raw costume descriptions. Integrate: "figure in [costume], [action]". The `camera_direction` (Story Bible `action` field) tells you what the character is doing.
+- **Duration = word_count / WPS** from sentence_text. The V2 scene blocks path must calculate this the same way deterministic_splitter does (DEFAULT_WPS = 2.5, or voice_duration-based). Missing duration causes downstream clip duration decisions to use wrong defaults.
+- **These are FOUR separate data paths. Don't cross them.** A fix to one (e.g., making sentence_text verbatim) must not accidentally change another (e.g., visual_description).
+
 ### Scene Blocking System (Story Bible V2)
 - **Two Story Bible formats exist**: V1 (`visual_arc`) and V2 (`scene_blocks`). Use `has_scene_blocks()` to detect version.
 - **Scene blocks group 2-5 images** sharing location + lighting. Only camera angle, action, expression change within a block.
@@ -121,3 +128,4 @@ _After each session, add a one-line summary of what was done and any new lessons
 | 2026-03-14 | Fix 3 pipeline issues: cinematic voice prompt position, act_coherence advisory, verified progressive writes | System prompt ordering matters; advisory checks for unreliable fixes; progressive writes already worked |
 | 2026-03-14 | Debug Script field write + add !approve command for blocked scripts | Wiring audit failed — "already working" claims need ACTUAL verification with debug logs, not code reading |
 | 2026-03-14 | Fix Script field missing from Airtable setup — field documented but never created | Documentation ≠ implementation; always check setup scripts match field audit comments |
+| 2026-03-15 | Fix 3 prompt builder bugs: Scene uses narration_excerpt, duration from word count, character integration | 4 separate data paths in prompt builder — don't cross them; V2 scene blocks must match V1 deterministic_splitter capabilities |


### PR DESCRIPTION
Bug 1: visual_description now uses Story Bible narration_excerpt (visual
content) instead of verbatim script text. The 9f0093d commit accidentally
set visual_description to verbatim_text, putting raw narrator dialogue
into the Scene field of prompts.

Bug 2: Characters field now integrates costume + action in context
("figure in [costume], [action]") instead of dumping raw costume
descriptions as a block.

Bug 3: V2 scene blocks path now calculates duration from sentence_text
word count using WPS (same formula as deterministic_splitter: default
2.5 WPS, or voice_duration-based). Previously no duration was set.

Four separate data paths kept distinct:
- visual_description = narration_excerpt (what to SHOW)
- sentence_text = verbatim script (what narrator SAYS)
- characters = costume + action integrated
- duration = word_count / WPS from sentence_text

312 tests passing (143 image_prompt_engine, 143 brief_translator, 26 integration).

https://claude.ai/code/session_01HSp9LraBqXaNoxbJzo9TDH