### PR TITLE
Fix targeted StoryEngine image generation on main

### DIFF
--- a/storyengine/backend/pipeline_executor.py
+++ b/storyengine/backend/pipeline_executor.py
@@ -1023,8 +1023,14 @@ class PipelineExecutor:
             await self._log_activity(bot_name, video_id, "failed", error_msg)
             return {"status": "failed", "error": error_msg}
 
-    async def run_images(self, video_id: str) -> dict:
-        """Generate images for a video."""
+    async def run_images(self, video_id: str, scene: int = None, index: int = None) -> dict:
+        """Generate images for a video.
+
+        Args:
+            video_id: Supabase video UUID
+            scene: Optional scene number for single-scene generation
+            index: Optional segment index within a scene for single-image generation
+        """
         await self._ensure_initialized()
         bot_name = "Image Bot"
 
@@ -1033,16 +1039,24 @@ class PipelineExecutor:
             if not video:
                 return {"status": "failed", "error": "Video not found"}
 
-            # Pipeline integrity check: voice must exist before image generation
-            all_voiced, total, voiced = await self._check_voice_exists(video_id)
-            if not all_voiced:
-                msg = f"Voice generation must complete before image generation. Missing voice for {total - voiced}/{total} scenes."
-                await self._log_activity(bot_name, video_id, "failed", msg)
-                await self._update_video_status(video_id, "ready_for_voice")
-                return {"status": "failed", "error": msg}
-
             current_status = video.get("status")
-            await self._log_activity(bot_name, video_id, "started", "Generating images")
+
+            # Full runs require voice completion; targeted re-runs bypass the stage gate.
+            if scene is None:
+                all_voiced, total, voiced = await self._check_voice_exists(video_id)
+                if not all_voiced:
+                    msg = f"Voice generation must complete before image generation. Missing voice for {total - voiced}/{total} scenes."
+                    await self._log_activity(bot_name, video_id, "failed", msg)
+                    await self._update_video_status(video_id, "ready_for_voice")
+                    return {"status": "failed", "error": msg}
+
+            if scene is not None and index is not None:
+                log_msg = f"Generating image for scene {scene} segment {index}"
+            elif scene is not None:
+                log_msg = f"Generating images for scene {scene}"
+            else:
+                log_msg = "Generating images"
+            await self._log_activity(bot_name, video_id, "started", log_msg)
 
             self._load_idea_from_video(video_id)
 
@@ -1050,10 +1064,25 @@ class PipelineExecutor:
             if self._pipeline.current_idea:
                 self._pipeline.current_idea["Status"] = "Ready For Images"
 
+            # Targeted re-generation hooks already exist in the underlying pipeline.
+            if scene is not None:
+                self._pipeline.scene_filter = scene
+            if index is not None:
+                self._pipeline.image_filter = index
+
             result = await self._pipeline.run_image_bot()
+
+            # Always reset filters after run
+            self._pipeline.scene_filter = None
+            self._pipeline.image_filter = None
 
             if result.get("error"):
                 raise Exception(result["error"])
+
+            # For targeted runs, keep the current video status stable.
+            if scene is not None:
+                await self._log_activity(bot_name, video_id, "completed", log_msg)
+                return {"status": current_status, "video_id": video_id}
 
             new_status = result.get("new_status", "ready_for_thumbnail")
 
@@ -1064,6 +1093,8 @@ class PipelineExecutor:
             return {"status": to_supabase(new_status), "video_id": video_id}
 
         except Exception as e:
+            self._pipeline.scene_filter = None
+            self._pipeline.image_filter = None
             error_msg = str(e)
             await self._log_activity(bot_name, video_id, "failed", error_msg)
             return {"status": "failed", "error": error_msg}
@@ -1273,4 +1304,3 @@ class PipelineExecutor:
             error_msg = str(e)
             await self._log_activity(bot_name, video_id, "failed", error_msg)
             return {"status": "failed", "error": error_msg}
-

--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -499,7 +499,7 @@ async def run_images(
     async def _run():
         try:
             executor = PipelineExecutor(tenant_id)
-            result = await executor.run_images(video_id)
+            result = await executor.run_images(video_id, scene=scene, index=index)
             _set_task_status(video_id, result.get("status", "unknown"), result.get("error"))
         except Exception as e:
             _set_task_status(video_id, "failed", str(e))
@@ -509,7 +509,14 @@ async def run_images(
 
     background_tasks.add_task(_run)
 
-    return PipelineResponse(video_id=video_id, status="running", message="Image generation started")
+    if scene is not None and index is not None:
+        msg = f"Generating image for scene {scene} segment {index}"
+    elif scene is not None:
+        msg = f"Generating images for scene {scene}"
+    else:
+        msg = "Image generation started"
+
+    return PipelineResponse(video_id=video_id, status="running", message=msg)
 
 
 @router.post("/sound-prompts/{video_id}", response_model=PipelineResponse)


### PR DESCRIPTION
## Summary
- fix the FastAPI image pipeline route so targeted scene/segment image generation actually reaches the executor
- add targeted scene/index support in `PipelineExecutor.run_images`
- preserve full-run voice guardrails while allowing targeted image reruns without forcing a full stage transition
- reset pipeline filters after targeted image runs to avoid leaking state across requests

## Testing
- `python3 -m py_compile storyengine/backend/routes/pipeline.py storyengine/backend/pipeline_executor.py`

## Context
The current deployed StoryEngine frontend on `main` already calls `/api/pipeline/images/{video_id}?scene=...&index=...`, but the backend was ignoring those params and always running the full image stage. This PR makes the existing UI behavior line up with the real backend execution path.