### PR TITLE
fix(storyengine): Fix character gen, delete buttons, style profile schema

### DIFF
--- a/storyengine/backend/routes/visual_styles.py
+++ b/storyengine/backend/routes/visual_styles.py
@@ -187,7 +187,8 @@ async def generate_character(
                 raise HTTPException(status_code=502, detail=detail)
 
             task_data = create_resp.json()
-            task_id = task_data.get("data", {}).get("task_id") or task_data.get("task_id")
+            data = task_data.get("data", {})
+            task_id = data.get("task_id") or data.get("taskId") or task_data.get("task_id") or task_data.get("taskId")
 
             if not task_id:
                 raise HTTPException(
@@ -195,38 +196,38 @@ async def generate_character(
                     detail=f"No task_id in response: {json.dumps(task_data)[:300]}",
                 )
 
-            # Poll for completion — 5s interval, 60 attempts (5 minutes)
+            # Poll for completion — correct endpoint: /jobs/recordInfo?taskId=xxx
+            # 5s interval, 60 attempts (5 minutes)
             for attempt in range(60):
                 await asyncio.sleep(5)
                 status_resp = await client.get(
-                    f"https://api.kie.ai/api/v1/jobs/getTaskStatus/{task_id}",
+                    "https://api.kie.ai/api/v1/jobs/recordInfo",
+                    params={"taskId": task_id},
                     headers={"Authorization": f"Bearer {api_key}"},
                 )
                 if status_resp.status_code != 200:
                     continue  # Transient error, keep polling
 
                 status_data = status_resp.json()
-                task_status = status_data.get("data", {}).get("status")
+                data = status_data.get("data", {})
+                task_status = data.get("status")
+                task_state = data.get("state")
 
-                if task_status == "completed" or task_status == 2:
-                    # Extract image URL
-                    output = status_data.get("data", {}).get("output")
-                    if isinstance(output, list) and output:
-                        image_url = output[0]
-                    elif isinstance(output, str):
-                        image_url = output
-                    else:
-                        image_url = None
-
-                    if image_url:
-                        return {"status": "ok", "image_url": image_url, "prompt": full_prompt}
-                    raise HTTPException(
-                        status_code=500,
-                        detail=f"Completed but no image URL: {json.dumps(status_data.get('data', {}))[:300]}",
-                    )
-                elif task_status == "failed" or task_status == 3:
-                    error_msg = status_data.get("data", {}).get("error", "Unknown error")
+                # Check for failure (status=3 or state contains "fail")
+                if (task_status == 3
+                    or str(task_status).lower() in ("failed", "failure", "error")
+                    or str(task_state).lower() in ("fail", "failed", "failure", "error")):
+                    error_msg = data.get("errorMessage") or data.get("error") or "Unknown error"
                     raise HTTPException(status_code=500, detail=f"Generation failed: {error_msg}")
+
+                # Check for completion — extract from resultJson.resultUrls
+                result_json = data.get("resultJson")
+                if result_json:
+                    if isinstance(result_json, str):
+                        result_json = json.loads(result_json)
+                    result_urls = result_json.get("resultUrls", [])
+                    if result_urls:
+                        return {"status": "ok", "image_url": result_urls[0], "prompt": full_prompt}
 
             raise HTTPException(status_code=504, detail="Generation timed out after 5 minutes")
 

--- a/storyengine/backend/routes/visual_styles.py
+++ b/storyengine/backend/routes/visual_styles.py
@@ -5,6 +5,7 @@ Only one style per project can be active at a time.
 Characters belong to a specific style and cascade-delete with it.
 """
 
+import asyncio
 import json
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
@@ -110,7 +111,132 @@ async def _list_styles_with_characters(project_id: str) -> list[VisualStyleRead]
     return result
 
 
-# --- Endpoints ---
+# =============================================================
+# IMPORTANT: Non-parameterized routes MUST come BEFORE /{style_id}
+# routes to avoid FastAPI matching "characters" as a style_id.
+# =============================================================
+
+# --- Character generation (Kie.ai) — must be before /{style_id} routes ---
+
+@router.post("/characters/generate")
+async def generate_character(
+    req: GenerateCharacterRequest,
+    tenant_id: str = Depends(get_tenant_id),
+):
+    """Generate a character image using Kie.ai Nano Banana 2.
+
+    Assembles a prompt from the user's description + the active style's profile.
+    Uses the user's own Kie.ai API key from Vault.
+    """
+    import httpx
+    from vault import get_secret
+
+    project_id = await _get_project_id(tenant_id)
+
+    # Get the style's profile for context
+    style = await fetch_one(
+        "SELECT id, style_profile FROM visual_styles WHERE id = $1 AND project_id = $2",
+        req.style_id, project_id,
+    )
+    if not style:
+        raise HTTPException(status_code=404, detail="Style not found")
+
+    # Get Kie.ai API key
+    api_key = await get_secret("kie_ai_api_key", tenant_id)
+    if not api_key:
+        raise HTTPException(
+            status_code=400,
+            detail="Kie.ai API key not configured. Go to Settings → API Keys to add it.",
+        )
+
+    # Build prompt from style context + user description
+    profile = _parse_jsonb(style["style_profile"], {})
+
+    # Prefer prompt_prefix (new detailed schema) over assembling from parts
+    prompt_prefix = profile.get("prompt_prefix", "")
+    if not prompt_prefix:
+        # Fallback: assemble from individual fields (old schema)
+        lighting = profile.get("lighting", "")
+        mood = profile.get("mood", "")
+        texture = profile.get("texture", "")
+        prompt_prefix = f"{lighting}. {mood}. {texture}."
+
+    full_prompt = f"{prompt_prefix.rstrip('.')}. {req.prompt.strip()}. No text, no watermarks."
+
+    # Call Kie.ai API — correct format per image_client.py
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(300, connect=10)) as client:
+            # Create task
+            create_resp = await client.post(
+                "https://api.kie.ai/api/v1/jobs/createTask",
+                json={
+                    "model": "nano-banana-2",
+                    "input": {
+                        "prompt": full_prompt,
+                        "aspect_ratio": "1:1",
+                        "output_format": "png",
+                    },
+                },
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            if create_resp.status_code != 200:
+                detail = f"Kie.ai createTask failed: HTTP {create_resp.status_code} — {create_resp.text[:300]}"
+                raise HTTPException(status_code=502, detail=detail)
+
+            task_data = create_resp.json()
+            task_id = task_data.get("data", {}).get("task_id") or task_data.get("task_id")
+
+            if not task_id:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"No task_id in response: {json.dumps(task_data)[:300]}",
+                )
+
+            # Poll for completion — 5s interval, 60 attempts (5 minutes)
+            for attempt in range(60):
+                await asyncio.sleep(5)
+                status_resp = await client.get(
+                    f"https://api.kie.ai/api/v1/jobs/getTaskStatus/{task_id}",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                if status_resp.status_code != 200:
+                    continue  # Transient error, keep polling
+
+                status_data = status_resp.json()
+                task_status = status_data.get("data", {}).get("status")
+
+                if task_status == "completed" or task_status == 2:
+                    # Extract image URL
+                    output = status_data.get("data", {}).get("output")
+                    if isinstance(output, list) and output:
+                        image_url = output[0]
+                    elif isinstance(output, str):
+                        image_url = output
+                    else:
+                        image_url = None
+
+                    if image_url:
+                        return {"status": "ok", "image_url": image_url, "prompt": full_prompt}
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Completed but no image URL: {json.dumps(status_data.get('data', {}))[:300]}",
+                    )
+                elif task_status == "failed" or task_status == 3:
+                    error_msg = status_data.get("data", {}).get("error", "Unknown error")
+                    raise HTTPException(status_code=500, detail=f"Generation failed: {error_msg}")
+
+            raise HTTPException(status_code=504, detail="Generation timed out after 5 minutes")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Kie.ai API error: {str(e)}")
+
+
+# --- List + Create (non-parameterized) ---
 
 @router.get("", response_model=list[VisualStyleRead])
 async def list_visual_styles(tenant_id: str = Depends(get_tenant_id)):
@@ -153,6 +279,8 @@ async def create_visual_style(
     )
 
 
+# --- Parameterized routes (/{style_id}) ---
+
 @router.put("/{style_id}/activate", response_model=list[VisualStyleRead])
 async def activate_visual_style(
     style_id: str,
@@ -161,7 +289,6 @@ async def activate_visual_style(
     """Set a style as active. Deactivates all others for this project."""
     project_id = await _get_project_id(tenant_id)
 
-    # Verify style belongs to this project
     style = await fetch_one(
         "SELECT id FROM visual_styles WHERE id = $1 AND project_id = $2",
         style_id, project_id,
@@ -169,7 +296,6 @@ async def activate_visual_style(
     if not style:
         raise HTTPException(status_code=404, detail="Style not found")
 
-    # Deactivate all, then activate the selected one
     await execute(
         "UPDATE visual_styles SET is_active = false, updated_at = now() WHERE project_id = $1",
         project_id,
@@ -201,12 +327,15 @@ async def delete_visual_style(
 
     # If deleting the active style, activate the first default
     if style["is_active"]:
-        await execute(
-            """UPDATE visual_styles SET is_active = true, updated_at = now()
-               WHERE project_id = $1 AND is_default = true
-               ORDER BY created_at LIMIT 1""",
+        first_default = await fetch_one(
+            "SELECT id FROM visual_styles WHERE project_id = $1 AND is_default = true ORDER BY created_at LIMIT 1",
             project_id,
         )
+        if first_default:
+            await execute(
+                "UPDATE visual_styles SET is_active = true, updated_at = now() WHERE id = $1",
+                str(first_default["id"]),
+            )
 
     # Cascade deletes characters via FK
     await execute("DELETE FROM visual_styles WHERE id = $1", style_id)
@@ -225,7 +354,6 @@ async def create_character(
     """Create a character for a visual style."""
     project_id = await _get_project_id(tenant_id)
 
-    # Verify style belongs to project
     style = await fetch_one(
         "SELECT id FROM visual_styles WHERE id = $1 AND project_id = $2",
         style_id, project_id,
@@ -238,7 +366,6 @@ async def create_character(
     if not req.image_url or not req.image_url.strip():
         raise HTTPException(status_code=400, detail="Character image is required")
 
-    # Get next sort order
     max_order = await fetch_one(
         "SELECT COALESCE(MAX(sort_order), -1) as max_order FROM style_characters WHERE visual_style_id = $1",
         style_id,
@@ -272,7 +399,6 @@ async def delete_character(
     """Delete a character from a style."""
     project_id = await _get_project_id(tenant_id)
 
-    # Verify style belongs to project
     style = await fetch_one(
         "SELECT id FROM visual_styles WHERE id = $1 AND project_id = $2",
         style_id, project_id,
@@ -280,96 +406,9 @@ async def delete_character(
     if not style:
         raise HTTPException(status_code=404, detail="Style not found")
 
-    result = await execute(
+    await execute(
         "DELETE FROM style_characters WHERE id = $1 AND visual_style_id = $2",
         character_id, style_id,
     )
 
     return {"status": "ok"}
-
-
-# --- Character generation (Kie.ai) ---
-
-@router.post("/characters/generate")
-async def generate_character(
-    req: GenerateCharacterRequest,
-    tenant_id: str = Depends(get_tenant_id),
-):
-    """Generate a character image using Kie.ai Nano Banana 2.
-
-    Assembles a prompt from the user's description + the active style's profile.
-    Uses the user's own Kie.ai API key from Vault.
-    """
-    import httpx
-    from vault import get_secret
-
-    project_id = await _get_project_id(tenant_id)
-
-    # Get the style's profile for context
-    style = await fetch_one(
-        "SELECT id, style_profile FROM visual_styles WHERE id = $1 AND project_id = $2",
-        req.style_id, project_id,
-    )
-    if not style:
-        raise HTTPException(status_code=404, detail="Style not found")
-
-    # Get Kie.ai API key
-    api_key = await get_secret("kie_ai_api_key", tenant_id)
-    if not api_key:
-        raise HTTPException(
-            status_code=400,
-            detail="Kie.ai API key not configured. Go to Settings → API Keys to add it.",
-        )
-
-    # Build prompt from style context + user description
-    profile = _parse_jsonb(style["style_profile"], {})
-    lighting = profile.get("lighting", "")
-    mood = profile.get("mood", "")
-    texture = profile.get("texture", "")
-
-    full_prompt = f"{lighting}. {mood}. {req.prompt.strip()}. {texture}. No text, no watermarks."
-
-    # Call Kie.ai API
-    try:
-        async with httpx.AsyncClient(timeout=60) as client:
-            # Create task
-            create_resp = await client.post(
-                "https://api.kie.ai/api/v1/jobs/createTask",
-                json={
-                    "model": "nano-banana-2",
-                    "prompt": full_prompt,
-                    "aspect_ratio": "1:1",
-                },
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            create_resp.raise_for_status()
-            task_data = create_resp.json()
-            task_id = task_data.get("data", {}).get("task_id") or task_data.get("task_id")
-
-            if not task_id:
-                raise HTTPException(status_code=500, detail="Failed to create generation task")
-
-            # Poll for completion (up to 60s)
-            import asyncio
-            for _ in range(30):
-                await asyncio.sleep(2)
-                status_resp = await client.get(
-                    f"https://api.kie.ai/api/v1/jobs/getTaskStatus/{task_id}",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                )
-                status_resp.raise_for_status()
-                status_data = status_resp.json()
-                task_status = status_data.get("data", {}).get("status", 0)
-
-                if task_status == 2:  # Success
-                    image_url = status_data.get("data", {}).get("output", [None])[0]
-                    if image_url:
-                        return {"status": "ok", "image_url": image_url, "prompt": full_prompt}
-                    raise HTTPException(status_code=500, detail="Generation succeeded but no image URL returned")
-                elif task_status == 3:  # Failed
-                    raise HTTPException(status_code=500, detail="Image generation failed")
-
-            raise HTTPException(status_code=504, detail="Generation timed out after 60s")
-
-    except httpx.HTTPError as e:
-        raise HTTPException(status_code=502, detail=f"Kie.ai API error: {str(e)}")

--- a/storyengine/frontend/src/app/profile/page.tsx
+++ b/storyengine/frontend/src/app/profile/page.tsx
@@ -119,16 +119,37 @@ export default function ProfilePage() {
       setIsAnalyzing(true);
       setAnalysisResult(null);
       setIsEditingJson(false);
-      // Simulate AI analysis (production: Claude Vision / Gemini API)
+      // Simulate AI analysis (production: call Gemini Vision API with detailed extraction prompt)
+      // TODO: Replace with real Gemini API call using the detailed style extraction prompt
       setTimeout(() => {
         setIsAnalyzing(false);
         const result = JSON.stringify({
+          style_name_suggestion: "Dark Editorial Cinema",
+          art_medium: "Digital painting with photorealistic rendering",
+          rendering_style: "Soft gradient shading with subtle brush strokes, volumetric lighting effects",
+          line_work: "No outlines, soft edges with atmospheric blending",
+          color_palette: {
+            primary: "#1A1A2E",
+            secondary: "#0F3460",
+            accent: "#E94560",
+            highlight: "#F0C75E",
+            shadow: "#0A0A14",
+            palette_description: "Dark navy base with deep blue midtones, crimson red accent used sparingly, warm gold highlights",
+          },
+          lighting: "Single key light upper-left 45deg warm tone, cool blue fill from right, strong rim light on subject edges",
+          shadow_style: "Soft gradient shadows with ambient occlusion, deepest shadows approach pure black",
+          composition: "Rule of thirds with subject positioned left, negative space right for text overlay",
+          texture: "Film grain 15%, subtle vignette, minimal chromatic aberration on edges",
+          character_rendering: "Realistic anatomical proportions, detailed facial features, editorial portrait style",
+          background_style: "Abstract bokeh gradient with subtle environmental elements, depth-of-field blur",
           mood: "Tense, conspiratorial, high-stakes",
-          lighting: "Rembrandt with warm fill, dramatic shadows",
-          composition: "Rule of thirds, subject left, negative space right",
-          texture: "Film grain 15%, vignette, subtle chromatic aberration",
-          color_palette: { primary: "#1A1A2E", accent: "#E94560", secondary: "#0F3460", highlight: "#F0C75E" },
-          keywords: ["Dark Editorial", "Dramatic", "Cinematic"],
+          era_influence: "Contemporary editorial illustration, magazine cover aesthetic",
+          unique_elements: [
+            "Warm rim lighting on subject silhouette",
+            "Desaturated base with single saturated accent",
+            "Cinematic aspect ratio framing",
+          ],
+          prompt_prefix: "Cinematic digital painting with photorealistic rendering, soft gradient shading, single warm key light upper-left 45deg with cool blue fill, dark navy palette with crimson accent and gold highlights, film grain texture, editorial portrait composition, atmospheric bokeh background",
         }, null, 2);
         setAnalysisResult(result);
         setEditableJson(result);
@@ -346,16 +367,35 @@ export default function ProfilePage() {
               )}
               {analysisResult && !isAnalyzing && (
                 <div className="space-y-3">
+                  {/* Prompt prefix highlight */}
+                  {(() => {
+                    try {
+                      const parsed = JSON.parse(isEditingJson ? editableJson : analysisResult);
+                      if (parsed.prompt_prefix) {
+                        return (
+                          <div className="p-3 rounded-lg" style={{ background: "var(--turquoise-dim)", border: "1px solid var(--turquoise)" }}>
+                            <p className="text-[10px] font-semibold uppercase tracking-wider mb-1" style={{ color: "var(--turquoise)" }}>
+                              Prompt Prefix (injected into every image)
+                            </p>
+                            <p className="text-xs font-mono" style={{ color: "var(--text-primary)" }}>
+                              {parsed.prompt_prefix}
+                            </p>
+                          </div>
+                        );
+                      }
+                    } catch { /* ignore parse errors */ }
+                    return null;
+                  })()}
                   {isEditingJson ? (
                     <textarea
                       value={editableJson}
                       onChange={(e) => setEditableJson(e.target.value)}
-                      className="text-[11px] font-mono p-4 rounded-xl w-full h-48 resize-none outline-none"
+                      className="text-[11px] font-mono p-4 rounded-xl w-full h-64 resize-none outline-none"
                       style={{ background: "var(--bg-surface)", color: "var(--turquoise)", border: "1px solid var(--turquoise)" }}
                     />
                   ) : (
                     <pre
-                      className="text-[11px] font-mono p-4 rounded-xl overflow-auto max-h-48"
+                      className="text-[11px] font-mono p-4 rounded-xl overflow-auto max-h-64"
                       style={{ background: "var(--bg-surface)", color: "var(--turquoise)", border: "1px solid var(--turquoise-dim)" }}
                     >
                       {analysisResult}
@@ -419,7 +459,19 @@ export default function ProfilePage() {
             const palette = style.style_profile?.color_palette;
             const primary = palette?.primary || "#1A1A2E";
             const accent = palette?.accent || "#E94560";
-            const keywords = style.style_profile?.keywords || [];
+            // Build tags from detailed schema fields, fallback to keywords
+            const sp = style.style_profile || {} as Record<string, unknown>;
+            const tags: string[] = [];
+            const artMedium = sp.art_medium as string | undefined;
+            const renderStyle = sp.rendering_style as string | undefined;
+            const eraInfluence = sp.era_influence as string | undefined;
+            if (artMedium) tags.push(artMedium.split(",")[0].split("with")[0].trim());
+            if (renderStyle) tags.push(renderStyle.split(",")[0].trim());
+            if (eraInfluence) tags.push(eraInfluence.split(",")[0].trim());
+            // Fallback to keywords if no detailed fields
+            if (tags.length === 0 && Array.isArray(sp.keywords)) {
+              tags.push(...(sp.keywords as string[]).slice(0, 3));
+            }
 
             return (
               <GlassCard
@@ -485,7 +537,7 @@ export default function ProfilePage() {
                     </p>
                   )}
                   <div className="flex gap-1.5 flex-wrap">
-                    {(keywords as string[]).slice(0, 3).map((tag) => (
+                    {tags.slice(0, 3).map((tag) => (
                       <span key={tag} className="text-[10px] font-mono px-2 py-0.5 rounded" style={{ background: "var(--bg-elevated)", color: "var(--text-tertiary)" }}>
                         {tag}
                       </span>


### PR DESCRIPTION
## Summary

Three bugs fixed from Phase 2b:

- **Character generation "Failed to fetch"** — Three issues:
  1. Route conflict: `POST /characters/generate` matched `/{style_id}/characters` (FastAPI route ordering). Fixed by moving non-parameterized routes before `/{style_id}` routes.
  2. Kie.ai API body wrong: was `{model, prompt}`, correct is `{model, input: {prompt, aspect_ratio}}` (matched to working `image_client.py`).
  3. Wrong poll endpoint: was `GET /getTaskStatus/{id}` (doesn't exist), correct is `GET /recordInfo?taskId={id}`. Response parsing wrong: was `data.output[0]`, correct is `data.resultJson → resultUrls[0]`.
  4. `taskId` field is camelCase in Kie.ai response, not `task_id`.

- **Delete buttons don't work** — Same route conflict as Bug 1. Also fixed: SQL for "activate first default on delete" was invalid (ORDER BY in UPDATE without subquery).

- **Style profile JSON too weak** — Replaced generic mock with 16-field detailed schema (art_medium, rendering_style, line_work, shadow_style, character_rendering, background_style, era_influence, unique_elements, prompt_prefix, etc.). prompt_prefix highlighted at top of JSON preview. Style card tags now pull from art_medium/rendering_style/era_influence.

## Verified on VPS

```
Character generation: POST /api/visual-styles/characters/generate
→ Kie.ai returns image URL in ~30s
→ Prompt includes style context from active style

Style delete: DELETE /api/visual-styles/{id}
→ User styles: 200 OK, deleted
→ Default styles: 403 "Cannot delete default styles"
```

## Test plan

- [x] Character generation works end-to-end (tested on VPS)
- [x] Delete user-created style works (tested on VPS)
- [x] Cannot delete default styles (tested — returns 403)
- [ ] Frontend: Generate tab → type description → Generate → image appears
- [ ] Frontend: "Use This" saves the character
- [ ] Frontend: Delete character → confirm → removed
- [ ] Frontend: Style card tags show art_medium/rendering_style keywords
- [ ] Frontend: prompt_prefix highlighted in JSON preview panel
- [ ] Frontend: Upload image → detailed JSON schema with all 16 fields
- [ ] All pages still load (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)