### PR TITLE
fix: Sort script scenes by scene number

### DIFF
--- a/storyengine/frontend/src/components/production/ScriptTab.tsx
+++ b/storyengine/frontend/src/components/production/ScriptTab.tsx
@@ -67,9 +67,10 @@ interface SceneState {
 }
 
 function initFromApi(apiScenes: ApiScriptScene[]): SceneState[] {
-  const total = apiScenes.length;
+  const sorted = [...apiScenes].sort((a, b) => (a.scene || 0) - (b.scene || 0));
+  const total = sorted.length;
   const actsCount = Math.min(total, 6);
-  return apiScenes.map((s) => ({
+  return sorted.map((s) => ({
     sceneNumber: s.scene || 0,
     actNumber: Math.ceil((s.scene || 1) / Math.ceil(total / actsCount)),
     narrationText: s.scene_text || "",


### PR DESCRIPTION
Sort script scenes by scene number before rendering. API returns in creation order, not scene order.

https://claude.ai/code/session_01GcsbVCBbtuVtkkV1qxFT5X