### PR TITLE
feat(storyengine): Unified Visuals tab + VPS auto-start service

### DIFF
--- a/storyengine/frontend/src/app/pipeline/[videoId]/page.tsx
+++ b/storyengine/frontend/src/app/pipeline/[videoId]/page.tsx
@@ -16,7 +16,7 @@ import { VoiceReviewTab } from "@/components/production/VoiceReviewTab";
 import { VisualsTab } from "@/components/production/VisualsTab";
 import { VideoClipsTab } from "@/components/production/VideoClipsTab";
 import { SoundTab } from "@/components/production/SoundTab";
-import { StoryboardTab } from "@/components/production/StoryboardTab";
+
 import { ThumbnailTab } from "@/components/production/ThumbnailTab";
 import { RenderTab } from "@/components/production/RenderTab";
 import { UploadTab } from "@/components/production/UploadTab";
@@ -56,7 +56,6 @@ const TABS = [
   { id: "visuals", label: "Visuals", icon: ImageIcon },
   { id: "clips", label: "Video Clips", icon: Video },
   { id: "sound", label: "Sound", icon: Volume2 },
-  { id: "storyboard", label: "Storyboard", icon: LayoutGrid },
   { id: "thumbnail", label: "Thumbnail", icon: Film },
   { id: "render", label: "Render", icon: Film },
   { id: "upload", label: "Upload", icon: Upload },
@@ -177,7 +176,7 @@ export default function VideoDetailPage() {
         {activeTab === "visuals" && <VisualsTab video={video} />}
         {activeTab === "clips" && <VideoClipsTab video={video} />}
         {activeTab === "sound" && <SoundTab video={video} />}
-        {activeTab === "storyboard" && <StoryboardTab video={video} />}
+
         {activeTab === "thumbnail" && <ThumbnailTab video={video} />}
         {activeTab === "render" && <RenderTab video={video} />}
         {activeTab === "upload" && <UploadTab video={video} />}

--- a/storyengine/frontend/src/components/production/VisualsTab.tsx
+++ b/storyengine/frontend/src/components/production/VisualsTab.tsx
@@ -2,106 +2,366 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Check, Loader2, Image as ImageIcon } from "lucide-react";
+import { Play, Pause, Check, Loader2, Pencil, Image as ImageIcon } from "lucide-react";
 import { GlassCard } from "@/components/ui/GlassCard";
 import { SegmentBadge } from "@/components/ui/SegmentBadge";
+import { StatusPill } from "@/components/ui/StatusPill";
+import { MiniWaveform } from "@/components/ui/MiniWaveform";
 import { ProgressRing } from "@/components/ui/ProgressRing";
 import { FilterSelect } from "@/components/ui/FilterSelect";
-import { MOCK_IMAGE_GEN_ITEMS } from "@/lib/mock-data";
-import type { Video } from "@/lib/types";
+import { MOCK_SCENE_VISUALS } from "@/lib/mock-data";
+import type { Video, SceneVisualGroup } from "@/lib/types";
 
 interface VisualsTabProps {
   video: Video;
 }
 
+const STATUS_ICON: Record<string, { icon: React.ReactNode; color: string; label: string }> = {
+  done: { icon: <Check size={10} />, color: "var(--green)", label: "Generated" },
+  generating: { icon: <Loader2 size={10} className="animate-spin" />, color: "var(--purple)", label: "Generating" },
+  pending: { icon: <ImageIcon size={10} />, color: "var(--text-tertiary)", label: "Pending" },
+};
+
 export function VisualsTab({ video }: VisualsTabProps) {
+  const [scenes, setScenes] = useState<SceneVisualGroup[]>(MOCK_SCENE_VISUALS);
+  const [storyboardOn, setStoryboardOn] = useState(false);
   const [model, setModel] = useState("nano-banana-2");
   const [styleProfile, setStyleProfile] = useState("holographic-hud");
+  const [playingScene, setPlayingScene] = useState<number | null>(null);
+  const [editingPrompt, setEditingPrompt] = useState<string | null>(null);
 
-  const completedCount = MOCK_IMAGE_GEN_ITEMS.filter((i) => i.completed).length;
-  const totalCount = MOCK_IMAGE_GEN_ITEMS.length;
+  const totalSegments = scenes.reduce((sum, s) => sum + s.segments.length, 0);
+  const doneSegments = scenes.reduce((sum, s) => sum + s.segments.filter((seg) => seg.status === "done").length, 0);
+
+  const updatePrompt = (segId: string, newPrompt: string) => {
+    setScenes((prev) =>
+      prev.map((scene) => ({
+        ...scene,
+        segments: scene.segments.map((seg) =>
+          seg.id === segId ? { ...seg, imagePrompt: newPrompt } : seg
+        ),
+      }))
+    );
+  };
+
+  const updateSentence = (segId: string, newText: string) => {
+    setScenes((prev) =>
+      prev.map((scene) => ({
+        ...scene,
+        segments: scene.segments.map((seg) =>
+          seg.id === segId ? { ...seg, sentenceText: newText } : seg
+        ),
+      }))
+    );
+  };
+
+  const updateNarration = (sceneNum: number, newText: string) => {
+    setScenes((prev) =>
+      prev.map((scene) =>
+        scene.sceneNumber === sceneNum ? { ...scene, narrationText: newText } : scene
+      )
+    );
+  };
+
+  const selectStoryboardPanel = (sceneNum: number, panelIdx: number) => {
+    setScenes((prev) =>
+      prev.map((s) => (s.sceneNumber === sceneNum ? { ...s, selectedStoryboardPanel: panelIdx } : s))
+    );
+  };
+
+  const approveStoryboard = (sceneNum: number) => {
+    setScenes((prev) =>
+      prev.map((s) => (s.sceneNumber === sceneNum ? { ...s, storyboardApproved: true } : s))
+    );
+  };
+
+  // Group by act
+  const actGroups = scenes.reduce((acc, scene) => {
+    if (!acc[scene.actNumber]) acc[scene.actNumber] = [];
+    acc[scene.actNumber].push(scene);
+    return acc;
+  }, {} as Record<number, SceneVisualGroup[]>);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[1fr_260px] gap-6">
-      {/* Image grid */}
-      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3">
-        {MOCK_IMAGE_GEN_ITEMS.map((img) => (
-          <GlassCard key={img.id} className="p-0 overflow-hidden">
-            <div
-              className="aspect-square relative flex items-center justify-center"
-              style={{ background: "var(--bg-elevated)" }}
+      {/* Main content */}
+      <div className="space-y-6">
+        {/* Controls bar */}
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>
+              Storyboard
+            </span>
+            <button
+              onClick={() => setStoryboardOn(!storyboardOn)}
+              className="relative w-12 h-6 rounded-full transition-all"
+              style={{ background: storyboardOn ? "var(--turquoise)" : "var(--bg-surface)" }}
             >
-              <svg className="absolute inset-0 w-full h-full opacity-15">
-                <defs>
-                  <pattern id={`vt-${img.id}`} width="20" height="20" patternUnits="userSpaceOnUse">
-                    <path d="M 20 0 L 0 0 0 20" fill="none" stroke="var(--purple)" strokeWidth="0.5" />
-                  </pattern>
-                </defs>
-                <rect width="100%" height="100%" fill={`url(#vt-${img.id})`} />
-              </svg>
-
-              <svg width="50" height="50" viewBox="0 0 50 50" className="opacity-15">
-                <rect x="8" y="8" width="28" height="28" fill="none" stroke="var(--text-tertiary)" strokeWidth="1" />
-                <line x1="8" y1="8" x2="14" y2="3" stroke="var(--text-tertiary)" strokeWidth="1" />
-                <line x1="36" y1="8" x2="42" y2="3" stroke="var(--text-tertiary)" strokeWidth="1" />
-                <rect x="14" y="3" width="28" height="28" fill="none" stroke="var(--text-tertiary)" strokeWidth="1" />
-              </svg>
-
-              {img.completed && (
-                <div className="absolute top-2 right-2 w-5 h-5 rounded-full flex items-center justify-center" style={{ background: "var(--green)" }}>
-                  <Check size={12} style={{ color: "var(--bg-void)" }} />
-                </div>
-              )}
-              {!img.completed && img.progress > 0 && (
-                <div className="absolute top-2 right-2">
-                  <Loader2 size={16} className="animate-spin" style={{ color: "var(--purple)" }} />
-                </div>
-              )}
-              <div className="absolute bottom-2 right-2">
-                <SegmentBadge label={img.segmentId} color="var(--purple)" />
-              </div>
-            </div>
-
-            <div className="px-3 py-2">
-              <p className="text-[10px] font-mono truncate" style={{ color: "var(--text-secondary)" }}>
-                <ImageIcon size={10} className="inline mr-1" style={{ color: "var(--purple)" }} />
-                {img.prompt}
-              </p>
-            </div>
-
-            <div className="h-1" style={{ background: "var(--bg-void)" }}>
-              <motion.div
-                className="h-full"
-                style={{ background: "var(--purple)" }}
-                initial={{ width: 0 }}
-                animate={{ width: `${img.progress}%` }}
-                transition={{ duration: 1, ease: "easeOut" as const }}
+              <div
+                className="w-5 h-5 rounded-full absolute top-0.5 transition-all"
+                style={{
+                  background: storyboardOn ? "var(--bg-void)" : "var(--text-tertiary)",
+                  left: storyboardOn ? "calc(100% - 22px)" : "2px",
+                }}
               />
+            </button>
+            <span className="text-[10px] font-mono" style={{ color: storyboardOn ? "var(--turquoise)" : "var(--text-tertiary)" }}>
+              {storyboardOn ? "ON" : "OFF"}
+            </span>
+          </div>
+        </div>
+
+        {/* Scenes grouped by act */}
+        {Object.entries(actGroups).map(([actNum, actScenes]) => (
+          <div key={actNum}>
+            <div className="flex items-center gap-4 mb-4">
+              <div className="flex-1 h-px" style={{ background: "var(--purple)", opacity: 0.3 }} />
+              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--purple)" }}>
+                Act {actNum}
+              </span>
+              <div className="flex-1 h-px" style={{ background: "var(--purple)", opacity: 0.3 }} />
             </div>
-          </GlassCard>
+
+            <div className="space-y-4">
+              {actScenes.map((scene) => (
+                <GlassCard key={scene.sceneNumber} className="p-5">
+                  {/* Scene header */}
+                  <div className="flex items-start gap-3 mb-4">
+                    <SegmentBadge label={`Scene ${scene.sceneNumber}`} color="var(--purple)" />
+                    <div className="flex-1">
+                      <textarea
+                        value={scene.narrationText}
+                        onChange={(e) => updateNarration(scene.sceneNumber, e.target.value)}
+                        rows={2}
+                        className="w-full text-sm leading-relaxed resize-none outline-none rounded-lg px-2 py-1 transition-all"
+                        style={{
+                          color: "var(--text-primary)",
+                          background: "transparent",
+                          border: "1px solid transparent",
+                        }}
+                        onFocus={(e) => { e.target.style.background = "var(--bg-elevated)"; e.target.style.borderColor = "var(--purple)"; }}
+                        onBlur={(e) => { e.target.style.background = "transparent"; e.target.style.borderColor = "transparent"; }}
+                      />
+                      <div className="flex items-center gap-3 mt-1">
+                        <span className="text-[10px] font-mono" style={{ color: "var(--text-tertiary)" }}>{scene.visualStyle}</span>
+                        <span className="text-[10px] font-mono" style={{ color: "var(--text-tertiary)" }}>{scene.composition}</span>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <button
+                        onClick={() => setPlayingScene(playingScene === scene.sceneNumber ? null : scene.sceneNumber)}
+                        className="w-7 h-7 rounded-full flex items-center justify-center shrink-0"
+                        style={{ background: "var(--green)", color: "var(--bg-void)" }}
+                      >
+                        {playingScene === scene.sceneNumber ? <Pause size={12} /> : <Play size={12} className="ml-0.5" />}
+                      </button>
+                      <MiniWaveform color="var(--green)" width={100} height={20} bars={25} />
+                      <span className="text-[10px] font-mono" style={{ color: "var(--text-tertiary)" }}>{scene.duration}</span>
+                    </div>
+                  </div>
+
+                  {/* Segment cards */}
+                  <div className="space-y-3">
+                    {scene.segments.map((seg) => {
+                      const statusInfo = STATUS_ICON[seg.status];
+                      const isEditing = editingPrompt === seg.id;
+                      return (
+                        <div
+                          key={seg.id}
+                          className="rounded-xl p-3 transition-all"
+                          style={{
+                            background: "rgba(255,255,255,0.02)",
+                            border: `1px solid ${seg.status === "done" ? "rgba(0, 230, 138, 0.15)" : seg.status === "generating" ? "rgba(139, 92, 246, 0.2)" : "rgba(255,255,255,0.05)"}`,
+                          }}
+                        >
+                          <div className="flex items-start gap-3">
+                            <SegmentBadge label={seg.segmentId} color={seg.status === "done" ? "var(--green)" : seg.status === "generating" ? "var(--purple)" : undefined} />
+                            <div className="flex-1 min-w-0 space-y-2">
+                              <div>
+                                <label className="text-[9px] uppercase tracking-wider font-medium" style={{ color: "var(--text-tertiary)" }}>
+                                  Sentence Text
+                                </label>
+                                <input
+                                  type="text"
+                                  value={seg.sentenceText}
+                                  onChange={(e) => updateSentence(seg.id, e.target.value)}
+                                  className="w-full text-sm outline-none rounded-lg px-2 py-1 mt-0.5 transition-all"
+                                  style={{ color: "var(--text-primary)", background: "transparent", border: "1px solid transparent" }}
+                                  onFocus={(e) => { e.target.style.background = "var(--bg-elevated)"; e.target.style.borderColor = "var(--turquoise)"; }}
+                                  onBlur={(e) => { e.target.style.background = "transparent"; e.target.style.borderColor = "transparent"; }}
+                                />
+                              </div>
+                              <div>
+                                <div className="flex items-center gap-1.5">
+                                  <label className="text-[9px] uppercase tracking-wider font-medium" style={{ color: "var(--purple)" }}>
+                                    Image Prompt
+                                  </label>
+                                  <Pencil size={8} style={{ color: "var(--purple)", opacity: 0.5 }} />
+                                </div>
+                                <textarea
+                                  value={seg.imagePrompt}
+                                  onChange={(e) => updatePrompt(seg.id, e.target.value)}
+                                  rows={isEditing ? 4 : 2}
+                                  className="w-full text-[12px] font-mono outline-none rounded-lg px-2 py-1 mt-0.5 resize-none transition-all"
+                                  style={{ color: "var(--text-secondary)", background: "transparent", border: "1px solid transparent" }}
+                                  onFocus={(e) => {
+                                    setEditingPrompt(seg.id);
+                                    e.target.style.background = "var(--bg-elevated)";
+                                    e.target.style.borderColor = "var(--purple)";
+                                  }}
+                                  onBlur={(e) => {
+                                    setEditingPrompt(null);
+                                    e.target.style.background = "transparent";
+                                    e.target.style.borderColor = "transparent";
+                                  }}
+                                />
+                              </div>
+                            </div>
+                            <div className="shrink-0 flex flex-col items-center gap-1.5">
+                              <div
+                                className="w-20 h-14 rounded-lg relative flex items-center justify-center overflow-hidden"
+                                style={{ background: "var(--bg-elevated)", border: "1px solid var(--border-subtle)" }}
+                              >
+                                <svg className="absolute inset-0 w-full h-full opacity-15">
+                                  <defs>
+                                    <pattern id={`vg-${seg.id}`} width="12" height="12" patternUnits="userSpaceOnUse">
+                                      <path d="M 12 0 L 0 0 0 12" fill="none" stroke="var(--purple)" strokeWidth="0.3" />
+                                    </pattern>
+                                  </defs>
+                                  <rect width="100%" height="100%" fill={`url(#vg-${seg.id})`} />
+                                </svg>
+                                {seg.status === "done" && (
+                                  <div className="absolute top-1 right-1 w-4 h-4 rounded-full flex items-center justify-center" style={{ background: "var(--green)" }}>
+                                    <Check size={8} style={{ color: "var(--bg-void)" }} />
+                                  </div>
+                                )}
+                                {seg.status === "generating" && (
+                                  <Loader2 size={14} className="animate-spin" style={{ color: "var(--purple)" }} />
+                                )}
+                              </div>
+                              <span className="text-[9px] font-mono flex items-center gap-1" style={{ color: statusInfo.color }}>
+                                {statusInfo.icon}
+                                {statusInfo.label}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {/* Storyboard section (conditional) */}
+                  {storyboardOn && scene.storyboardPanels && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.3 }}
+                      className="mt-4 pt-4"
+                      style={{ borderTop: "1px solid var(--border-subtle)" }}
+                    >
+                      <div className="flex items-center justify-between mb-3">
+                        <div className="flex items-center gap-2">
+                          <StatusPill label="Storyboard" color={scene.storyboardApproved ? "green" : "turquoise"} size="sm" />
+                          {scene.storyboardApproved && (
+                            <span className="text-[10px] font-mono" style={{ color: "var(--green)" }}>Approved</span>
+                          )}
+                        </div>
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => approveStoryboard(scene.sceneNumber)}
+                            disabled={scene.storyboardApproved}
+                            className="text-[10px] px-2.5 py-1 rounded-lg transition-all disabled:opacity-40"
+                            style={{ border: "1px solid var(--turquoise)", color: "var(--turquoise)" }}
+                          >
+                            {scene.storyboardApproved ? "Approved" : "Approve"}
+                          </button>
+                          <button
+                            className="text-[10px] px-2.5 py-1 rounded-lg"
+                            style={{ border: "1px solid var(--border)", color: "var(--text-secondary)" }}
+                          >
+                            Regenerate
+                          </button>
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-3 gap-1.5">
+                        {scene.storyboardPanels.map((panel, panelIdx) => {
+                          const isSelected = scene.selectedStoryboardPanel === panelIdx;
+                          const isApproved = scene.storyboardApproved && isSelected;
+                          return (
+                            <button
+                              key={panel.id}
+                              onClick={() => selectStoryboardPanel(scene.sceneNumber, panelIdx)}
+                              className="aspect-video rounded relative overflow-hidden transition-all"
+                              style={{
+                                background: "var(--bg-elevated)",
+                                border: isSelected ? "2px solid var(--turquoise)" : "1px solid var(--border-subtle)",
+                                opacity: scene.storyboardApproved && !isSelected ? 0.3 : 1,
+                              }}
+                            >
+                              <svg className="absolute inset-0 w-full h-full opacity-15">
+                                <defs>
+                                  <pattern id={`sb-${panel.id}`} width="10" height="10" patternUnits="userSpaceOnUse">
+                                    <path d="M 10 0 L 0 0 0 10" fill="none" stroke="var(--turquoise)" strokeWidth="0.3" />
+                                  </pattern>
+                                </defs>
+                                <rect width="100%" height="100%" fill={`url(#sb-${panel.id})`} />
+                              </svg>
+                              {isApproved && (
+                                <div className="absolute inset-0 flex items-center justify-center bg-black/30">
+                                  <div className="w-6 h-6 rounded-full flex items-center justify-center" style={{ background: "var(--turquoise)" }}>
+                                    <Check size={12} style={{ color: "var(--bg-void)" }} />
+                                  </div>
+                                </div>
+                              )}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <div className="flex items-center gap-1 mt-2">
+                        {scene.storyboardPanels.map((_, panelIdx) => (
+                          <button
+                            key={panelIdx}
+                            onClick={() => selectStoryboardPanel(scene.sceneNumber, panelIdx)}
+                            className="flex items-center justify-center text-[9px] font-mono transition-all"
+                            style={{
+                              width: 18, height: 18, borderRadius: "50%",
+                              background: scene.selectedStoryboardPanel === panelIdx ? "var(--turquoise)" : "transparent",
+                              color: scene.selectedStoryboardPanel === panelIdx ? "var(--bg-void)" : "var(--text-tertiary)",
+                              border: `1.5px solid ${scene.selectedStoryboardPanel === panelIdx ? "var(--turquoise)" : "var(--text-tertiary)"}`,
+                            }}
+                          >
+                            {panelIdx + 1}
+                          </button>
+                        ))}
+                      </div>
+                    </motion.div>
+                  )}
+                </GlassCard>
+              ))}
+            </div>
+          </div>
         ))}
       </div>
 
-      {/* Sidebar */}
+      {/* Right sidebar */}
       <div className="space-y-4">
         <GlassCard className="p-5">
           <h3 className="text-xs font-semibold uppercase tracking-wider mb-4" style={{ color: "var(--text-secondary)" }}>
             Generation Stats
           </h3>
           <div className="flex justify-center mb-4">
-            <ProgressRing value={(completedCount / totalCount) * 100} size={90} color="var(--purple)" strokeWidth={7}>
-              <span className="text-lg font-bold" style={{ color: "var(--text-primary)" }}>{completedCount}</span>
-              <span className="text-[8px] uppercase" style={{ color: "var(--text-secondary)" }}>Images</span>
+            <ProgressRing value={(doneSegments / totalSegments) * 100} size={90} color="var(--purple)" strokeWidth={7}>
+              <span className="text-lg font-bold" style={{ color: "var(--text-primary)" }}>{doneSegments}</span>
+              <span className="text-[8px] uppercase" style={{ color: "var(--text-secondary)" }}>/ {totalSegments}</span>
             </ProgressRing>
           </div>
-
-          <FilterSelect label="Model" options={[{ value: "nano-banana-2", label: "Nano Banana 2" }, { value: "seed-dream", label: "Seed Dream 4.5" }]} value={model} onChange={setModel} className="mb-3" />
-          <FilterSelect label="Style Profile" options={[{ value: "holographic-hud", label: "Holographic HUD" }, { value: "cinematic", label: "Cinematic Illustration" }]} value={styleProfile} onChange={setStyleProfile} className="mb-3" />
-
+          <FilterSelect label="Model" options={[{ value: "nano-banana-2", label: "Nano Banana 2" }, { value: "seed-dream-4.5", label: "Seed Dream 4.5" }]} value={model} onChange={setModel} className="mb-3" />
+          <FilterSelect label="Style Profile" options={[{ value: "holographic-hud", label: "Holographic HUD" }, { value: "cinematic-illustration", label: "Cinematic Illustration" }, { value: "cinematic-dossier", label: "Cinematic Dossier" }, { value: "clay-mannequin", label: "Clay Mannequin" }]} value={styleProfile} onChange={setStyleProfile} className="mb-3" />
           <div className="pt-3" style={{ borderTop: "1px solid var(--border-subtle)" }}>
             <p className="text-xs font-semibold mb-1" style={{ color: "var(--text-secondary)" }}>Cost Tracker</p>
             <p className="text-lg font-mono" style={{ color: "var(--gold)" }}>
-              ${(completedCount * 0.025).toFixed(3)} <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>/ ${(totalCount * 0.025).toFixed(2)}</span>
+              ${(doneSegments * 0.025).toFixed(3)} <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>/ ${(totalSegments * 0.025).toFixed(2)}</span>
             </p>
           </div>
         </GlassCard>

--- a/storyengine/frontend/src/lib/mock-data.ts
+++ b/storyengine/frontend/src/lib/mock-data.ts
@@ -9,6 +9,7 @@ import type {
   SettingsData,
   VoiceSegment,
   ImageGenItem,
+  SceneVisualGroup,
 } from "./types";
 
 export const MOCK_VIDEOS: Video[] = [
@@ -395,6 +396,54 @@ export const MOCK_IMAGE_GEN_ITEMS: ImageGenItem[] = Array.from({ length: 12 }, (
   progress: i < 3 ? 100 : i < 6 ? 100 : i < 9 ? Math.random() * 80 + 10 : 0,
   completed: i < 6,
 }));
+
+// Unified scene visuals — maps scenes → sentence texts → image prompts → images
+export const MOCK_SCENE_VISUALS: SceneVisualGroup[] = [
+  {
+    sceneNumber: 1, actNumber: 1,
+    narrationText: "In the shadow of a crumbling empire, one decision would reshape the balance of power across three continents — and almost nobody saw it coming.",
+    visualStyle: "dossier", composition: "wide", duration: "9s",
+    segments: [
+      { id: "v1-s1", segmentId: "S-01", sentenceText: "In the shadow of a crumbling empire,", imagePrompt: "Aerial dusk shot of a decaying imperial palace, crumbling marble columns, deep crimson sky fading to dark navy. Dossier style, Rembrandt side-lighting, wide establishing composition.", status: "done" },
+      { id: "v1-s2", segmentId: "S-02", sentenceText: "one decision would reshape the balance of power across three continents", imagePrompt: "Three-panel split screen showing continental maps — Europe, Middle East, Asia — connected by glowing red lines converging on a single point. Schema overlay, HUD grid elements, medium shot.", status: "done" },
+      { id: "v1-s3", segmentId: "S-03", sentenceText: "and almost nobody saw it coming.", imagePrompt: "Close-up of a diplomat's hands clasped on a mahogany table, documents scattered, a red 'CLASSIFIED' stamp visible. Dossier style, shallow depth of field, warm amber accent.", status: "generating" },
+    ],
+    storyboardPanels: Array.from({ length: 9 }, (_, i) => ({ id: `sb1-p${i + 1}`, selected: i === 0 })),
+  },
+  {
+    sceneNumber: 2, actNumber: 1,
+    narrationText: "The year was 2024. Behind closed doors in Tehran, a delegation sat across from envoys they had every reason to distrust — but desperation has a way of rewriting old grudges.",
+    visualStyle: "echo", composition: "medium", duration: "11s",
+    segments: [
+      { id: "v2-s1", segmentId: "S-04", sentenceText: "The year was 2024.", imagePrompt: "Title card style — bold '2024' in serif font overlaid on a blurred Tehran skyline at twilight. Echo painterly style, warm candlelit glow, cinematic grain.", status: "done" },
+      { id: "v2-s2", segmentId: "S-05", sentenceText: "Behind closed doors in Tehran, a delegation sat across from envoys they had every reason to distrust", imagePrompt: "Interior of an ornate Persian meeting room, two groups of officials seated across a long table, tension visible in body language. Echo historical style, oil painting texture, medium shot.", status: "done" },
+      { id: "v2-s3", segmentId: "S-06", sentenceText: "but desperation has a way of rewriting old grudges.", imagePrompt: "Close-up of two hands reaching across a table in a reluctant handshake, gold rings catching candlelight. Echo style, Caravaggio lighting, tight portrait crop.", status: "pending" },
+    ],
+    storyboardPanels: Array.from({ length: 9 }, (_, i) => ({ id: `sb2-p${i + 1}`, selected: false, approved: i === 4 })),
+    storyboardApproved: true,
+    selectedStoryboardPanel: 4,
+  },
+  {
+    sceneNumber: 3, actNumber: 1,
+    narrationText: "What they didn't know was that every word was being relayed in real-time to a situation room 4,000 miles away, where analysts were already calculating the cost of betrayal.",
+    visualStyle: "schema", composition: "closeup", duration: "10s",
+    segments: [
+      { id: "v3-s1", segmentId: "S-07", sentenceText: "What they didn't know was that every word was being relayed in real-time", imagePrompt: "Glowing data streams flowing through fiber optic cables, digital signal visualization with turquoise HUD overlay. Schema style, neon accents on dark background, environmental shot.", status: "done" },
+      { id: "v3-s2", segmentId: "S-08", sentenceText: "to a situation room 4,000 miles away,", imagePrompt: "Pentagon-style situation room with multiple screens showing satellite feeds, blue-lit operators at workstations. Schema HUD overlay, wide establishing shot, cold teal lighting.", status: "generating" },
+      { id: "v3-s3", segmentId: "S-09", sentenceText: "where analysts were already calculating the cost of betrayal.", imagePrompt: "Close-up of a screen showing risk assessment calculations, red warning indicators, a hand pointing at key data. Schema data overlay style, close-up composition, turquoise and red accent.", status: "pending" },
+    ],
+  },
+  {
+    sceneNumber: 4, actNumber: 2,
+    narrationText: "To understand how Iran fell into this trap, we need to rewind — not years, but decades — to a pattern that political theorists call the Thucydides Trap.",
+    visualStyle: "dossier", composition: "wide", duration: "10s",
+    segments: [
+      { id: "v4-s1", segmentId: "S-10", sentenceText: "To understand how Iran fell into this trap,", imagePrompt: "A chess board with Persian-styled pieces, one king piece tipping over in slow motion, dramatic spotlight. Dossier style, Rembrandt lighting, overhead shot.", status: "pending" },
+      { id: "v4-s2", segmentId: "S-11", sentenceText: "we need to rewind — not years, but decades", imagePrompt: "Time-lapse montage of Tehran skyline transforming from 1970s to present day, overlaid calendar pages peeling away. Dossier documentary style, wide pan composition.", status: "pending" },
+      { id: "v4-s3", segmentId: "S-12", sentenceText: "to a pattern that political theorists call the Thucydides Trap.", imagePrompt: "Ancient Greek marble bust of Thucydides with modern geopolitical map projected onto it, glowing connection lines. Echo/Schema hybrid, medium portrait composition.", status: "pending" },
+    ],
+  },
+];
 
 // Pipeline stage counts for the funnel
 export const PIPELINE_FUNNEL = [

--- a/storyengine/frontend/src/lib/types.ts
+++ b/storyengine/frontend/src/lib/types.ts
@@ -127,3 +127,25 @@ export interface ImageGenItem {
   completed: boolean;
   imageUrl?: string;
 }
+
+export interface VisualSegment {
+  id: string;
+  sentenceText: string;
+  imagePrompt: string;
+  imageUrl?: string;
+  status: "pending" | "generating" | "done";
+  segmentId: string;
+}
+
+export interface SceneVisualGroup {
+  sceneNumber: number;
+  actNumber: number;
+  narrationText: string;
+  visualStyle: string;
+  composition: string;
+  duration: string;
+  segments: VisualSegment[];
+  storyboardPanels?: StoryboardPanel[];
+  storyboardApproved?: boolean;
+  selectedStoryboardPanel?: number;
+}

--- a/storyengine/frontend/storyengine-frontend.service
+++ b/storyengine/frontend/storyengine-frontend.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=StoryEngine Frontend (Next.js)
+After=network.target
+
+[Service]
+Type=simple
+User=clawd
+WorkingDirectory=/home/clawd/projects/economy-fastforward/storyengine/frontend
+ExecStart=/usr/bin/npm run start
+Restart=always
+RestartSec=5
+Environment=NODE_ENV=production
+Environment=PORT=3001
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Unified Visuals tab merges Visuals + Storyboard into one flow: Scene → Sentence Text → Image Prompt → Image
- Every text field is editable inline (narration, sentence text, image prompts) for human-AI co-creation
- Storyboard toggle: ON adds 3x3 contact sheet grids per scene, OFF hides them
- Audio play button + mini waveform per scene
- Removed separate Storyboard tab from video detail (absorbed into Visuals)
- Added systemd service file for auto-starting frontend on VPS boot

## Test plan

- [ ] `/pipeline/v3` → Visuals tab: see scenes grouped by act with editable sentence text + image prompts
- [ ] Click any text field → becomes editable with turquoise/purple border
- [ ] Toggle Storyboard ON → 3x3 grids appear under each scene
- [ ] Toggle Storyboard OFF → grids disappear
- [ ] No "Storyboard" tab in the tab bar

## VPS auto-start setup
```bash
sudo cp storyengine/frontend/storyengine-frontend.service /etc/systemd/system/
sudo systemctl enable --now storyengine-frontend
```

https://claude.ai/code/session_01GcsbVCBbtuVtkkV1qxFT5X