### PR TITLE
Harden StoryEngine UI wiring feedback

### DIFF
--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -485,6 +485,12 @@ async def run_images(
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
+    if variants is not None and variants > 1:
+        raise HTTPException(
+            status_code=501,
+            detail="Image variants are not wired in the production backend yet.",
+        )
+
     if scene is None and not is_at_or_past_stage(video["status"], "ready_for_images"):
         raise HTTPException(
             status_code=400,

--- a/storyengine/frontend/src/components/production/RenderTab.tsx
+++ b/storyengine/frontend/src/components/production/RenderTab.tsx
@@ -255,6 +255,8 @@ export function RenderTab({ video }: RenderTabProps) {
               ]}
               value={musicTrack}
               onChange={setMusicTrack}
+              disabled
+              title="Render music selection is not wired to the production backend yet."
             />
             <FilterSelect
               label="Export Format"
@@ -264,7 +266,12 @@ export function RenderTab({ video }: RenderTabProps) {
               ]}
               value={exportFormat}
               onChange={setExportFormat}
+              disabled
+              title="Render export format selection is not wired to the production backend yet."
             />
+            <p className="text-[10px]" style={{ color: "var(--text-tertiary)" }}>
+              Render overrides will be enabled once backend render options are wired end to end.
+            </p>
           </div>
         </GlassCard>
 

--- a/storyengine/frontend/src/components/production/StoryboardVisualsTab.tsx
+++ b/storyengine/frontend/src/components/production/StoryboardVisualsTab.tsx
@@ -585,7 +585,12 @@ export function StoryboardVisualsTab({ video, onGoToScriptVoice }: StoryboardVis
               value={model}
               onChange={setModel}
               className="mb-3"
+              disabled
+              title="Image model selection is not wired to the production backend yet."
             />
+            <p className="text-[10px] mb-3" style={{ color: "var(--text-tertiary)" }}>
+              Model selection will be enabled once provider overrides are wired end to end.
+            </p>
 
             <div className="space-y-2 mb-3 pt-3" style={{ borderTop: "1px solid var(--border-subtle)" }}>
               <div className="flex items-center justify-between">

--- a/storyengine/frontend/src/components/production/VideoClipsTab.tsx
+++ b/storyengine/frontend/src/components/production/VideoClipsTab.tsx
@@ -322,7 +322,12 @@ export function VideoClipsTab({ video }: VideoClipsTabProps) {
             ]}
             value={model}
             onChange={setModel}
+            disabled
+            title="Video model selection is not wired to the production backend yet."
           />
+          <p className="text-[10px] mt-3" style={{ color: "var(--text-tertiary)" }}>
+            Video model selection will be enabled once provider overrides are wired end to end.
+          </p>
           <div className="pt-3 mt-3" style={{ borderTop: "1px solid var(--border-subtle)" }}>
             <p className="text-xs font-semibold mb-1" style={{ color: "var(--text-secondary)" }}>
               Estimated Cost

--- a/storyengine/frontend/src/components/production/VisualsTab.tsx
+++ b/storyengine/frontend/src/components/production/VisualsTab.tsx
@@ -454,7 +454,12 @@ export function VisualsTab({ video }: VisualsTabProps) {
             value={model}
             onChange={setModel}
             className="mb-3"
+            disabled
+            title="Image model selection is not wired to the production backend yet."
           />
+          <p className="text-[10px] mb-3" style={{ color: "var(--text-tertiary)" }}>
+            Model selection will be enabled once provider overrides are wired end to end.
+          </p>
 
           <div className="pt-3" style={{ borderTop: "1px solid var(--border-subtle)" }}>
             <p className="text-xs font-semibold mb-1" style={{ color: "var(--text-secondary)" }}>

--- a/storyengine/frontend/src/components/ui/FilterSelect.tsx
+++ b/storyengine/frontend/src/components/ui/FilterSelect.tsx
@@ -8,9 +8,11 @@ interface FilterSelectProps {
   onChange: (value: string) => void;
   label?: string;
   className?: string;
+  disabled?: boolean;
+  title?: string;
 }
 
-export function FilterSelect({ options, value, onChange, label, className }: FilterSelectProps) {
+export function FilterSelect({ options, value, onChange, label, className, disabled = false, title }: FilterSelectProps) {
   return (
     <div className={cn("flex flex-col gap-1", className)}>
       {label && (
@@ -21,11 +23,15 @@ export function FilterSelect({ options, value, onChange, label, className }: Fil
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        title={title}
         className="px-3 py-2 rounded-lg text-sm font-body outline-none transition-all"
         style={{
           background: "var(--bg-elevated)",
-          color: "var(--text-primary)",
+          color: disabled ? "var(--text-tertiary)" : "var(--text-primary)",
           border: "1px solid var(--border)",
+          opacity: disabled ? 0.65 : 1,
+          cursor: disabled ? "not-allowed" : "pointer",
         }}
         onFocus={(e) => (e.target.style.borderColor = "var(--turquoise)")}
         onBlur={(e) => (e.target.style.borderColor = "var(--border)")}

--- a/storyengine/frontend/src/components/video-detail/image-segment-card.tsx
+++ b/storyengine/frontend/src/components/video-detail/image-segment-card.tsx
@@ -22,7 +22,7 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
     enabled: generating,
     onComplete: () => {
       setGenerating(false);
-      queryClient.invalidateQueries({ queryKey: ["assets", videoId] });
+      queryClient.invalidateQueries({ queryKey: ["video-assets", videoId] });
       onRefresh();
     },
     onFailed: () => {
@@ -192,16 +192,17 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
               </button>
               <button
                 onClick={handleVariants}
-                disabled={generating}
+                disabled
                 className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded disabled:opacity-50"
                 style={{
                   border: "1px solid var(--border)",
                   color: "var(--text-secondary)",
                   background: "var(--bg-card-hover)",
                 }}
+                title="Image variants are not wired in the production backend yet."
               >
                 <Star size={11} />
-                3 Variants · $0.075
+                Variants Soon
               </button>
             </>
           )}


### PR DESCRIPTION
## Summary
- fix the image segment card to invalidate the real `video-assets` cache key after generation completes
- disable unfinished image variant and model-selection controls so the UI stops implying unsupported backend behavior
- return a clear API error when image variant generation is requested directly

## Verification
- `git diff --check`
- `python3 -m py_compile storyengine/backend/routes/pipeline.py`

## Notes
- Frontend typecheck was not run in this worktree because `storyengine/frontend/node_modules` is not installed here.