### PR TITLE
Wire StoryEngine media pipeline to Supabase and Drive

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -9,6 +9,7 @@ See `.env.example` for all required variables. Critical ones:
 | `AIRTABLE_BASE_ID` | Airtable | `appCIcC58YSTwK3CE` |
 | `ELEVENLABS_API_KEY` | ElevenLabs | Voice synthesis |
 | `ELEVENLABS_VOICE_ID` | ElevenLabs | `G17SuINrv2H9FC6nvetn` |
+| `ELEVENLABS_MODEL_ID` | ElevenLabs | Usually `eleven_multilingual_v2` |
 | `OPENAI_API_KEY` | Whisper API | Audio transcription |
 | `KIE_AI_API_KEY` | Kie.ai | Images, video, thumbnails |
 | `GOOGLE_CLIENT_ID/SECRET/REFRESH_TOKEN` | Google | Drive & Docs OAuth |

--- a/docs/storyengine-supabase-mapping.md
+++ b/docs/storyengine-supabase-mapping.md
@@ -1,0 +1,188 @@
+# StoryEngine -> Supabase Production Mapping
+
+This repo currently contains two competing models:
+
+1. A prototype `Project` model in `storyengine/frontend/prisma/schema.prisma`
+2. A production-oriented Supabase schema already migrated from Airtable
+
+The UI transition has been painful because Airtable was not just a database. It
+was also the workflow engine, operator console, and pipeline contract.
+
+The correct direction is:
+
+- Treat Supabase production tables as the source of truth
+- Treat StoryEngine UI as a control/view layer over those tables
+- Stop deepening the local Prisma `Project` abstraction unless it becomes a
+  pure view model instead of a persisted data model
+
+## Production Tables Seen In Supabase
+
+From the current Supabase workspace and screenshot:
+
+- `videos`
+- `scripts`
+- `assets`
+- `stage_transitions`
+- `channel_profiles`
+- `visual_styles`
+- `style_characters`
+- `users`
+- `memberships`
+- `tenants`
+
+## Recommended Ownership
+
+## Storage Rule
+
+Use a strict split:
+
+- Supabase stores text, metadata, statuses, references, and logs
+- Google Drive stores generated binary assets
+
+That means:
+
+- `scripts.voice_over_url` should point to Google Drive
+- `assets.image_url` should point to Google Drive
+- `assets.video_url` / `assets.video_clip_url` should point to Google Drive
+- sound effects and thumbnails should also resolve to Google Drive URLs
+
+Pipeline contract for every generated file:
+
+1. Generate through provider
+2. Upload or proxy the binary into Google Drive
+3. Save the Drive URL and file metadata into Supabase
+4. Log the stage transition in Supabase
+
+### `videos`
+
+Top-level production record.
+
+Suggested responsibility:
+
+- title
+- top-level status
+- tenant / membership ownership
+- selected profile / visual style
+- upload / render metadata
+
+### `scripts`
+
+Scene-level narration and voiceover state.
+
+Observed columns in the screenshot:
+
+- `title`
+- `scene_text`
+- `script_status`
+- `voice_status`
+- `voice_over_url`
+
+Likely or recommended columns:
+
+- `id`
+- `video_id`
+- `scene_number`
+
+Temporary fallback if `video_id` is not available everywhere:
+
+- join by `title`
+
+### `assets`
+
+Prompt and media artifact table.
+
+Suggested responsibility:
+
+- prompt rows
+- images
+- video clips
+- thumbnails
+- audio derivatives
+- provider task metadata
+- Google Drive file URLs and IDs where available
+
+Likely or recommended fields:
+
+- `video_id`
+- `script_id` or `scene_number`
+- `asset_type`
+- `status`
+- `prompt_text`
+- `asset_url`
+
+### `stage_transitions`
+
+Append-only workflow log.
+
+Suggested responsibility:
+
+- every pipeline step start / completion / error
+- trigger source
+- timestamps
+- operator / automation provenance
+
+## UI Mapping
+
+### Dashboard
+
+Should read from `videos`, not a local `projects` table.
+
+### New Project
+
+Should create a `videos` row.
+
+### Detail Page
+
+Should aggregate:
+
+- `videos` -> header and overall status
+- `scripts` -> scene cards and voice state
+- `assets` -> prompts, images, clips
+- `stage_transitions` -> activity log / progress timeline
+
+### Image Prompt Generation
+
+Should read:
+
+- `videos`
+- `scripts`
+- selected style/profile tables
+
+Should write:
+
+- prompt rows to `assets`
+- lifecycle rows to `stage_transitions`
+- optional top-level status changes to `videos`
+
+## Migration Strategy
+
+1. Introduce Supabase-backed read services for `videos/scripts/assets/stage_transitions`
+2. Add API routes that expose a `VideoDetailViewModel` to the frontend
+3. Switch UI screens to those routes
+4. Retire Prisma-backed `Project` persistence
+5. Keep Prisma only if it remains necessary for auth during a transition period
+
+## Logging Contract
+
+Every pipeline stage should produce log rows in `stage_transitions`:
+
+- `queued`
+- `started`
+- `completed`
+- `failed`
+
+Suggested payload:
+
+- `video_id`
+- `stage`
+- `status`
+- `source`
+- `message`
+- `metadata`
+- `created_at`
+
+## Current Risk
+
+The repo does not yet contain the exact Supabase schema contract in code, so the
+initial Supabase service layer must be resilient to small naming differences
+while we finish swapping routes over.

--- a/storyengine/config/.env.example
+++ b/storyengine/config/.env.example
@@ -6,7 +6,7 @@
 # ---- Platform API Keys (used when user has no BYOK) ----
 ANTHROPIC_API_KEY=sk-ant-xxxxx
 KIE_AI_API_KEY=xxxxx
-WAVESPEED_API_KEY=xxxxx
+ELEVENLABS_API_KEY=xxxxx
 
 # ---- Google OAuth & Drive ----
 GOOGLE_CLIENT_ID=xxxxx.apps.googleusercontent.com
@@ -20,6 +20,7 @@ GOOGLE_OAUTH_CLIENT_SECRET=xxxxx
 
 # ---- ElevenLabs ----
 ELEVENLABS_VOICE_ID=G17SuINrv2H9FC6nvetn
+ELEVENLABS_MODEL_ID=eleven_multilingual_v2
 
 # ---- NextAuth ----
 NEXTAUTH_SECRET=generate-a-random-secret-here
@@ -27,6 +28,11 @@ NEXTAUTH_URL=http://localhost:3000
 
 # ---- Database ----
 DATABASE_URL=file:./dev.db
+
+# ---- Supabase ----
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-public-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # ---- Encryption (32 bytes hex for AES-256) ----
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

--- a/storyengine/frontend/.env.example
+++ b/storyengine/frontend/.env.example
@@ -14,6 +14,22 @@ GOOGLE_OAUTH_CLIENT_SECRET=xxxxx
 # Database
 DATABASE_URL=file:./dev.db
 
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-public-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Voice
+ELEVENLABS_API_KEY=your-elevenlabs-api-key
+ELEVENLABS_VOICE_ID=G17SuINrv2H9FC6nvetn
+ELEVENLABS_MODEL_ID=eleven_multilingual_v2
+
+# Google Drive (voice/image/file storage)
+GOOGLE_CLIENT_ID=xxxxx.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=xxxxx
+GOOGLE_REFRESH_TOKEN=xxxxx
+GOOGLE_DRIVE_FOLDER_ID=1zqsSvdyLWTRIt-Ri8VQELbYHhJihn6YD
+
 # Encryption key for BYOK (32 bytes as hex)
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ENCRYPTION_KEY=generate-64-hex-chars-here

--- a/storyengine/frontend/app/(dashboard)/project/[id]/page.tsx
+++ b/storyengine/frontend/app/(dashboard)/project/[id]/page.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+
+type AssetRow = {
+  id?: string | number;
+  scene?: number;
+  sentence_index?: number;
+  sentence_text?: string;
+  image_index?: number;
+  image_prompt?: string;
+  video_prompt?: string;
+  shot_type?: string;
+  status?: string;
+  image_url?: string;
+  drive_image_url?: string;
+  video_clip_url?: string;
+};
+
+type Scene = {
+  id: string;
+  sceneNumber: number;
+  sceneText: string;
+  scriptStatus: string;
+  voiceStatus: string;
+  voiceOverUrl?: string;
+  assets: AssetRow[];
+};
+
+type VideoDetail = {
+  video: {
+    id?: string | number;
+    video_title?: string;
+    status?: string;
+  };
+  scenes: Scene[];
+  transitions: Array<{
+    id?: string | number;
+    from_status?: string;
+    to_status?: string;
+    triggered_by?: string;
+    error_message?: string;
+    created_at?: string;
+  }>;
+};
+
+function formatStatus(status?: string) {
+  return (status || "unknown").replaceAll("_", " ");
+}
+
+export default function ProjectPage() {
+  const params = useParams();
+  const videoId = params.id as string;
+
+  const [detail, setDetail] = useState<VideoDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [busyScene, setBusyScene] = useState<number | null>(null);
+  const [busyVoiceScene, setBusyVoiceScene] = useState<number | null>(null);
+  const [busyAssetId, setBusyAssetId] = useState<string | null>(null);
+  const [busyClipAssetId, setBusyClipAssetId] = useState<string | null>(null);
+
+  async function loadDetail() {
+    try {
+      const res = await fetch(`/api/videos/${videoId}`);
+      if (!res.ok) throw new Error("Failed to load video");
+      const data = await res.json();
+      setDetail(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load video");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadDetail();
+  }, [videoId]);
+
+  async function handleGenerateImagePrompts(sceneNumber: number) {
+    setBusyScene(sceneNumber);
+    setMessage("");
+
+    try {
+      const res = await fetch(`/api/videos/${videoId}/image-prompts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sceneNumber }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to generate image prompts");
+      }
+
+      setMessage(
+        data.asset_insert_error
+          ? `Prompts generated for Scene ${sceneNumber}, but saving prompt assets failed: ${data.asset_insert_error}`
+          : `Prompts generated and inserted for Scene ${sceneNumber}.`
+      );
+
+      await loadDetail();
+    } catch (err) {
+      setMessage(
+        err instanceof Error ? err.message : "Failed to generate image prompts"
+      );
+    } finally {
+      setBusyScene(null);
+    }
+  }
+
+  async function handleGenerateVoice(sceneNumber: number) {
+    setBusyVoiceScene(sceneNumber);
+    setMessage("");
+
+    try {
+      const res = await fetch(`/api/videos/${videoId}/voice`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sceneNumber }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to generate voice");
+      }
+
+      if (data.skipped) {
+        setMessage(`Scene ${sceneNumber}: ${data.reason}.`);
+      } else {
+        setMessage(
+          data.script_update_error
+            ? `Voice generated for Scene ${sceneNumber}, but saving the script row failed: ${data.script_update_error}`
+            : `Voice generated and saved for Scene ${sceneNumber}.`
+        );
+      }
+
+      await loadDetail();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Failed to generate voice");
+    } finally {
+      setBusyVoiceScene(null);
+    }
+  }
+
+  async function handleGenerateImage(assetId: string) {
+    setBusyAssetId(assetId);
+    setMessage("");
+
+    try {
+      const res = await fetch(`/api/videos/${videoId}/images`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ assetId }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to generate image");
+      }
+
+      if (data.skipped) {
+        setMessage(`Image skipped: ${data.reason}.`);
+      } else {
+        setMessage(
+          data.asset_update_error
+            ? `Image generated, but saving the asset row failed: ${data.asset_update_error}`
+            : "Image generated and saved."
+        );
+      }
+
+      await loadDetail();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Failed to generate image");
+    } finally {
+      setBusyAssetId(null);
+    }
+  }
+
+  async function handleGenerateClip(assetId: string) {
+    setBusyClipAssetId(assetId);
+    setMessage("");
+
+    try {
+      const res = await fetch(`/api/videos/${videoId}/clips`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ assetId }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to generate clip");
+      }
+
+      if (data.skipped) {
+        setMessage(`Clip skipped: ${data.reason}.`);
+      } else {
+        setMessage(
+          data.asset_update_error
+            ? `Clip generated, but saving the asset row failed: ${data.asset_update_error}`
+            : "Clip generated and saved."
+        );
+      }
+
+      await loadDetail();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Failed to generate clip");
+    } finally {
+      setBusyClipAssetId(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="text-text-secondary">Loading video...</div>
+      </div>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="text-error">{error || "Video not found"}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold mb-1">{detail.video.video_title || "Untitled video"}</h1>
+        <p className="text-text-secondary text-sm">
+          Status: <span className="capitalize">{formatStatus(detail.video.status)}</span>
+        </p>
+        {message && <p className="text-sm text-text-secondary mt-3">{message}</p>}
+      </div>
+
+      <section className="space-y-6">
+        {detail.scenes.length === 0 ? (
+          <div className="border border-border border-dashed rounded-xl p-12 text-center">
+            <h3 className="text-lg font-medium text-text-primary mb-2">No script scenes found</h3>
+            <p className="text-text-secondary">
+              This video does not currently have any rows in `scripts` that the UI can load.
+            </p>
+          </div>
+        ) : (
+          detail.scenes.map((scene) => {
+            const promptAssets = scene.assets.filter(
+              (asset) => !!asset.image_prompt
+            );
+
+            return (
+              <div
+                key={scene.id}
+                className="border border-border rounded-xl overflow-hidden"
+              >
+                <div className="bg-surface px-5 py-4 border-b border-border flex items-center justify-between">
+                  <div>
+                    <h3 className="font-semibold">Scene {scene.sceneNumber}</h3>
+                    <p className="text-sm text-text-secondary mt-0.5">
+                      Script: {formatStatus(scene.scriptStatus)} | Voice:{" "}
+                      {formatStatus(scene.voiceStatus)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={() => handleGenerateImagePrompts(scene.sceneNumber)}
+                      disabled={busyScene === scene.sceneNumber}
+                      className="px-4 py-2 bg-accent hover:bg-accent-hover disabled:opacity-50 text-background text-sm font-medium rounded-lg transition-colors"
+                    >
+                      {busyScene === scene.sceneNumber
+                        ? "Generating..."
+                        : "Generate Image Prompts"}
+                    </button>
+                    <button
+                      onClick={() => handleGenerateVoice(scene.sceneNumber)}
+                      disabled={busyVoiceScene === scene.sceneNumber || !!scene.voiceOverUrl}
+                      className="px-4 py-2 border border-border hover:bg-surface disabled:opacity-50 text-text-primary text-sm font-medium rounded-lg transition-colors"
+                    >
+                      {busyVoiceScene === scene.sceneNumber
+                        ? "Generating Voice..."
+                        : scene.voiceOverUrl
+                          ? "Voice Ready"
+                          : "Generate Voice"}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="p-5 space-y-5">
+                  <div>
+                    <h4 className="text-xs font-medium text-text-tertiary uppercase tracking-wide mb-2">
+                      Scene Text
+                    </h4>
+                    <p className="text-sm text-text-secondary leading-relaxed">
+                      {scene.sceneText || "No scene text available"}
+                    </p>
+                  </div>
+
+                  {scene.voiceOverUrl && (
+                    <div>
+                      <h4 className="text-xs font-medium text-text-tertiary uppercase tracking-wide mb-2">
+                        Voice Over
+                      </h4>
+                      <a
+                        href={scene.voiceOverUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-sm text-accent hover:underline"
+                      >
+                        Open voice-over asset
+                      </a>
+                    </div>
+                  )}
+
+                  {promptAssets.length > 0 && (
+                    <div className="space-y-3">
+                      <h4 className="text-xs font-medium text-text-tertiary uppercase tracking-wide">
+                        Prompt Assets ({promptAssets.length})
+                      </h4>
+                      {promptAssets.map((asset, index) => (
+                        <div
+                          key={`${asset.id ?? "prompt"}-${index}`}
+                          className="grid grid-cols-12 gap-4 p-4 bg-surface rounded-lg border border-border"
+                        >
+                          <div className="col-span-4">
+                            <div className="text-xs font-medium text-text-tertiary mb-1">
+                              Script Segment
+                            </div>
+                            <p className="text-sm text-text-primary leading-relaxed">
+                              {asset.sentence_text || "No segment metadata"}
+                            </p>
+                          </div>
+
+                          <div className="col-span-5">
+                            <div className="flex items-center gap-2 mb-1">
+                              <span className="text-xs font-medium text-text-tertiary">
+                                Prompt
+                              </span>
+                              <span className="px-2 py-0.5 bg-accent/20 text-accent text-xs font-medium rounded">
+                                {asset.shot_type || "unknown"}
+                              </span>
+                            </div>
+                            <p className="text-sm text-text-secondary leading-relaxed line-clamp-5">
+                              {asset.image_prompt || "No prompt text available"}
+                            </p>
+                          </div>
+
+                          <div className="col-span-3">
+                            {asset.image_url || asset.drive_image_url || asset.video_clip_url ? (
+                              <div className="space-y-2">
+                                {(asset.image_url || asset.drive_image_url) && (
+                                  <a
+                                    href={asset.image_url || asset.drive_image_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-sm text-accent hover:underline block"
+                                  >
+                                    Open image
+                                  </a>
+                                )}
+                                {asset.video_clip_url && (
+                                  <a
+                                    href={asset.video_clip_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-sm text-accent hover:underline block"
+                                  >
+                                    Open clip
+                                  </a>
+                                )}
+                                <div className="text-xs text-text-tertiary">
+                                  Status: {formatStatus(asset.status)}
+                                </div>
+                                {(asset.image_url || asset.drive_image_url) &&
+                                  !asset.video_clip_url &&
+                                  asset.id && (
+                                    <button
+                                      onClick={() => handleGenerateClip(String(asset.id))}
+                                      disabled={
+                                        busyClipAssetId === String(asset.id) ||
+                                        !!asset.video_clip_url
+                                      }
+                                      className="px-3 py-1.5 border border-border hover:bg-surface disabled:opacity-50 text-text-primary text-xs font-medium rounded-lg transition-colors"
+                                    >
+                                      {busyClipAssetId === String(asset.id)
+                                        ? "Generating Clip..."
+                                        : asset.video_clip_url
+                                          ? "Clip Ready"
+                                          : "Generate Clip"}
+                                    </button>
+                                  )}
+                              </div>
+                            ) : (
+                              <div className="space-y-2">
+                                <div className="text-xs text-text-tertiary">
+                                  Status: {formatStatus(asset.status)}
+                                </div>
+                                {asset.id && (
+                                  <button
+                                    onClick={() => handleGenerateImage(String(asset.id))}
+                                    disabled={
+                                      busyAssetId === String(asset.id) ||
+                                      !!asset.image_url ||
+                                      !!asset.drive_image_url
+                                    }
+                                    className="px-3 py-1.5 bg-accent hover:bg-accent-hover disabled:opacity-50 text-background text-xs font-medium rounded-lg transition-colors"
+                                  >
+                                    {busyAssetId === String(asset.id)
+                                      ? "Generating..."
+                                      : asset.image_url || asset.drive_image_url
+                                        ? "Image Ready"
+                                        : "Generate Image"}
+                                  </button>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </section>
+
+      <section className="border border-border rounded-xl p-5">
+        <h3 className="font-semibold mb-4">Stage Log</h3>
+        {detail.transitions.length === 0 ? (
+          <p className="text-sm text-text-secondary">
+            No stage transitions logged yet.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {detail.transitions.slice(0, 12).map((transition, index) => (
+              <div
+                key={`${transition.id ?? "transition"}-${index}`}
+                className="text-sm text-text-secondary border-b border-border last:border-b-0 pb-3 last:pb-0"
+              >
+                <div className="text-text-primary">
+                  {formatStatus(transition.from_status)} {"->"} {formatStatus(transition.to_status)}
+                </div>
+                <div>{transition.error_message || "Transition logged"}</div>
+                <div className="text-xs text-text-tertiary mt-1">
+                  {transition.triggered_by || "unknown source"}
+                  {transition.created_at ? ` • ${new Date(transition.created_at).toLocaleString()}` : ""}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/storyengine/frontend/app/api/videos/[id]/clips/route.ts
+++ b/storyengine/frontend/app/api/videos/[id]/clips/route.ts
@@ -1,0 +1,258 @@
+import { NextResponse } from "next/server";
+import { getSupabaseVideoDetail } from "@/lib/pipeline/supabase-store";
+import {
+  logStageTransition,
+  updateAssetRow,
+} from "@/lib/pipeline/write-store";
+import { proxyGeneratedVideo } from "@/lib/pipeline/asset-storage";
+
+const CREATE_TASK_URL = "https://api.kie.ai/api/v1/jobs/createTask";
+const RECORD_INFO_URL = "https://api.kie.ai/api/v1/jobs/recordInfo";
+
+async function createVideoTask(args: {
+  apiKey: string;
+  imageUrl: string;
+  prompt: string;
+  duration?: number;
+}): Promise<string> {
+  const response = await fetch(CREATE_TASK_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${args.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "grok-imagine/image-to-video",
+      input: {
+        image_urls: [args.imageUrl],
+        prompt: args.prompt,
+        duration: args.duration === 10 ? "10" : "6",
+        mode: "normal",
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Kie createTask error: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as { data?: { taskId?: string } };
+  const taskId = data?.data?.taskId;
+  if (!taskId) {
+    throw new Error("Kie video API did not return a taskId");
+  }
+
+  return taskId;
+}
+
+async function pollVideoCompletion(args: {
+  apiKey: string;
+  taskId: string;
+  maxAttempts?: number;
+  pollIntervalMs?: number;
+}): Promise<string> {
+  const maxAttempts = args.maxAttempts ?? 120;
+  const pollIntervalMs = args.pollIntervalMs ?? 5000;
+
+  for (let index = 0; index < maxAttempts; index += 1) {
+    const response = await fetch(
+      `${RECORD_INFO_URL}?taskId=${encodeURIComponent(args.taskId)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${args.apiKey}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      continue;
+    }
+
+    const statusPayload = (await response.json()) as {
+      data?: { status?: number; resultJson?: unknown };
+    };
+    const status = statusPayload?.data?.status;
+    if (status === 3) {
+      throw new Error("Kie clip generation failed");
+    }
+
+    const resultJson = statusPayload?.data?.resultJson;
+    if (resultJson) {
+      const parsed =
+        typeof resultJson === "string" ? JSON.parse(resultJson) : resultJson;
+      const urls = (parsed as { resultUrls?: string[] })?.resultUrls;
+      if (Array.isArray(urls) && urls.length > 0 && urls[0]) {
+        return urls[0];
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  throw new Error("Kie clip generation timed out");
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  let tenantIdForLogging: string | null = null;
+  let videoIdForLogging: string | number = id;
+  let fromStatusForLogging: string | undefined;
+
+  try {
+    const body = await request.json();
+    const { assetId, force } = body as { assetId?: string; force?: boolean };
+
+    if (!assetId) {
+      return NextResponse.json({ error: "assetId is required" }, { status: 400 });
+    }
+
+    const detail = await getSupabaseVideoDetail(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Video not found" }, { status: 404 });
+    }
+
+    const tenantId =
+      typeof detail.video.tenant_id === "string" ? detail.video.tenant_id : "";
+    const videoId = detail.video.id ?? id;
+    const asset = detail.assets.find((item) => String(item.id) === String(assetId));
+
+    tenantIdForLogging = tenantId || null;
+    videoIdForLogging = videoId;
+    fromStatusForLogging =
+      typeof detail.video.status === "string" ? detail.video.status : undefined;
+
+    if (!tenantId) {
+      return NextResponse.json(
+        { error: "Video is missing tenant_id" },
+        { status: 500 }
+      );
+    }
+
+    const sourceImageUrl =
+      asset?.drive_image_url || asset?.image_url || undefined;
+    const clipPrompt = asset?.video_prompt || asset?.image_prompt || undefined;
+
+    if (!asset || !sourceImageUrl || !clipPrompt) {
+      return NextResponse.json(
+        { error: "Asset not found or missing source image/prompt for clip generation" },
+        { status: 404 }
+      );
+    }
+
+    const existingClipUrl =
+      typeof asset.video_clip_url === "string" && asset.video_clip_url
+        ? asset.video_clip_url
+        : "";
+    const normalizedStatus =
+      typeof asset.status === "string" ? asset.status.toLowerCase() : "";
+
+    if (!force && existingClipUrl) {
+      return NextResponse.json({
+        asset_id: assetId,
+        video_clip_url: existingClipUrl,
+        skipped: true,
+        reason: "clip already exists",
+      });
+    }
+
+    if (
+      !force &&
+      (normalizedStatus === "generating clip" || normalizedStatus === "generating")
+    ) {
+      return NextResponse.json({
+        asset_id: assetId,
+        skipped: true,
+        reason: `asset already ${normalizedStatus}`,
+      });
+    }
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: "Generating Clip",
+      triggeredBy: "storyengine_ui",
+    });
+
+    await updateAssetRow({
+      assetId,
+      status: "Generating Clip",
+      generationMethod: "kie_ai",
+      contentType: "video",
+      videoStatus: "Generating",
+    });
+
+    const apiKey = process.env.KIE_AI_API_KEY;
+    if (!apiKey) {
+      throw new Error("KIE_AI_API_KEY is not configured");
+    }
+
+    const taskId = await createVideoTask({
+      apiKey,
+      imageUrl: sourceImageUrl,
+      prompt: clipPrompt,
+    });
+    const providerUrl = await pollVideoCompletion({
+      apiKey,
+      taskId,
+    });
+
+    const fileName = `${detail.video.video_title || "video"} - Scene ${asset.scene || 0} - Clip ${asset.image_index || 1}.mp4`;
+    const driveResult = await proxyGeneratedVideo({
+      video: detail.video,
+      fileName,
+      sourceUrl: providerUrl,
+      mimeType: "video/mp4",
+    });
+
+    const updateResult = await updateAssetRow({
+      assetId,
+      status: "Done",
+      videoClipUrl: driveResult.url,
+      videoUrl: driveResult.url,
+      generationMethod: "kie_ai",
+      contentType: "video",
+      videoStatus: "Done",
+      animationStatus: "Done",
+    });
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: updateResult.error ? "Clip Generated (Asset Update Failed)" : "Clip Ready",
+      triggeredBy: "storyengine_ui",
+      errorMessage: updateResult.error ?? undefined,
+    });
+
+    return NextResponse.json({
+      asset_id: assetId,
+      video_clip_url: driveResult.url,
+      asset_update_error: updateResult.error,
+    });
+  } catch (error) {
+    if (tenantIdForLogging) {
+      await logStageTransition({
+        tenantId: tenantIdForLogging,
+        videoId: videoIdForLogging,
+        fromStatus: fromStatusForLogging,
+        toStatus: "Clip Failure",
+        triggeredBy: "storyengine_ui",
+        errorMessage: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+
+    console.error("Clip generation failed:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Clip generation failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/storyengine/frontend/app/api/videos/[id]/image-prompts/route.ts
+++ b/storyengine/frontend/app/api/videos/[id]/image-prompts/route.ts
@@ -1,0 +1,207 @@
+import { NextResponse } from "next/server";
+import { getSupabaseVideoDetail } from "@/lib/pipeline/supabase-store";
+import { logStageTransition, insertPromptAssets } from "@/lib/pipeline/write-store";
+
+const MODEL = "claude-sonnet-4-5-20250929";
+
+type SceneImage = {
+  script_segment: string;
+  shot_type: string;
+  prompt: string;
+  image_url?: string;
+};
+
+function buildSystemPrompt() {
+  return `You are an expert visual director for AI-generated documentary videos.
+
+YOUR TASK: Segment scene narration into distinct visual concepts and generate image prompts for each.
+
+=== SEGMENTATION RULES ===
+1. Each segment represents one distinct visual concept.
+2. Break narration where the visual should change.
+3. Aim for 4-8 segments per scene.
+4. Each segment should cover roughly 6-10 seconds of narration.
+5. Do not repeat the same script segment across multiple outputs.
+
+=== OUTPUT FORMAT ===
+Return raw JSON only:
+{
+  "scene_images": [
+    {
+      "script_segment": "Exact narration excerpt",
+      "shot_type": "establishing",
+      "prompt": "Full image prompt..."
+    }
+  ]
+}`;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  let tenantIdForLogging: string | null = null;
+  let videoIdForLogging: string | number = id;
+  let fromStatusForLogging: string | undefined;
+
+  try {
+    const body = await request.json();
+    const { sceneNumber } = body as { sceneNumber?: number };
+
+    if (typeof sceneNumber !== "number") {
+      return NextResponse.json(
+        { error: "sceneNumber is required" },
+        { status: 400 }
+      );
+    }
+
+    const detail = await getSupabaseVideoDetail(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Video not found" }, { status: 404 });
+    }
+
+    const videoId = detail.video.id ?? id;
+    const tenantId =
+      typeof detail.video.tenant_id === "string" ? detail.video.tenant_id : "";
+    const title =
+      typeof detail.video.video_title === "string" ? detail.video.video_title : "";
+    const scene = detail.scenes.find((item) => item.sceneNumber === sceneNumber);
+
+    tenantIdForLogging = tenantId || null;
+    videoIdForLogging = videoId;
+    fromStatusForLogging =
+      typeof detail.video.status === "string" ? detail.video.status : undefined;
+
+    if (!tenantId) {
+      return NextResponse.json(
+        { error: "Video is missing tenant_id" },
+        { status: 500 }
+      );
+    }
+
+    if (!scene?.sceneText) {
+      return NextResponse.json(
+        { error: `No script scene found for scene ${sceneNumber}` },
+        { status: 404 }
+      );
+    }
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: "Generating Image Prompts",
+      triggeredBy: "storyengine_ui",
+    });
+
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error("ANTHROPIC_API_KEY is not configured");
+    }
+
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 4096,
+        temperature: 1.0,
+        system: buildSystemPrompt(),
+        messages: [
+          {
+            role: "user",
+            content: `Segment this scene narration into visual concepts and generate image prompts.
+
+VIDEO TITLE: "${title}"
+SCENE NUMBER: ${scene.sceneNumber}
+
+FULL NARRATION:
+${scene.sceneText}
+
+Create 4-8 segments.
+Each segment must map to a different portion of the narration.
+Return raw JSON only.`,
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Anthropic API error: ${response.status} ${errorText}`);
+    }
+
+    const payload = (await response.json()) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    const textBlock = payload.content?.[0];
+    if (!textBlock || textBlock.type !== "text" || !textBlock.text) {
+      throw new Error("Unexpected response type from Anthropic API");
+    }
+
+    const cleaned = textBlock.text
+      .replace(/```json\n?/g, "")
+      .replace(/```\n?/g, "")
+      .trim();
+
+    const data = JSON.parse(cleaned) as { scene_images?: SceneImage[] };
+    const sceneImages = Array.isArray(data.scene_images) ? data.scene_images : [];
+
+    const insertResult = await insertPromptAssets(
+      sceneImages.map((item, index) => ({
+        tenantId,
+        videoId,
+        sceneNumber: scene.sceneNumber,
+        videoTitle: title,
+        sentenceIndex: index + 1,
+        sentenceText: item.script_segment,
+        imageIndex: index + 1,
+        imagePrompt: item.prompt,
+        shotType: item.shot_type,
+        status: "Pending",
+      }))
+    );
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: insertResult.error ? "Image Prompts Generated (Asset Insert Failed)" : "Ready For Images",
+      triggeredBy: "storyengine_ui",
+      errorMessage: insertResult.error ?? undefined,
+    });
+
+    return NextResponse.json({
+      scene_images: sceneImages,
+      inserted_assets: insertResult.inserted.length,
+      asset_insert_error: insertResult.error,
+    });
+  } catch (error) {
+    if (tenantIdForLogging) {
+      await logStageTransition({
+        tenantId: tenantIdForLogging,
+        videoId: videoIdForLogging,
+        fromStatus: fromStatusForLogging,
+        toStatus: "Image Prompt Failure",
+        triggeredBy: "storyengine_ui",
+        errorMessage: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+
+    console.error("Image prompt generation failed:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Image prompt generation failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/storyengine/frontend/app/api/videos/[id]/images/route.ts
+++ b/storyengine/frontend/app/api/videos/[id]/images/route.ts
@@ -1,0 +1,252 @@
+import { NextResponse } from "next/server";
+import { getSupabaseVideoDetail } from "@/lib/pipeline/supabase-store";
+import {
+  logStageTransition,
+  updateAssetRow,
+} from "@/lib/pipeline/write-store";
+import { proxyGeneratedImage } from "@/lib/pipeline/asset-storage";
+
+const CREATE_TASK_URL = "https://api.kie.ai/api/v1/jobs/createTask";
+const RECORD_INFO_URL = "https://api.kie.ai/api/v1/jobs/recordInfo";
+const DEFAULT_IMAGE_MODEL = "nano-banana-2";
+
+async function createImageTask(args: {
+  apiKey: string;
+  prompt: string;
+  aspectRatio?: string;
+  model?: string;
+}): Promise<string> {
+  const response = await fetch(CREATE_TASK_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${args.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: args.model || DEFAULT_IMAGE_MODEL,
+      input: {
+        prompt: args.prompt,
+        image_size: args.aspectRatio || "16:9",
+        output_format: "png",
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Kie createTask error: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as { data?: { taskId?: string } };
+  const taskId = data?.data?.taskId;
+  if (!taskId) {
+    throw new Error("Kie API did not return a taskId");
+  }
+
+  return taskId;
+}
+
+async function pollImageCompletion(args: {
+  apiKey: string;
+  taskId: string;
+  maxAttempts?: number;
+  pollIntervalMs?: number;
+}): Promise<string> {
+  const maxAttempts = args.maxAttempts ?? 45;
+  const pollIntervalMs = args.pollIntervalMs ?? 2000;
+
+  for (let index = 0; index < maxAttempts; index += 1) {
+    const response = await fetch(
+      `${RECORD_INFO_URL}?taskId=${encodeURIComponent(args.taskId)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${args.apiKey}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      continue;
+    }
+
+    const statusPayload = (await response.json()) as {
+      data?: { status?: number; resultJson?: unknown };
+    };
+    const status = statusPayload?.data?.status;
+    if (status === 3) {
+      throw new Error("Kie image generation failed");
+    }
+
+    const resultJson = statusPayload?.data?.resultJson;
+    if (resultJson) {
+      const parsed =
+        typeof resultJson === "string" ? JSON.parse(resultJson) : resultJson;
+      const urls = (parsed as { resultUrls?: string[] })?.resultUrls;
+      if (Array.isArray(urls) && urls.length > 0 && urls[0]) {
+        return urls[0];
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  throw new Error("Kie image generation timed out");
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  let tenantIdForLogging: string | null = null;
+  let videoIdForLogging: string | number = id;
+  let fromStatusForLogging: string | undefined;
+
+  try {
+    const body = await request.json();
+    const { assetId, force } = body as { assetId?: string; force?: boolean };
+
+    if (!assetId) {
+      return NextResponse.json({ error: "assetId is required" }, { status: 400 });
+    }
+
+    const detail = await getSupabaseVideoDetail(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Video not found" }, { status: 404 });
+    }
+
+    const tenantId =
+      typeof detail.video.tenant_id === "string" ? detail.video.tenant_id : "";
+    const videoId = detail.video.id ?? id;
+    const asset = detail.assets.find((item) => String(item.id) === String(assetId));
+
+    tenantIdForLogging = tenantId || null;
+    videoIdForLogging = videoId;
+    fromStatusForLogging =
+      typeof detail.video.status === "string" ? detail.video.status : undefined;
+
+    if (!tenantId) {
+      return NextResponse.json(
+        { error: "Video is missing tenant_id" },
+        { status: 500 }
+      );
+    }
+
+    if (!asset?.image_prompt) {
+      return NextResponse.json(
+        { error: "Asset not found or missing image_prompt" },
+        { status: 404 }
+      );
+    }
+
+    const existingImageUrl =
+      typeof asset.drive_image_url === "string" && asset.drive_image_url
+        ? asset.drive_image_url
+        : typeof asset.image_url === "string" && asset.image_url
+          ? asset.image_url
+          : "";
+    const normalizedStatus =
+      typeof asset.status === "string" ? asset.status.toLowerCase() : "";
+
+    if (!force && existingImageUrl) {
+      return NextResponse.json({
+        asset_id: assetId,
+        image_url: existingImageUrl,
+        skipped: true,
+        reason: "image already exists",
+      });
+    }
+
+    if (
+      !force &&
+      (normalizedStatus === "generating" || normalizedStatus === "pending")
+    ) {
+      return NextResponse.json({
+        asset_id: assetId,
+        skipped: true,
+        reason: `asset already ${normalizedStatus}`,
+      });
+    }
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: "Generating Image",
+      triggeredBy: "storyengine_ui",
+    });
+
+    await updateAssetRow({
+      assetId,
+      status: "Generating",
+      generationMethod: "kie_ai",
+      contentType: "image",
+    });
+
+    const apiKey = process.env.KIE_AI_API_KEY;
+    if (!apiKey) {
+      throw new Error("KIE_AI_API_KEY is not configured");
+    }
+
+    const taskId = await createImageTask({
+      apiKey,
+      prompt: asset.image_prompt,
+    });
+    const providerUrl = await pollImageCompletion({
+      apiKey,
+      taskId,
+    });
+
+    const fileName = `${detail.video.video_title || "video"} - Scene ${asset.scene || 0} - Image ${asset.image_index || 1}.png`;
+    const driveResult = await proxyGeneratedImage({
+      video: detail.video,
+      fileName,
+      sourceUrl: providerUrl,
+      mimeType: "image/png",
+    });
+
+    const updateResult = await updateAssetRow({
+      assetId,
+      status: "Done",
+      imageUrl: driveResult.url,
+      driveImageUrl: driveResult.url,
+      generationMethod: "kie_ai",
+      contentType: "image",
+    });
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: updateResult.error ? "Image Generated (Asset Update Failed)" : "Image Ready",
+      triggeredBy: "storyengine_ui",
+      errorMessage: updateResult.error ?? undefined,
+    });
+
+    return NextResponse.json({
+      asset_id: assetId,
+      image_url: driveResult.url,
+      asset_update_error: updateResult.error,
+    });
+  } catch (error) {
+    if (tenantIdForLogging) {
+      await logStageTransition({
+        tenantId: tenantIdForLogging,
+        videoId: videoIdForLogging,
+        fromStatus: fromStatusForLogging,
+        toStatus: "Image Failure",
+        triggeredBy: "storyengine_ui",
+        errorMessage: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+
+    console.error("Image generation failed:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Image generation failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/storyengine/frontend/app/api/videos/[id]/route.ts
+++ b/storyengine/frontend/app/api/videos/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { getSupabaseVideoDetail } from "@/lib/pipeline/supabase-store";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const detail = await getSupabaseVideoDetail(id);
+
+    if (!detail) {
+      return NextResponse.json({ error: "Video not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(detail);
+  } catch (error) {
+    console.error("Error fetching Supabase video detail:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch Supabase video detail",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/storyengine/frontend/app/api/videos/[id]/voice/route.ts
+++ b/storyengine/frontend/app/api/videos/[id]/voice/route.ts
@@ -1,0 +1,228 @@
+import { NextResponse } from "next/server";
+import { getSupabaseVideoDetail } from "@/lib/pipeline/supabase-store";
+import {
+  logStageTransition,
+  updateScriptVoice,
+} from "@/lib/pipeline/write-store";
+import { uploadGeneratedAudio } from "@/lib/pipeline/asset-storage";
+
+const ELEVENLABS_API_URL = "https://api.elevenlabs.io/v1/text-to-speech";
+const DEFAULT_VOICE_ID = "G17SuINrv2H9FC6nvetn";
+const DEFAULT_MODEL_ID = "eleven_multilingual_v2";
+
+async function generateVoiceAudio(args: {
+  apiKey: string;
+  text: string;
+  voiceId: string;
+  modelId: string;
+}): Promise<ArrayBuffer> {
+  const response = await fetch(`${ELEVENLABS_API_URL}/${args.voiceId}`, {
+    method: "POST",
+    headers: {
+      "xi-api-key": args.apiKey,
+      Accept: "audio/mpeg",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      text: args.text,
+      model_id: args.modelId,
+      output_format: "mp3_44100_128",
+      voice_settings: {
+        stability: 0.5,
+        similarity_boost: 1.0,
+        use_speaker_boost: true,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Voice API error: ${response.status} ${errorText}`);
+  }
+
+  const audioBuffer = await response.arrayBuffer();
+  if (audioBuffer.byteLength === 0) {
+    throw new Error("Voice API returned empty audio");
+  }
+
+  return audioBuffer;
+}
+
+async function uploadVoiceToGoogleDrive(args: {
+  audioBuffer: ArrayBuffer;
+  video: { id?: string | number; video_title?: string };
+  sceneNumber: number;
+}): Promise<string> {
+  const videoLabel =
+    typeof args.video.video_title === "string" && args.video.video_title.trim()
+      ? args.video.video_title.trim()
+      : `video-${String(args.video.id ?? "untitled")}`;
+  const result = await uploadGeneratedAudio({
+    video: args.video,
+    fileName: `${videoLabel} - Scene ${args.sceneNumber}.mp3`,
+    content: Buffer.from(args.audioBuffer),
+  });
+  return result.url;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  let tenantIdForLogging: string | null = null;
+  let videoIdForLogging: string | number = id;
+  let fromStatusForLogging: string | undefined;
+
+  try {
+    const body = await request.json();
+    const { sceneNumber, force } = body as {
+      sceneNumber?: number;
+      force?: boolean;
+    };
+
+    if (typeof sceneNumber !== "number") {
+      return NextResponse.json(
+        { error: "sceneNumber is required" },
+        { status: 400 }
+      );
+    }
+
+    const detail = await getSupabaseVideoDetail(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Video not found" }, { status: 404 });
+    }
+
+    const tenantId =
+      typeof detail.video.tenant_id === "string" ? detail.video.tenant_id : "";
+    const videoId = detail.video.id ?? id;
+    const scene = detail.scenes.find((item) => item.sceneNumber === sceneNumber);
+
+    tenantIdForLogging = tenantId || null;
+    videoIdForLogging = videoId;
+    fromStatusForLogging =
+      typeof detail.video.status === "string" ? detail.video.status : undefined;
+
+    if (!tenantId) {
+      return NextResponse.json(
+        { error: "Video is missing tenant_id" },
+        { status: 500 }
+      );
+    }
+
+    if (!scene?.sceneText) {
+      return NextResponse.json(
+        { error: `No script scene found for scene ${sceneNumber}` },
+        { status: 404 }
+      );
+    }
+
+    const existingVoiceUrl =
+      typeof scene.voiceOverUrl === "string" ? scene.voiceOverUrl : "";
+    const normalizedVoiceStatus =
+      typeof scene.voiceStatus === "string" ? scene.voiceStatus.toLowerCase() : "";
+
+    if (!force && existingVoiceUrl) {
+      return NextResponse.json({
+        sceneNumber,
+        voice_over_url: existingVoiceUrl,
+        skipped: true,
+        reason: "voice already exists",
+      });
+    }
+
+    if (
+      !force &&
+      (normalizedVoiceStatus === "generating" || normalizedVoiceStatus === "done")
+    ) {
+      return NextResponse.json({
+        sceneNumber,
+        voice_over_url: existingVoiceUrl || null,
+        skipped: true,
+        reason: `voice already ${normalizedVoiceStatus}`,
+      });
+    }
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: "Generating Voice",
+      triggeredBy: "storyengine_ui",
+    });
+
+    const scriptId = scene.id;
+    await updateScriptVoice({
+      scriptId,
+      voiceStatus: "Generating",
+    });
+
+    const apiKey = process.env.ELEVENLABS_API_KEY;
+    if (!apiKey) {
+      throw new Error("ELEVENLABS_API_KEY is not configured");
+    }
+
+    const voiceId = process.env.ELEVENLABS_VOICE_ID || DEFAULT_VOICE_ID;
+    const modelId = process.env.ELEVENLABS_MODEL_ID || DEFAULT_MODEL_ID;
+    const startedAt = Date.now();
+    const audioBuffer = await generateVoiceAudio({
+      apiKey,
+      text: scene.sceneText,
+      voiceId,
+      modelId,
+    });
+    const outputUrl = await uploadVoiceToGoogleDrive({
+      audioBuffer,
+      video: detail.video,
+      sceneNumber: scene.sceneNumber,
+    });
+    const durationSeconds = Math.max(
+      1,
+      Math.round((Date.now() - startedAt) / 1000)
+    );
+
+    const updateResult = await updateScriptVoice({
+      scriptId,
+      voiceStatus: "Done",
+      voiceOverUrl: outputUrl,
+      voiceId,
+      voiceDurationSeconds: durationSeconds,
+    });
+
+    await logStageTransition({
+      tenantId,
+      videoId,
+      fromStatus: fromStatusForLogging,
+      toStatus: updateResult.error ? "Voice Generated (Script Update Failed)" : "Voice Ready",
+      triggeredBy: "storyengine_ui",
+      durationSeconds,
+      errorMessage: updateResult.error ?? undefined,
+    });
+
+    return NextResponse.json({
+      sceneNumber,
+      voice_over_url: outputUrl,
+      script_update_error: updateResult.error,
+    });
+  } catch (error) {
+    if (tenantIdForLogging) {
+      await logStageTransition({
+        tenantId: tenantIdForLogging,
+        videoId: videoIdForLogging,
+        fromStatus: fromStatusForLogging,
+        toStatus: "Voice Failure",
+        triggeredBy: "storyengine_ui",
+        errorMessage: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+
+    console.error("Voice generation failed:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Voice generation failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/storyengine/frontend/lib/google-drive.ts
+++ b/storyengine/frontend/lib/google-drive.ts
@@ -1,0 +1,196 @@
+import { google } from "googleapis";
+import { Readable } from "stream";
+
+const DEFAULT_PARENT_FOLDER_ID = "1zqsSvdyLWTRIt-Ri8VQELbYHhJihn6YD";
+
+type UploadResult = {
+  id: string;
+  name: string;
+  url: string;
+};
+
+export class GoogleDriveClient {
+  private drive;
+  private parentFolderId: string;
+
+  constructor() {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+
+    if (!clientId || !clientSecret || !refreshToken) {
+      throw new Error("Google OAuth credentials not found in environment");
+    }
+
+    this.parentFolderId =
+      process.env.GOOGLE_DRIVE_FOLDER_ID || DEFAULT_PARENT_FOLDER_ID;
+
+    const oauth2Client = new google.auth.OAuth2(clientId, clientSecret);
+    oauth2Client.setCredentials({ refresh_token: refreshToken });
+
+    this.drive = google.drive({ version: "v3", auth: oauth2Client });
+  }
+
+  getRootFolderId(): string {
+    return this.parentFolderId;
+  }
+
+  async createFolder(
+    name: string,
+    parentId?: string
+  ): Promise<{ id: string; name: string; url: string }> {
+    const response = await this.drive.files.create({
+      requestBody: {
+        name,
+        mimeType: "application/vnd.google-apps.folder",
+        parents: [parentId || this.parentFolderId],
+      },
+      fields: "id, name",
+    });
+
+    const folderId = response.data.id!;
+    return {
+      id: folderId,
+      name: response.data.name!,
+      url: `https://drive.google.com/drive/folders/${folderId}`,
+    };
+  }
+
+  async findFolderByName(
+    name: string,
+    parentId?: string
+  ): Promise<{ id: string; name: string; url: string } | null> {
+    const escapedName = name.replace(/'/g, "\\'");
+    const query = [
+      "mimeType = 'application/vnd.google-apps.folder'",
+      `name = '${escapedName}'`,
+      `'${parentId || this.parentFolderId}' in parents`,
+      "trashed = false",
+    ].join(" and ");
+
+    const response = await this.drive.files.list({
+      q: query,
+      fields: "files(id, name)",
+      pageSize: 1,
+    });
+
+    const match = response.data.files?.[0];
+    if (!match?.id || !match.name) {
+      return null;
+    }
+
+    return {
+      id: match.id,
+      name: match.name,
+      url: `https://drive.google.com/drive/folders/${match.id}`,
+    };
+  }
+
+  async getOrCreateFolder(
+    name: string,
+    parentId?: string
+  ): Promise<{ id: string; name: string; url: string }> {
+    const existing = await this.findFolderByName(name, parentId);
+    if (existing) {
+      return existing;
+    }
+
+    return this.createFolder(name, parentId);
+  }
+
+  async uploadFile(args: {
+    content: Buffer;
+    name: string;
+    mimeType: string;
+    folderId?: string;
+  }): Promise<UploadResult> {
+    const stream = new Readable();
+    stream.push(args.content);
+    stream.push(null);
+
+    const response = await this.drive.files.create({
+      requestBody: {
+        name: args.name,
+        parents: [args.folderId || this.parentFolderId],
+      },
+      media: {
+        mimeType: args.mimeType,
+        body: stream,
+      },
+      fields: "id, name",
+    });
+
+    const fileId = response.data.id!;
+
+    await this.drive.permissions.create({
+      fileId,
+      requestBody: { role: "reader", type: "anyone" },
+    });
+
+    return {
+      id: fileId,
+      name: response.data.name!,
+      url: `https://drive.google.com/uc?export=download&id=${fileId}`,
+    };
+  }
+
+  async uploadAudio(
+    content: Buffer,
+    name: string,
+    folderId?: string
+  ): Promise<UploadResult> {
+    return this.uploadFile({
+      content,
+      name,
+      folderId,
+      mimeType: "audio/mpeg",
+    });
+  }
+
+  async uploadImage(
+    content: Buffer,
+    name: string,
+    folderId?: string,
+    mimeType = "image/png"
+  ): Promise<UploadResult> {
+    return this.uploadFile({
+      content,
+      name,
+      folderId,
+      mimeType,
+    });
+  }
+
+  async uploadVideo(
+    content: Buffer,
+    name: string,
+    folderId?: string
+  ): Promise<UploadResult> {
+    return this.uploadFile({
+      content,
+      name,
+      folderId,
+      mimeType: "video/mp4",
+    });
+  }
+
+  async proxyFileToDrive(args: {
+    sourceUrl: string;
+    fileName: string;
+    folderId?: string;
+    mimeType: string;
+  }): Promise<UploadResult> {
+    const response = await fetch(args.sourceUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download remote file: ${response.status}`);
+    }
+
+    const content = Buffer.from(await response.arrayBuffer());
+    return this.uploadFile({
+      content,
+      name: args.fileName,
+      folderId: args.folderId,
+      mimeType: args.mimeType,
+    });
+  }
+}

--- a/storyengine/frontend/lib/pipeline/asset-storage.ts
+++ b/storyengine/frontend/lib/pipeline/asset-storage.ts
@@ -1,0 +1,153 @@
+import { GoogleDriveClient } from "@/lib/google-drive";
+import type { VideoRow } from "./types";
+import { updateVideoDriveFolder } from "./write-store";
+
+type AssetFolderKind =
+  | "audio"
+  | "images"
+  | "video"
+  | "thumbnails"
+  | "storyboards"
+  | "sound";
+
+const FOLDER_NAMES: Record<AssetFolderKind, string> = {
+  audio: "audio",
+  images: "images",
+  video: "video",
+  thumbnails: "thumbnails",
+  storyboards: "storyboards",
+  sound: "sound",
+};
+
+function safeVideoFolderName(video: VideoRow): string {
+  const raw =
+    typeof video.video_title === "string" && video.video_title.trim()
+      ? video.video_title.trim()
+      : `video-${String(video.id ?? "untitled")}`;
+
+  return raw.replace(/[<>:"/\\|?*\u0000-\u001F]/g, "").slice(0, 120);
+}
+
+export async function ensureVideoDriveFolder(video: VideoRow): Promise<{
+  driveFolderId: string;
+  driveFolderLink: string;
+}> {
+  const existingId =
+    typeof video.drive_folder_id === "string" ? video.drive_folder_id : "";
+  const existingLink =
+    typeof video.drive_folder_link === "string" ? video.drive_folder_link : "";
+
+  if (existingId && existingLink) {
+    return {
+      driveFolderId: existingId,
+      driveFolderLink: existingLink,
+    };
+  }
+
+  const drive = new GoogleDriveClient();
+  const folder = await drive.getOrCreateFolder(safeVideoFolderName(video));
+
+  if (video.id) {
+    await updateVideoDriveFolder({
+      videoId: video.id,
+      driveFolderId: folder.id,
+      driveFolderLink: folder.url,
+    });
+  }
+
+  return {
+    driveFolderId: folder.id,
+    driveFolderLink: folder.url,
+  };
+}
+
+export async function ensureVideoAssetSubfolder(args: {
+  video: VideoRow;
+  kind: AssetFolderKind;
+}): Promise<{ folderId: string; folderLink: string }> {
+  const drive = new GoogleDriveClient();
+  const { driveFolderId } = await ensureVideoDriveFolder(args.video);
+  const subfolder = await drive.getOrCreateFolder(
+    FOLDER_NAMES[args.kind],
+    driveFolderId
+  );
+
+  return {
+    folderId: subfolder.id,
+    folderLink: subfolder.url,
+  };
+}
+
+export async function uploadGeneratedAudio(args: {
+  video: VideoRow;
+  fileName: string;
+  content: Buffer;
+}): Promise<{ fileId: string; url: string }> {
+  const drive = new GoogleDriveClient();
+  const { folderId } = await ensureVideoAssetSubfolder({
+    video: args.video,
+    kind: "audio",
+  });
+  const result = await drive.uploadAudio(args.content, args.fileName, folderId);
+  return { fileId: result.id, url: result.url };
+}
+
+export async function proxyGeneratedImage(args: {
+  video: VideoRow;
+  fileName: string;
+  sourceUrl: string;
+  mimeType?: string;
+}): Promise<{ fileId: string; url: string }> {
+  const drive = new GoogleDriveClient();
+  const { folderId } = await ensureVideoAssetSubfolder({
+    video: args.video,
+    kind: "images",
+  });
+  const result = await drive.proxyFileToDrive({
+    sourceUrl: args.sourceUrl,
+    fileName: args.fileName,
+    folderId,
+    mimeType: args.mimeType ?? "image/png",
+  });
+  return { fileId: result.id, url: result.url };
+}
+
+export async function proxyGeneratedVideo(args: {
+  video: VideoRow;
+  fileName: string;
+  sourceUrl: string;
+  mimeType?: string;
+}): Promise<{ fileId: string; url: string }> {
+  const drive = new GoogleDriveClient();
+  const { folderId } = await ensureVideoAssetSubfolder({
+    video: args.video,
+    kind: "video",
+  });
+  const result = await drive.proxyFileToDrive({
+    sourceUrl: args.sourceUrl,
+    fileName: args.fileName,
+    folderId,
+    mimeType: args.mimeType ?? "video/mp4",
+  });
+  return { fileId: result.id, url: result.url };
+}
+
+export async function proxyGeneratedSound(args: {
+  video: VideoRow;
+  fileName: string;
+  sourceUrl: string;
+  mimeType?: string;
+}): Promise<{ fileId: string; url: string }> {
+  const drive = new GoogleDriveClient();
+  const { folderId } = await ensureVideoAssetSubfolder({
+    video: args.video,
+    kind: "sound",
+  });
+  const result = await drive.proxyFileToDrive({
+    sourceUrl: args.sourceUrl,
+    fileName: args.fileName,
+    folderId,
+    mimeType: args.mimeType ?? "audio/mpeg",
+  });
+  return { fileId: result.id, url: result.url };
+}

--- a/storyengine/frontend/lib/pipeline/normalize.ts
+++ b/storyengine/frontend/lib/pipeline/normalize.ts
@@ -1,0 +1,71 @@
+import type {
+  AssetRow,
+  ScriptRow,
+  StageTransitionRow,
+  VideoDetailViewModel,
+  VideoRow,
+  VideoSceneViewModel,
+} from "./types";
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function rowId(value: unknown, fallback: string): string {
+  if (typeof value === "string" && value) return value;
+  if (typeof value === "number") return String(value);
+  return fallback;
+}
+
+export function buildVideoDetailViewModel(args: {
+  video: VideoRow;
+  scripts: ScriptRow[];
+  assets: AssetRow[];
+  transitions: StageTransitionRow[];
+}): VideoDetailViewModel {
+  const { video, scripts, assets, transitions } = args;
+
+  const scenes: VideoSceneViewModel[] = scripts
+    .map((script, index) => {
+      const sceneNumber =
+        asNumber(script.scene, -1) > 0
+          ? asNumber(script.scene, index + 1)
+          : index + 1;
+
+      const matchingAssets = assets.filter((asset) => {
+        const assetScene = asNumber(asset.scene, -1);
+        return assetScene === sceneNumber;
+      });
+
+      return {
+        id: rowId(script.id, `scene-${sceneNumber}`),
+        sceneNumber,
+        sceneText: asString(script.scene_text),
+        scriptStatus: asString(script.script_status, "unknown"),
+        voiceStatus: asString(script.voice_status, "unknown"),
+        voiceOverUrl: asString(script.voice_over_url) || undefined,
+        assets: matchingAssets,
+      };
+    })
+    .sort((a, b) => a.sceneNumber - b.sceneNumber);
+
+  return {
+    video,
+    scenes,
+    assets,
+    transitions: transitions.sort((a, b) => {
+      const aTime = Date.parse(asString(a.created_at));
+      const bTime = Date.parse(asString(b.created_at));
+      return Number.isFinite(aTime) && Number.isFinite(bTime) ? bTime - aTime : 0;
+    }),
+  };
+}

--- a/storyengine/frontend/lib/pipeline/supabase-store.ts
+++ b/storyengine/frontend/lib/pipeline/supabase-store.ts
@@ -1,0 +1,83 @@
+import { createServiceRoleSupabaseClient } from "@/lib/supabase/server";
+import { buildVideoDetailViewModel } from "./normalize";
+import type {
+  AssetRow,
+  ScriptRow,
+  StageTransitionRow,
+  VideoDetailViewModel,
+  VideoRow,
+} from "./types";
+
+async function maybeSelectByColumn<T extends Record<string, unknown>>(args: {
+  table: string;
+  column: string;
+  value: string | number;
+}): Promise<T[]> {
+  const supabase = createServiceRoleSupabaseClient();
+  const { data, error } = await supabase
+    .from(args.table)
+    .select("*")
+    .eq(args.column, args.value);
+
+  if (error) {
+    return [];
+  }
+
+  return (data || []) as T[];
+}
+
+export async function getSupabaseVideoById(
+  id: string | number
+): Promise<VideoRow | null> {
+  const supabase = createServiceRoleSupabaseClient();
+  const { data, error } = await supabase.from("videos").select("*").eq("id", id).limit(1);
+
+  if (error || !data || data.length === 0) {
+    return null;
+  }
+
+  return data[0] as VideoRow;
+}
+
+export async function getSupabaseVideoDetail(
+  id: string | number
+): Promise<VideoDetailViewModel | null> {
+  const video = await getSupabaseVideoById(id);
+  if (!video) return null;
+
+  const videoId = video.id ?? id;
+  const title = typeof video.video_title === "string" ? video.video_title : "";
+
+  const [scriptsByVideoId, assetsByVideoId, transitionsByVideoId] = await Promise.all([
+    maybeSelectByColumn<ScriptRow>({ table: "scripts", column: "video_id", value: videoId }),
+    maybeSelectByColumn<AssetRow>({ table: "assets", column: "video_id", value: videoId }),
+    maybeSelectByColumn<StageTransitionRow>({
+      table: "stage_transitions",
+      column: "video_id",
+      value: videoId,
+    }),
+  ]);
+
+  const scripts =
+    scriptsByVideoId.length > 0 || !title
+      ? scriptsByVideoId
+      : await maybeSelectByColumn<ScriptRow>({ table: "scripts", column: "title", value: title });
+
+  const assets =
+    assetsByVideoId.length > 0 || !title
+      ? assetsByVideoId
+      : await maybeSelectByColumn<AssetRow>({
+          table: "assets",
+          column: "video_title",
+          value: title,
+        });
+
+  const transitions = transitionsByVideoId;
+
+  return buildVideoDetailViewModel({
+    video,
+    scripts,
+    assets,
+    transitions,
+  });
+}

--- a/storyengine/frontend/lib/pipeline/types.ts
+++ b/storyengine/frontend/lib/pipeline/types.ts
@@ -1,0 +1,76 @@
+export type PipelineRow = Record<string, unknown>;
+
+export interface VideoRow extends PipelineRow {
+  id?: string | number;
+  tenant_id?: string;
+  project_id?: string;
+  video_title?: string;
+  status?: string;
+  drive_folder_id?: string;
+  drive_folder_link?: string;
+}
+
+export interface ScriptRow extends PipelineRow {
+  id?: string | number;
+  tenant_id?: string;
+  video_id?: string | number;
+  scene?: number;
+  title?: string;
+  scene_text?: string;
+  script_status?: string;
+  voice_status?: string;
+  voice_over_url?: string;
+}
+
+export interface AssetRow extends PipelineRow {
+  id?: string | number;
+  tenant_id?: string;
+  video_id?: string | number;
+  airtable_record_id?: string;
+  video_title?: string;
+  scene?: number;
+  sentence_index?: number;
+  sentence_text?: string;
+  image_index?: number;
+  image_prompt?: string;
+  video_prompt?: string;
+  shot_type?: string;
+  image_url?: string;
+  drive_image_url?: string;
+  status?: string;
+  content_type?: string;
+  generation_method?: string;
+  video_status?: string;
+  video_clip_url?: string;
+  animation_status?: string;
+}
+
+export interface StageTransitionRow extends PipelineRow {
+  id?: string | number;
+  tenant_id?: string;
+  video_id?: string | number;
+  from_status?: string;
+  to_status?: string;
+  triggered_by?: string;
+  cost?: number;
+  duration_seconds?: number;
+  error_message?: string;
+  created_at?: string;
+}
+
+export interface VideoSceneViewModel {
+  id: string;
+  sceneNumber: number;
+  sceneText: string;
+  scriptStatus: string;
+  voiceStatus: string;
+  voiceOverUrl?: string;
+  assets: AssetRow[];
+}
+
+export interface VideoDetailViewModel {
+  video: VideoRow;
+  scenes: VideoSceneViewModel[];
+  assets: AssetRow[];
+  transitions: StageTransitionRow[];
+}

--- a/storyengine/frontend/lib/pipeline/write-store.ts
+++ b/storyengine/frontend/lib/pipeline/write-store.ts
@@ -1,0 +1,185 @@
+import { createServiceRoleSupabaseClient } from "@/lib/supabase/server";
+import type { AssetRow, StageTransitionRow } from "./types";
+
+type TransitionInput = {
+  tenantId: string;
+  videoId: string | number;
+  fromStatus?: string;
+  toStatus: string;
+  triggeredBy: string;
+  cost?: number;
+  durationSeconds?: number;
+  errorMessage?: string;
+};
+
+type PromptAssetInput = {
+  tenantId: string;
+  videoId: string | number;
+  sceneNumber: number;
+  videoTitle?: string;
+  sentenceIndex?: number;
+  sentenceText?: string;
+  imageIndex?: number;
+  imagePrompt: string;
+  shotType?: string;
+  status?: string;
+};
+
+type ScriptVoiceUpdateInput = {
+  scriptId: string | number;
+  voiceStatus?: string | null;
+  voiceOverUrl?: string | null;
+  voiceId?: string | null;
+  voiceDurationSeconds?: number | null;
+};
+
+type VideoDriveFolderInput = {
+  videoId: string | number;
+  driveFolderId: string;
+  driveFolderLink: string;
+};
+
+type AssetUpdateInput = {
+  assetId: string | number;
+  status?: string | null;
+  imageUrl?: string | null;
+  videoUrl?: string | null;
+  videoClipUrl?: string | null;
+  soundEffectUrl?: string | null;
+  generationMethod?: string | null;
+  contentType?: string | null;
+  driveImageUrl?: string | null;
+  animationStatus?: string | null;
+  videoStatus?: string | null;
+};
+
+export async function logStageTransition(
+  input: TransitionInput
+): Promise<StageTransitionRow | null> {
+  const supabase = createServiceRoleSupabaseClient();
+  const row = {
+    tenant_id: input.tenantId,
+    video_id: input.videoId,
+    from_status: input.fromStatus ?? null,
+    to_status: input.toStatus,
+    triggered_by: input.triggeredBy,
+    cost: input.cost ?? 0,
+    duration_seconds: input.durationSeconds ?? null,
+    error_message: input.errorMessage ?? null,
+  };
+
+  const { data, error } = await supabase
+    .from("stage_transitions")
+    .insert(row)
+    .select("*")
+    .limit(1);
+
+  if (error) {
+    console.error("Failed to log stage transition:", error);
+    return null;
+  }
+
+  return ((data || [])[0] || null) as StageTransitionRow | null;
+}
+
+export async function insertPromptAssets(
+  rows: PromptAssetInput[]
+): Promise<{ inserted: AssetRow[]; error: string | null }> {
+  const supabase = createServiceRoleSupabaseClient();
+
+  const payload = rows.map((row) => ({
+    tenant_id: row.tenantId,
+    video_id: row.videoId,
+    video_title: row.videoTitle ?? null,
+    scene: row.sceneNumber,
+    sentence_index: row.sentenceIndex ?? null,
+    sentence_text: row.sentenceText ?? null,
+    image_index: row.imageIndex ?? null,
+    status: row.status ?? "generated",
+    image_prompt: row.imagePrompt,
+    shot_type: row.shotType ?? null,
+  }));
+
+  const { data, error } = await supabase.from("assets").insert(payload).select("*");
+
+  if (error) {
+    console.error("Failed to insert prompt assets:", error);
+    return { inserted: [], error: error.message };
+  }
+
+  return { inserted: (data || []) as AssetRow[], error: null };
+}
+
+export async function updateScriptVoice(
+  input: ScriptVoiceUpdateInput
+): Promise<{ success: boolean; error: string | null }> {
+  const supabase = createServiceRoleSupabaseClient();
+  const payload = {
+    voice_status: input.voiceStatus ?? null,
+    voice_over_url: input.voiceOverUrl ?? null,
+    voice_id: input.voiceId ?? null,
+    voice_duration_seconds: input.voiceDurationSeconds ?? null,
+  };
+
+  const { error } = await supabase
+    .from("scripts")
+    .update(payload)
+    .eq("id", input.scriptId);
+
+  if (error) {
+    console.error("Failed to update script voice:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true, error: null };
+}
+
+export async function updateVideoDriveFolder(
+  input: VideoDriveFolderInput
+): Promise<{ success: boolean; error: string | null }> {
+  const supabase = createServiceRoleSupabaseClient();
+  const { error } = await supabase
+    .from("videos")
+    .update({
+      drive_folder_id: input.driveFolderId,
+      drive_folder_link: input.driveFolderLink,
+    })
+    .eq("id", input.videoId);
+
+  if (error) {
+    console.error("Failed to update video drive folder:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true, error: null };
+}
+
+export async function updateAssetRow(
+  input: AssetUpdateInput
+): Promise<{ success: boolean; error: string | null }> {
+  const supabase = createServiceRoleSupabaseClient();
+  const payload = {
+    status: input.status ?? null,
+    image_url: input.imageUrl ?? null,
+    video_url: input.videoUrl ?? null,
+    video_clip_url: input.videoClipUrl ?? null,
+    sound_effect_url: input.soundEffectUrl ?? null,
+    generation_method: input.generationMethod ?? null,
+    content_type: input.contentType ?? null,
+    drive_image_url: input.driveImageUrl ?? null,
+    animation_status: input.animationStatus ?? null,
+    video_status: input.videoStatus ?? null,
+  };
+
+  const { error } = await supabase
+    .from("assets")
+    .update(payload)
+    .eq("id", input.assetId);
+
+  if (error) {
+    console.error("Failed to update asset row:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true, error: null };
+}

--- a/storyengine/frontend/lib/supabase/client.ts
+++ b/storyengine/frontend/lib/supabase/client.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@supabase/supabase-js";
+import { getSupabaseAnonKey, getSupabaseUrl } from "./config";
+
+export function createBrowserSupabaseClient() {
+  return createClient(getSupabaseUrl(), getSupabaseAnonKey(), {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+    },
+  });
+}

--- a/storyengine/frontend/lib/supabase/config.ts
+++ b/storyengine/frontend/lib/supabase/config.ts
@@ -1,0 +1,27 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+export function getSupabaseUrl(): string {
+  if (!SUPABASE_URL) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL is not configured");
+  }
+
+  return SUPABASE_URL;
+}
+
+export function getSupabaseAnonKey(): string {
+  if (!SUPABASE_ANON_KEY) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY is not configured");
+  }
+
+  return SUPABASE_ANON_KEY;
+}
+
+export function getSupabaseServiceRoleKey(): string {
+  if (!SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not configured");
+  }
+
+  return SUPABASE_SERVICE_ROLE_KEY;
+}

--- a/storyengine/frontend/lib/supabase/server.ts
+++ b/storyengine/frontend/lib/supabase/server.ts
@@ -1,0 +1,24 @@
+import { createClient } from "@supabase/supabase-js";
+import {
+  getSupabaseAnonKey,
+  getSupabaseServiceRoleKey,
+  getSupabaseUrl,
+} from "./config";
+
+export function createServerSupabaseClient() {
+  return createClient(getSupabaseUrl(), getSupabaseAnonKey(), {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+export function createServiceRoleSupabaseClient() {
+  return createClient(getSupabaseUrl(), getSupabaseServiceRoleKey(), {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}

--- a/storyengine/frontend/package-lock.json
+++ b/storyengine/frontend/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@auth/prisma-adapter": "^1.5.0",
         "@prisma/client": "^5.10.0",
+        "@supabase/supabase-js": "^2.56.0",
         "bcryptjs": "^2.4.3",
         "clsx": "^2.1.0",
+        "googleapis": "^130.0.0",
         "next": "^14.2.0",
         "next-auth": "^4.24.0",
         "react": "^18.3.0",
@@ -44,39 +46,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@auth/core": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.3.tgz",
-      "integrity": "sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@panva/hkdf": "^1.1.1",
-        "@types/cookie": "0.6.0",
-        "cookie": "0.6.0",
-        "jose": "^5.1.3",
-        "oauth4webapi": "^2.10.4",
-        "preact": "10.11.3",
-        "preact-render-to-string": "5.2.3"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^7"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
       }
     },
     "node_modules/@auth/prisma-adapter": {
@@ -599,6 +568,7 @@
       "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.13"
       },
@@ -675,6 +645,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
+      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.1.tgz",
+      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
+      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
+      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.1.tgz",
+      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
+      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.100.1",
+        "@supabase/functions-js": "2.100.1",
+        "@supabase/postgrest-js": "2.100.1",
+        "@supabase/realtime-js": "2.100.1",
+        "@supabase/storage-js": "2.100.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -726,7 +782,6 @@
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -745,6 +800,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -758,6 +814,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -805,6 +870,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -1311,6 +1377,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1326,6 +1393,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1673,6 +1749,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -1688,6 +1784,15 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1746,6 +1851,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1759,6 +1865,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -1794,7 +1906,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1808,7 +1919,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2077,7 +2187,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2165,7 +2274,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2182,6 +2290,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -2270,7 +2387,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2280,7 +2396,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2318,7 +2433,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2404,6 +2518,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2573,6 +2688,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2845,6 +2961,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3044,7 +3166,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3081,6 +3202,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -3095,7 +3259,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3120,7 +3283,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3257,11 +3419,79 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "130.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-130.0.0.tgz",
+      "integrity": "sha512-+ZSOowVv+vGBTueu1Ot9O7EqC0U4PS9l7fUjzc0ThCT4w4g+r78Vgn17q7eGBB5JMu4hxYC1hbbm1U/MCnYFdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3282,6 +3512,19 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -3339,7 +3582,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3368,13 +3610,34 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3786,6 +4049,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -3940,6 +4215,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3970,6 +4246,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -4020,6 +4305,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -4137,7 +4443,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4204,7 +4509,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4388,6 +4692,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -4443,7 +4767,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4806,6 +5129,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4954,6 +5278,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
       "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -4994,6 +5319,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -5029,6 +5355,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5055,6 +5396,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5067,6 +5409,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5284,6 +5627,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5417,7 +5780,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5437,7 +5799,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5454,7 +5815,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5473,7 +5833,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5974,6 +6333,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5993,6 +6353,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -6143,6 +6509,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6174,7 +6541,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6253,6 +6619,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6267,6 +6639,22 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6491,6 +6879,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/storyengine/frontend/package.json
+++ b/storyengine/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.56.0",
+    "googleapis": "^130.0.0",
     "next": "^14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,37 @@
 
 _Reference `ANIMATION_SYSTEM_REVIEW.md` for detailed feature specs before starting any roadmap item._
 
-- [ ] _No active tasks_
+### StoryEngine Wiring Checklist
+
+- [ ] Replace StoryEngine's remaining local Prisma/SQLite assumptions with the intended Supabase data path
+- [ ] Add a single source of truth doc for StoryEngine data flow: UI -> Next API/service layer -> Supabase -> generation providers
+- [ ] Remove or clearly demote the unused Express backend path if Next.js routes remain the active control plane
+- [ ] Confirm auth/session ownership on all project routes; eliminate dev-user fallbacks
+- [ ] Confirm how channel profiles are selected for project generation and persist the chosen profile on each project
+- [ ] Make saved API keys actually drive generation calls instead of using env-only fallbacks
+- [ ] Verify script generation wiring in the current UI against the live code path
+- [ ] Verify voice-over wiring in the current UI against the live code path
+- [ ] Verify sentence-splitting wiring in the current UI against the live code path
+- [ ] Separate sentence splitting from image prompt generation if those are intended to be distinct stages in the UI
+- [ ] Persist image prompt results into project scene data so prompts survive refresh/reload
+- [ ] Add a project-level image prompt generation route that uses project data + selected profile + saved key
+- [ ] Wire per-scene and/or batch image prompt actions in the project UI to the persisted route
+- [ ] Wire image generation after prompts: prompt -> provider call -> permanent asset URL -> project scene update
+- [x] Decide whether generated assets should proxy through Google Drive or an updated Supabase storage path
+- [ ] Add status transitions for StoryEngine project stages so the UI reflects actual progress
+- [ ] Add usage/cost tracking on live generation routes once the call paths are real
+- [ ] Verify Remotion/export/render handoff after scenes/prompts/images are persisted
+- [ ] Add a shared Google Drive asset storage layer for voice, image, video, sound, thumbnail, and storyboard files
+- [ ] Ensure each video gets a dedicated Drive folder and subfolders for asset types
+
+### Active Task
+
+- [ ] Wire StoryEngine image prompts to persist on the project record and survive reload
+- [ ] Reuse profile/key-aware generation logic where possible instead of hardcoded prompts
+- [ ] Verify the current codebase location of script/voice/sentence-splitting wiring and document any missing links
+- [ ] Replace the local `Project` persistence path with a Supabase `VideoDetail` read model over `videos/scripts/assets/stage_transitions`
+- [ ] Add stage-transition logging for every pipeline step that the UI triggers
+- [ ] Route all generated binary assets through the shared Drive asset service before writing URLs into Supabase
 
 ## Backlog (from Roadmap)
 


### PR DESCRIPTION
## Summary
- pivot StoryEngine video detail routes onto the Supabase production tables
- add Supabase-backed stage logging plus Google Drive asset storage helpers
- wire image prompts, voice, image generation, and clip generation through the new pipeline path
- add idempotency checks so finished media does not regenerate accidentally

## Testing
- `cd storyengine/frontend && ./node_modules/.bin/tsc --noEmit`

## Notes
- this PR intentionally isolates the StoryEngine Supabase/Drive wiring work from other unrelated local branch changes
- deployment impact is limited to the StoryEngine frontend/api paths and supporting docs/env examples