### PR TITLE
feat: Pipeline reset + real sentence expansion

### DIFF
--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 
 from auth import get_tenant_id
-from database import fetch_one
+from database import fetch_one, execute
 from pipeline_executor import PipelineExecutor
 from status_map import to_supabase, to_pipeline, get_next_status_supabase
 
@@ -865,3 +865,92 @@ async def orchestrate_decide_only(
             "reasoning": f"Orchestrator error: {e}",
             "confidence": 0.0,
         }
+
+
+# --- Reset Pipeline ---
+
+class ResetRequest(BaseModel):
+    """Request to reset a video's pipeline stage."""
+    reset_to: str = "ready_for_scripting"  # Which status to reset to
+
+
+@router.post("/reset/{video_id}")
+async def reset_pipeline(
+    video_id: str,
+    request: ResetRequest,
+    tenant_id: str = Depends(get_tenant_id),
+):
+    """Reset a video's pipeline — delete downstream data and set status back.
+
+    reset_to options:
+    - "ready_for_scripting" — delete scripts + assets, keep research
+    - "ready_for_voice" — delete voice audio, keep scripts
+    - "ready_for_images" — delete images, keep prompts
+    """
+    video = await fetch_one(
+        "SELECT id, status FROM videos WHERE id = $1 AND tenant_id = $2",
+        video_id, tenant_id,
+    )
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    reset_to = request.reset_to
+    deleted = {"scripts": 0, "assets": 0}
+
+    if reset_to == "ready_for_scripting":
+        # Delete all scripts and assets for this video
+        result = await execute(
+            "DELETE FROM scripts WHERE video_id = $1 AND tenant_id = $2",
+            video_id, tenant_id,
+        )
+        deleted["scripts"] = int(result.split()[-1]) if result else 0
+
+        result = await execute(
+            "DELETE FROM assets WHERE video_id = $1 AND tenant_id = $2",
+            video_id, tenant_id,
+        )
+        deleted["assets"] = int(result.split()[-1]) if result else 0
+
+        # Clear script field on video
+        await execute(
+            "UPDATE videos SET script = NULL, status = $1 WHERE id = $2 AND tenant_id = $3",
+            reset_to, video_id, tenant_id,
+        )
+
+    elif reset_to == "ready_for_voice":
+        # Clear voice URLs from scripts
+        await execute(
+            "UPDATE scripts SET voice_over_url = NULL, voice_status = 'Create' WHERE video_id = $1 AND tenant_id = $2",
+            video_id, tenant_id,
+        )
+        await execute(
+            "UPDATE videos SET status = $1 WHERE id = $2 AND tenant_id = $3",
+            reset_to, video_id, tenant_id,
+        )
+
+    elif reset_to in ("ready_for_image_prompts", "ready_for_images"):
+        # Delete assets (images)
+        result = await execute(
+            "DELETE FROM assets WHERE video_id = $1 AND tenant_id = $2",
+            video_id, tenant_id,
+        )
+        deleted["assets"] = int(result.split()[-1]) if result else 0
+
+        await execute(
+            "UPDATE videos SET status = $1 WHERE id = $2 AND tenant_id = $3",
+            reset_to, video_id, tenant_id,
+        )
+
+    else:
+        # Just update status
+        await execute(
+            "UPDATE videos SET status = $1 WHERE id = $2 AND tenant_id = $3",
+            reset_to, video_id, tenant_id,
+        )
+
+    return {
+        "status": "reset",
+        "video_id": video_id,
+        "reset_to": reset_to,
+        "deleted": deleted,
+    }

--- a/storyengine/frontend/src/app/pipeline/[videoId]/page.tsx
+++ b/storyengine/frontend/src/app/pipeline/[videoId]/page.tsx
@@ -5,11 +5,11 @@ import { useParams } from "next/navigation";
 import { motion } from "framer-motion";
 import {
   ArrowLeft, FileText, Mic, Image as ImageIcon, Film,
-  BarChart3, Search, Video, Upload, Loader2,
+  BarChart3, Search, Video, Upload, Loader2, RotateCcw,
 } from "lucide-react";
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
-import { getVideo } from "@/lib/api";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getVideo, resetPipeline } from "@/lib/api";
 import { StatusPill } from "@/components/ui/StatusPill";
 import { ProgressStepper } from "@/components/ui/ProgressStepper";
 import { ResearchTab } from "@/components/production/ResearchTab";
@@ -113,6 +113,7 @@ function getDefaultTab(status: string): string {
 export default function VideoDetailPage() {
   const params = useParams();
   const videoId = params.videoId as string;
+  const queryClient = useQueryClient();
 
   const { data: video, isLoading, error } = useQuery({
     queryKey: ["video", videoId],
@@ -122,7 +123,26 @@ export default function VideoDetailPage() {
   const status = video?.status || "idea_logged";
   const defaultTab = useMemo(() => getDefaultTab(status), [status]);
   const [activeTab, setActiveTab] = useState<string | null>(null);
+  const [resetting, setResetting] = useState(false);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
   const currentTab = activeTab || defaultTab;
+
+  const handleReset = async (resetTo: string) => {
+    setResetting(true);
+    try {
+      await resetPipeline(videoId, resetTo);
+      // Invalidate all queries for this video to refetch fresh data
+      queryClient.invalidateQueries({ queryKey: ["video", videoId] });
+      queryClient.invalidateQueries({ queryKey: ["video-script", videoId] });
+      queryClient.invalidateQueries({ queryKey: ["video-assets", videoId] });
+      setShowResetConfirm(false);
+      setActiveTab("research");
+    } catch (err) {
+      alert(`Reset failed: ${(err as Error).message}`);
+    } finally {
+      setResetting(false);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -202,13 +222,67 @@ export default function VideoDetailPage() {
             )}
           </div>
         </div>
-        <div className="text-right">
-          <p className="text-xs font-mono" style={{ color: "var(--text-tertiary)" }}>
-            Est. Cost
-          </p>
-          <p className="text-lg font-mono font-semibold" style={{ color: "var(--gold)" }}>
-            ${(video.total_cost || 0).toFixed(2)}
-          </p>
+        <div className="flex items-center gap-4">
+          <div className="text-right">
+            <p className="text-xs font-mono" style={{ color: "var(--text-tertiary)" }}>
+              Est. Cost
+            </p>
+            <p className="text-lg font-mono font-semibold" style={{ color: "var(--gold)" }}>
+              ${(video.total_cost || 0).toFixed(2)}
+            </p>
+          </div>
+
+          {/* Reset button */}
+          <div className="relative">
+            <button
+              onClick={() => setShowResetConfirm(!showResetConfirm)}
+              className="p-2 rounded-lg transition-all hover:bg-[var(--bg-surface)]"
+              style={{ color: "var(--text-tertiary)" }}
+              title="Reset pipeline"
+            >
+              <RotateCcw size={16} />
+            </button>
+
+            {showResetConfirm && (
+              <div
+                className="absolute right-0 top-full mt-2 z-50 w-56 rounded-xl p-4 space-y-2"
+                style={{ background: "var(--bg-deep)", border: "1px solid var(--border)", boxShadow: "0 8px 32px rgba(0,0,0,0.5)" }}
+              >
+                <p className="text-xs font-semibold mb-2" style={{ color: "var(--text-primary)" }}>Reset to:</p>
+                <button
+                  onClick={() => handleReset("ready_for_scripting")}
+                  disabled={resetting}
+                  className="w-full text-left text-xs px-3 py-2 rounded-lg transition-all hover:bg-[var(--bg-surface)]"
+                  style={{ color: "var(--orange)" }}
+                >
+                  {resetting ? "Resetting..." : "Script Stage"} <span style={{ color: "var(--text-tertiary)" }}>— delete scripts + images</span>
+                </button>
+                <button
+                  onClick={() => handleReset("ready_for_voice")}
+                  disabled={resetting}
+                  className="w-full text-left text-xs px-3 py-2 rounded-lg transition-all hover:bg-[var(--bg-surface)]"
+                  style={{ color: "var(--green)" }}
+                >
+                  Voice Stage <span style={{ color: "var(--text-tertiary)" }}>— keep scripts, redo voice</span>
+                </button>
+                <button
+                  onClick={() => handleReset("ready_for_images")}
+                  disabled={resetting}
+                  className="w-full text-left text-xs px-3 py-2 rounded-lg transition-all hover:bg-[var(--bg-surface)]"
+                  style={{ color: "var(--purple)" }}
+                >
+                  Images Stage <span style={{ color: "var(--text-tertiary)" }}>— keep scripts, redo images</span>
+                </button>
+                <button
+                  onClick={() => setShowResetConfirm(false)}
+                  className="w-full text-xs px-3 py-1.5 rounded-lg mt-1"
+                  style={{ color: "var(--text-tertiary)" }}
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </motion.div>
 

--- a/storyengine/frontend/src/lib/api.ts
+++ b/storyengine/frontend/src/lib/api.ts
@@ -148,6 +148,13 @@ export const launchCandidate = (candidateId: string) =>
     { method: "POST" }
   );
 
+// Pipeline reset
+export const resetPipeline = (videoId: string, resetTo: string) =>
+  fetchApi<{ status: string; video_id: string; reset_to: string; deleted: { scripts: number; assets: number } }>(
+    `/api/pipeline/reset/${videoId}`,
+    { method: "POST", body: JSON.stringify({ reset_to: resetTo }) }
+  );
+
 // Agent Quality Pipeline
 export const getAgentStats = () =>
   fetchApi<AgentStats>("/api/agents/stats");


### PR DESCRIPTION
## Summary
- Pipeline reset endpoint (POST /api/pipeline/reset/{videoId}) — delete scripts/assets and reset status
- Reset button (↻) in video detail header with 3 options: Script Stage, Voice Stage, Images Stage
- ScriptTab Expand uses real sentence_text from assets (fixes 38→16 count)

## Test plan
- [ ] Click ↻ button on drone video → select "Script Stage" → deletes scripts + assets, resets to research
- [ ] Research tab still shows data after reset
- [ ] Script tab shows "Script not generated yet" after reset

https://claude.ai/code/session_01GcsbVCBbtuVtkkV1qxFT5X