### PR TITLE
feat(storyengine): Editable Script tab + inline SFX + collapsible acts

### DIFF
--- a/storyengine/frontend/src/app/pipeline/[videoId]/page.tsx
+++ b/storyengine/frontend/src/app/pipeline/[videoId]/page.tsx
@@ -4,8 +4,8 @@ import { useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import { motion } from "framer-motion";
 import {
-  ArrowLeft, FileText, Mic, Image as ImageIcon, LayoutGrid, Film,
-  BarChart3, Search, Volume2, Video, Upload, ImageIcon as Thumbnail,
+  ArrowLeft, FileText, Mic, Image as ImageIcon, Film,
+  BarChart3, Search, Video, Upload,
 } from "lucide-react";
 import Link from "next/link";
 import { StatusPill } from "@/components/ui/StatusPill";
@@ -15,7 +15,6 @@ import { ScriptTab } from "@/components/production/ScriptTab";
 import { VoiceReviewTab } from "@/components/production/VoiceReviewTab";
 import { VisualsTab } from "@/components/production/VisualsTab";
 import { VideoClipsTab } from "@/components/production/VideoClipsTab";
-import { SoundTab } from "@/components/production/SoundTab";
 
 import { ThumbnailTab } from "@/components/production/ThumbnailTab";
 import { RenderTab } from "@/components/production/RenderTab";
@@ -55,7 +54,6 @@ const TABS = [
   { id: "voice", label: "Voice & Storyboard", icon: Mic },
   { id: "visuals", label: "Visuals", icon: ImageIcon },
   { id: "clips", label: "Video Clips", icon: Video },
-  { id: "sound", label: "Sound", icon: Volume2 },
   { id: "thumbnail", label: "Thumbnail", icon: Film },
   { id: "render", label: "Render", icon: Film },
   { id: "upload", label: "Upload", icon: Upload },
@@ -175,8 +173,6 @@ export default function VideoDetailPage() {
         {activeTab === "voice" && <VoiceReviewTab video={video} />}
         {activeTab === "visuals" && <VisualsTab video={video} />}
         {activeTab === "clips" && <VideoClipsTab video={video} />}
-        {activeTab === "sound" && <SoundTab video={video} />}
-
         {activeTab === "thumbnail" && <ThumbnailTab video={video} />}
         {activeTab === "render" && <RenderTab video={video} />}
         {activeTab === "upload" && <UploadTab video={video} />}

--- a/storyengine/frontend/src/components/production/ScriptTab.tsx
+++ b/storyengine/frontend/src/components/production/ScriptTab.tsx
@@ -1,83 +1,367 @@
 "use client";
 
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Merge, Trash2, Plus, Volume2, Library, Wand2, Play, Pause } from "lucide-react";
 import { GlassCard } from "@/components/ui/GlassCard";
 import { SegmentBadge } from "@/components/ui/SegmentBadge";
 import { ActionButton } from "@/components/ui/ActionButton";
+import { MiniWaveform } from "@/components/ui/MiniWaveform";
+import { FilterSelect } from "@/components/ui/FilterSelect";
 import { MOCK_SCRIPT_SCENES } from "@/lib/mock-data";
-import type { Video } from "@/lib/types";
+import type { Video, ScriptScene } from "@/lib/types";
 
 interface ScriptTabProps {
   video: Video;
 }
 
+// SFX library presets
+const SFX_LIBRARY = [
+  { value: "", label: "— No SFX —" },
+  { value: "ambient-tension", label: "Ambient Tension" },
+  { value: "war-drums", label: "War Drums (distant)" },
+  { value: "paper-shuffle", label: "Paper Shuffle" },
+  { value: "door-close", label: "Heavy Door Close" },
+  { value: "crowd-murmur", label: "Crowd Murmur" },
+  { value: "typing", label: "Keyboard Typing" },
+  { value: "explosion-distant", label: "Distant Explosion" },
+  { value: "clock-ticking", label: "Clock Ticking" },
+  { value: "heartbeat", label: "Heartbeat" },
+  { value: "wind", label: "Desert Wind" },
+  { value: "helicopter", label: "Helicopter Flyover" },
+  { value: "news-broadcast", label: "News Broadcast Chatter" },
+  { value: "custom", label: "✦ Generate Custom..." },
+];
+
+interface SceneState extends ScriptScene {
+  soundMode: "none" | "library" | "custom";
+  soundLibraryValue: string;
+  soundCustomPrompt: string;
+}
+
 export function ScriptTab({ video }: ScriptTabProps) {
-  const actGroups = MOCK_SCRIPT_SCENES.reduce((acc, scene) => {
+  const [scenes, setScenes] = useState<SceneState[]>(
+    MOCK_SCRIPT_SCENES.map((s) => ({
+      ...s,
+      soundMode: "none",
+      soundLibraryValue: "",
+      soundCustomPrompt: "",
+    }))
+  );
+  const [collapsedActs, setCollapsedActs] = useState<Record<number, boolean>>({});
+  const [playingScene, setPlayingScene] = useState<number | null>(null);
+
+  // Group scenes by act
+  const actGroups = scenes.reduce((acc, scene) => {
     if (!acc[scene.actNumber]) acc[scene.actNumber] = [];
     acc[scene.actNumber].push(scene);
     return acc;
-  }, {} as Record<number, typeof MOCK_SCRIPT_SCENES>);
+  }, {} as Record<number, SceneState[]>);
+
+  const toggleAct = (actNum: number) => {
+    setCollapsedActs((prev) => ({ ...prev, [actNum]: !prev[actNum] }));
+  };
+
+  const updateNarration = (sceneNum: number, text: string) => {
+    setScenes((prev) => prev.map((s) => (s.sceneNumber === sceneNum ? { ...s, narrationText: text } : s)));
+  };
+
+  const updateSource = (sceneNum: number, srcIdx: number, text: string) => {
+    setScenes((prev) =>
+      prev.map((s) => {
+        if (s.sceneNumber !== sceneNum || !s.sources) return s;
+        const newSources = [...s.sources];
+        newSources[srcIdx] = text;
+        return { ...s, sources: newSources };
+      })
+    );
+  };
+
+  const updateVisualStyle = (sceneNum: number, style: string) => {
+    setScenes((prev) => prev.map((s) => (s.sceneNumber === sceneNum ? { ...s, visualStyle: style } : s)));
+  };
+
+  const updateComposition = (sceneNum: number, comp: string) => {
+    setScenes((prev) => prev.map((s) => (s.sceneNumber === sceneNum ? { ...s, composition: comp } : s)));
+  };
+
+  // Merge scene into the one above (append text, delete this scene)
+  const mergeUp = (sceneNum: number) => {
+    setScenes((prev) => {
+      const idx = prev.findIndex((s) => s.sceneNumber === sceneNum);
+      if (idx <= 0) return prev;
+      const merged = [...prev];
+      merged[idx - 1] = {
+        ...merged[idx - 1],
+        narrationText: merged[idx - 1].narrationText + " " + merged[idx].narrationText,
+      };
+      merged.splice(idx, 1);
+      return merged;
+    });
+  };
+
+  // Delete a scene
+  const deleteScene = (sceneNum: number) => {
+    setScenes((prev) => prev.filter((s) => s.sceneNumber !== sceneNum));
+  };
+
+  // Add a new scene after the given one
+  const addSceneAfter = (sceneNum: number) => {
+    setScenes((prev) => {
+      const idx = prev.findIndex((s) => s.sceneNumber === sceneNum);
+      const actNum = prev[idx]?.actNumber || 1;
+      const newScene: SceneState = {
+        sceneNumber: Math.max(...prev.map((s) => s.sceneNumber)) + 1,
+        actNumber: actNum,
+        narrationText: "",
+        visualStyle: "dossier",
+        composition: "medium",
+        sources: [],
+        imageGenerated: false,
+        soundMode: "none",
+        soundLibraryValue: "",
+        soundCustomPrompt: "",
+      };
+      const result = [...prev];
+      result.splice(idx + 1, 0, newScene);
+      return result;
+    });
+  };
+
+  // Sound controls
+  const updateSoundMode = (sceneNum: number, mode: "none" | "library" | "custom") => {
+    setScenes((prev) => prev.map((s) => (s.sceneNumber === sceneNum ? { ...s, soundMode: mode } : s)));
+  };
+
+  const updateSoundLibrary = (sceneNum: number, value: string) => {
+    setScenes((prev) =>
+      prev.map((s) => {
+        if (s.sceneNumber !== sceneNum) return s;
+        if (value === "custom") return { ...s, soundMode: "custom", soundLibraryValue: "" };
+        return { ...s, soundLibraryValue: value, soundMode: value ? "library" : "none" };
+      })
+    );
+  };
+
+  const updateSoundPrompt = (sceneNum: number, prompt: string) => {
+    setScenes((prev) => prev.map((s) => (s.sceneNumber === sceneNum ? { ...s, soundCustomPrompt: prompt } : s)));
+  };
+
+  const totalScenes = scenes.length;
+  const wordCount = scenes.reduce((sum, s) => sum + s.narrationText.split(/\s+/).filter(Boolean).length, 0);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-6">
       {/* Script scenes */}
-      <div className="space-y-6">
-        {Object.entries(actGroups).map(([actNum, scenes]) => (
-          <div key={actNum}>
-            <div className="flex items-center gap-4 mb-4">
-              <div className="flex-1 h-px" style={{ background: "var(--orange)", opacity: 0.3 }} />
-              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--orange)" }}>
-                Act {actNum}
-              </span>
-              <div className="flex-1 h-px" style={{ background: "var(--orange)", opacity: 0.3 }} />
-            </div>
+      <div className="space-y-4">
+        {Object.entries(actGroups).map(([actNum, actScenes]) => {
+          const isCollapsed = collapsedActs[Number(actNum)];
+          const actWordCount = actScenes.reduce((sum, s) => sum + s.narrationText.split(/\s+/).filter(Boolean).length, 0);
 
-            <div className="space-y-3">
-              {scenes.map((scene) => (
-                <GlassCard
-                  key={scene.sceneNumber}
-                  className="p-4"
-                  style={{
-                    borderLeftWidth: 3,
-                    borderLeftColor: scene.imageGenerated ? "var(--turquoise)" : "var(--orange)",
-                  }}
-                >
-                  <div className="flex items-start gap-3">
-                    <SegmentBadge
-                      label={`S-${String(scene.sceneNumber).padStart(2, "0")}`}
-                      color={scene.imageGenerated ? undefined : "var(--orange)"}
-                    />
-                    <div className="flex-1">
-                      <p className="text-sm leading-relaxed" style={{ color: "var(--text-primary)" }}>
-                        {scene.narrationText}
-                      </p>
+          return (
+            <div key={actNum}>
+              {/* Act header — clickable to collapse */}
+              <button
+                onClick={() => toggleAct(Number(actNum))}
+                className="flex items-center gap-3 w-full mb-3 group"
+              >
+                <div className="flex-1 h-px" style={{ background: "var(--orange)", opacity: 0.3 }} />
+                <div className="flex items-center gap-2 px-3 py-1 rounded-full transition-all"
+                  style={{ background: isCollapsed ? "rgba(255, 120, 73, 0.1)" : "transparent" }}>
+                  {isCollapsed ? (
+                    <ChevronRight size={14} style={{ color: "var(--orange)" }} />
+                  ) : (
+                    <ChevronDown size={14} style={{ color: "var(--orange)" }} />
+                  )}
+                  <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--orange)" }}>
+                    Act {actNum}
+                  </span>
+                  <span className="text-[10px] font-mono" style={{ color: "var(--text-tertiary)" }}>
+                    {actScenes.length} scenes · {actWordCount} words
+                  </span>
+                </div>
+                <div className="flex-1 h-px" style={{ background: "var(--orange)", opacity: 0.3 }} />
+              </button>
+
+              {/* Scenes (collapsible) */}
+              {!isCollapsed && (
+                <div className="space-y-3">
+                  {actScenes.map((scene, sceneIdx) => (
+                    <GlassCard
+                      key={scene.sceneNumber}
+                      className="p-4"
+                      style={{
+                        borderLeftWidth: 3,
+                        borderLeftColor: scene.imageGenerated ? "var(--turquoise)" : "var(--orange)",
+                      }}
+                    >
+                      {/* Scene header row */}
+                      <div className="flex items-center gap-2 mb-2">
+                        <SegmentBadge
+                          label={`S-${String(scene.sceneNumber).padStart(2, "0")}`}
+                          color={scene.imageGenerated ? undefined : "var(--orange)"}
+                        />
+                        {/* Play button */}
+                        <button
+                          onClick={() => setPlayingScene(playingScene === scene.sceneNumber ? null : scene.sceneNumber)}
+                          className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
+                          style={{ background: "var(--green)", color: "var(--bg-void)" }}
+                        >
+                          {playingScene === scene.sceneNumber ? <Pause size={10} /> : <Play size={10} className="ml-0.5" />}
+                        </button>
+                        <MiniWaveform color="var(--green)" width={60} height={16} bars={15} />
+
+                        <div className="flex-1" />
+
+                        {/* Scene actions */}
+                        <button
+                          onClick={() => mergeUp(scene.sceneNumber)}
+                          title="Merge into scene above"
+                          className="p-1 rounded transition-colors hover:bg-[var(--bg-surface)]"
+                          style={{ color: "var(--text-tertiary)" }}
+                        >
+                          <Merge size={12} />
+                        </button>
+                        <button
+                          onClick={() => addSceneAfter(scene.sceneNumber)}
+                          title="Add scene below"
+                          className="p-1 rounded transition-colors hover:bg-[var(--bg-surface)]"
+                          style={{ color: "var(--text-tertiary)" }}
+                        >
+                          <Plus size={12} />
+                        </button>
+                        <button
+                          onClick={() => deleteScene(scene.sceneNumber)}
+                          title="Delete scene"
+                          className="p-1 rounded transition-colors hover:bg-[var(--bg-surface)]"
+                          style={{ color: "var(--text-tertiary)" }}
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      </div>
+
+                      {/* Narration text — editable */}
+                      <textarea
+                        value={scene.narrationText}
+                        onChange={(e) => updateNarration(scene.sceneNumber, e.target.value)}
+                        rows={Math.max(2, Math.ceil(scene.narrationText.length / 100))}
+                        className="w-full text-sm leading-relaxed resize-none outline-none rounded-lg px-3 py-2 transition-all"
+                        style={{
+                          color: "var(--text-primary)",
+                          background: "transparent",
+                          border: "1px solid transparent",
+                        }}
+                        onFocus={(e) => { e.target.style.background = "var(--bg-elevated)"; e.target.style.borderColor = "var(--orange)"; }}
+                        onBlur={(e) => { e.target.style.background = "transparent"; e.target.style.borderColor = "transparent"; }}
+                      />
+
+                      {/* Sources — editable */}
                       {scene.sources && scene.sources.length > 0 && (
-                        <div className="flex gap-2 mt-2 flex-wrap">
-                          {scene.sources.map((src) => (
-                            <span
-                              key={src}
-                              className="text-[10px] font-mono px-2 py-0.5 rounded"
-                              style={{ background: "var(--yellow-dim)", color: "var(--yellow)" }}
-                            >
-                              [{src}]
-                            </span>
+                        <div className="flex gap-2 mt-1 flex-wrap items-center">
+                          {scene.sources.map((src, srcIdx) => (
+                            <input
+                              key={srcIdx}
+                              type="text"
+                              value={src}
+                              onChange={(e) => updateSource(scene.sceneNumber, srcIdx, e.target.value)}
+                              className="text-[10px] font-mono px-2 py-0.5 rounded outline-none w-auto"
+                              style={{
+                                background: "var(--yellow-dim)",
+                                color: "var(--yellow)",
+                                border: "1px solid transparent",
+                                width: `${Math.max(src.length * 7 + 20, 60)}px`,
+                              }}
+                              onFocus={(e) => { e.target.style.borderColor = "var(--yellow)"; }}
+                              onBlur={(e) => { e.target.style.borderColor = "transparent"; }}
+                            />
                           ))}
                         </div>
                       )}
-                      <div className="flex items-center gap-3 mt-2">
-                        <span className="text-[10px] font-mono" style={{ color: "var(--text-tertiary)" }}>
-                          {scene.visualStyle}
-                        </span>
-                        <span className="text-[10px] font-mono" style={{ color: "var(--text-tertiary)" }}>
-                          {scene.composition}
-                        </span>
+
+                      {/* Visual style + composition — editable */}
+                      <div className="flex items-center gap-2 mt-2">
+                        <input
+                          type="text"
+                          value={scene.visualStyle}
+                          onChange={(e) => updateVisualStyle(scene.sceneNumber, e.target.value)}
+                          className="text-[10px] font-mono px-2 py-0.5 rounded outline-none w-20"
+                          style={{ color: "var(--text-tertiary)", background: "transparent", border: "1px solid transparent" }}
+                          onFocus={(e) => { e.target.style.background = "var(--bg-elevated)"; e.target.style.borderColor = "var(--turquoise)"; }}
+                          onBlur={(e) => { e.target.style.background = "transparent"; e.target.style.borderColor = "transparent"; }}
+                        />
+                        <input
+                          type="text"
+                          value={scene.composition}
+                          onChange={(e) => updateComposition(scene.sceneNumber, e.target.value)}
+                          className="text-[10px] font-mono px-2 py-0.5 rounded outline-none w-24"
+                          style={{ color: "var(--text-tertiary)", background: "transparent", border: "1px solid transparent" }}
+                          onFocus={(e) => { e.target.style.background = "var(--bg-elevated)"; e.target.style.borderColor = "var(--turquoise)"; }}
+                          onBlur={(e) => { e.target.style.background = "transparent"; e.target.style.borderColor = "transparent"; }}
+                        />
                       </div>
-                    </div>
-                  </div>
-                </GlassCard>
-              ))}
+
+                      {/* Sound FX section — inline */}
+                      <div className="mt-3 pt-3" style={{ borderTop: "1px solid rgba(255,255,255,0.04)" }}>
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <Volume2 size={12} style={{ color: "var(--gold)", opacity: 0.6 }} />
+                          <span className="text-[9px] uppercase tracking-wider font-medium" style={{ color: "var(--gold)" }}>
+                            SFX
+                          </span>
+
+                          {/* Library selector */}
+                          <select
+                            value={scene.soundMode === "library" ? scene.soundLibraryValue : scene.soundMode === "custom" ? "custom" : ""}
+                            onChange={(e) => updateSoundLibrary(scene.sceneNumber, e.target.value)}
+                            className="text-[11px] font-mono px-2 py-1 rounded-lg outline-none flex-1 max-w-[200px]"
+                            style={{
+                              background: "var(--bg-elevated)",
+                              color: "var(--text-secondary)",
+                              border: "1px solid var(--border-subtle)",
+                            }}
+                          >
+                            {SFX_LIBRARY.map((sfx) => (
+                              <option key={sfx.value} value={sfx.value}>{sfx.label}</option>
+                            ))}
+                          </select>
+
+                          {scene.soundMode === "library" && scene.soundLibraryValue && (
+                            <button
+                              className="w-5 h-5 rounded-full flex items-center justify-center"
+                              style={{ background: "var(--green)", color: "var(--bg-void)" }}
+                              title="Preview sound"
+                            >
+                              <Play size={8} className="ml-px" />
+                            </button>
+                          )}
+                        </div>
+
+                        {/* Custom prompt — only when "Generate Custom" selected */}
+                        {scene.soundMode === "custom" && (
+                          <div className="mt-2 flex items-start gap-2">
+                            <Wand2 size={12} style={{ color: "var(--purple)", marginTop: 6 }} />
+                            <textarea
+                              value={scene.soundCustomPrompt}
+                              onChange={(e) => updateSoundPrompt(scene.sceneNumber, e.target.value)}
+                              placeholder="Describe the sound effect you want AI to generate..."
+                              rows={2}
+                              className="flex-1 text-[11px] font-mono outline-none rounded-lg px-2 py-1.5 resize-none transition-all"
+                              style={{
+                                color: "var(--text-secondary)",
+                                background: "var(--bg-elevated)",
+                                border: "1px solid var(--purple-dim)",
+                              }}
+                              onFocus={(e) => { e.target.style.borderColor = "var(--purple)"; }}
+                              onBlur={(e) => { e.target.style.borderColor = "var(--purple-dim)"; }}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </GlassCard>
+                  ))}
+                </div>
+              )}
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Metadata sidebar */}
@@ -89,8 +373,8 @@ export function ScriptTab({ video }: ScriptTabProps) {
           <div className="space-y-3">
             {[
               { label: "Framework", value: video.framework || "—" },
-              { label: "Word Count", value: String(video.wordCount || 0) },
-              { label: "Scene Count", value: String(video.sceneCount || 0) },
+              { label: "Word Count", value: String(wordCount) },
+              { label: "Scene Count", value: String(totalScenes) },
               { label: "Target Length", value: `${video.videoLengthMin || 0} min` },
               { label: "Est. Cost", value: `$${(video.estimatedCost || 0).toFixed(2)}` },
             ].map((row) => (
@@ -99,6 +383,19 @@ export function ScriptTab({ video }: ScriptTabProps) {
                 <span className="text-sm font-mono font-medium" style={{ color: "var(--text-primary)" }}>{row.value}</span>
               </div>
             ))}
+          </div>
+        </GlassCard>
+
+        <GlassCard className="p-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "var(--gold)" }}>
+            SFX Library
+          </h3>
+          <p className="text-[10px] mb-3" style={{ color: "var(--text-tertiary)" }}>
+            Select from presets or generate custom SFX per scene. Library sounds are free, custom generation costs ~$0.02 each.
+          </p>
+          <div className="flex items-center gap-2 text-[10px] font-mono">
+            <Library size={12} style={{ color: "var(--gold)" }} />
+            <span style={{ color: "var(--text-secondary)" }}>{SFX_LIBRARY.length - 2} presets</span>
           </div>
         </GlassCard>
 


### PR DESCRIPTION
## Summary

- Script tab fully rewritten: every text field editable inline (narration, sources, visual style, composition)
- Collapsible acts: click act header to collapse/expand with scene count + word count
- Sentence merge: pull text from scene below into current, delete the lower one
- Add/delete scenes with + and trash buttons
- Inline SFX per scene: 12 preset sounds from library dropdown, or "Generate Custom" AI prompt
- Play button + mini waveform per scene
- Live word count in sidebar
- Sound tab removed (SFX now lives inline per scene in Script tab)
- Tab bar reduced to 9 tabs

## Test plan

- [ ] `/pipeline/v5` → Script tab: click act header to collapse/expand
- [ ] Click any narration text → editable textarea with orange border
- [ ] Click merge button → text merges with scene above
- [ ] SFX dropdown → select preset or "Generate Custom" → shows AI prompt textarea
- [ ] Sidebar word count updates as you type
- [ ] No "Sound" tab in the tab bar

https://claude.ai/code/session_01GcsbVCBbtuVtkkV1qxFT5X