### PR TITLE
Add StoryEngine image variant generation

### DIFF
--- a/storyengine/backend/pipeline_executor.py
+++ b/storyengine/backend/pipeline_executor.py
@@ -14,6 +14,7 @@ Usage:
 import os
 import sys
 import asyncio
+import uuid
 from datetime import datetime, timezone
 from typing import Optional, Any
 from pathlib import Path
@@ -1095,6 +1096,137 @@ class PipelineExecutor:
         except Exception as e:
             self._pipeline.scene_filter = None
             self._pipeline.image_filter = None
+            error_msg = str(e)
+            await self._log_activity(bot_name, video_id, "failed", error_msg)
+            return {"status": "failed", "error": error_msg}
+
+    async def run_image_variants(self, video_id: str, scene: int, index: int, variants: int = 3) -> dict:
+        """Generate image variants for a single scene/index without affecting primary assets."""
+        await self._ensure_initialized()
+        bot_name = "Image Variant Bot"
+
+        if not self._pipeline.image_client:
+            return {"status": "failed", "error": "Image client not available"}
+
+        try:
+            video = await self._get_video(video_id)
+            if not video:
+                return {"status": "failed", "error": "Video not found"}
+
+            asset = await fetch_one(
+                """SELECT id, sentence_index, sentence_text, image_prompt, shot_type, hero_shot
+                   FROM assets
+                   WHERE video_id = $1 AND tenant_id = $2 AND scene = $3 AND image_index = $4
+                     AND (generation_method IS NULL OR generation_method <> 'variant_candidate')
+                   ORDER BY created_at
+                   LIMIT 1""",
+                video_id, self.tenant_id, scene, index,
+            )
+            if not asset:
+                return {"status": "failed", "error": f"Base asset not found for scene {scene} image {index}"}
+
+            prompt = asset.get("image_prompt")
+            if not prompt:
+                return {"status": "failed", "error": "Base asset has no image prompt"}
+
+            await self._log_activity(
+                bot_name,
+                video_id,
+                "started",
+                f"Generating {variants} variant(s) for scene {scene} image {index}",
+            )
+
+            self._load_idea_from_video(video_id)
+
+            from orchestrator.pipeline_constants import Models
+            from shared.clients.image_client import ImageClient
+            from shared.clients.airtable_client import get_image_model_override
+
+            model_override = get_image_model_override(self._pipeline.current_idea or {})
+            if model_override and model_override not in ImageClient.VALID_SCENE_MODELS:
+                model_override = ""
+
+            use_reference = bool(self._pipeline.core_image_url) and model_override != Models.IMAGE_ZIMAGE
+
+            existing = await fetch_one(
+                """SELECT COALESCE(MAX(panel_position), 0) AS max_variant
+                   FROM assets
+                   WHERE video_id = $1 AND tenant_id = $2 AND scene = $3 AND image_index = $4
+                     AND generation_method = 'variant_candidate'""",
+                video_id, self.tenant_id, scene, index,
+            )
+            next_variant_position = int(existing.get("max_variant") or 0) + 1
+            created = 0
+
+            for offset in range(variants):
+                if model_override == Models.IMAGE_ZIMAGE:
+                    result = await self._pipeline.image_client.generate_scene_image_zimage(prompt, aspect_ratio="16:9")
+                elif use_reference:
+                    result = await self._pipeline.image_client.generate_scene_image(prompt, self._pipeline.core_image_url)
+                else:
+                    result_urls = await self._pipeline.image_client.generate_and_wait(prompt, aspect_ratio="16:9")
+                    result = {"url": result_urls[0]} if result_urls else None
+
+                if not result or not result.get("url"):
+                    continue
+
+                image_url = result["url"]
+                drive_download_url = None
+                try:
+                    image_content = await self._pipeline.image_client.download_image(image_url)
+                    filename = (
+                        f"Scene_{str(scene).zfill(2)}_{str(index).zfill(2)}"
+                        f"_variant_{str(next_variant_position + offset).zfill(2)}.png"
+                    )
+                    drive_file = self._pipeline.google.upload_image(
+                        image_content, filename, self._pipeline.project_folder_id
+                    )
+                    if drive_file and drive_file.get("id"):
+                        drive_download_url = self._pipeline.google.make_file_public(drive_file["id"])
+                except Exception as drive_err:
+                    print(f"      ⚠️ Variant Drive upload failed: {drive_err}", flush=True)
+
+                await execute(
+                    """INSERT INTO assets (
+                        id, tenant_id, video_id, video_title, scene, image_index, sentence_index,
+                        sentence_text, image_prompt, shot_type, hero_shot, image_url, drive_image_url,
+                        status, generation_method, panel_position, created_at, updated_at
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7,
+                        $8, $9, $10, $11, $12, $13,
+                        $14, $15, $16, now(), now()
+                    )""",
+                    str(uuid.uuid4()),
+                    self.tenant_id,
+                    video_id,
+                    video.get("video_title"),
+                    scene,
+                    index,
+                    asset.get("sentence_index") or index,
+                    asset.get("sentence_text"),
+                    prompt,
+                    asset.get("shot_type"),
+                    asset.get("hero_shot") or False,
+                    image_url,
+                    drive_download_url,
+                    "Done",
+                    "variant_candidate",
+                    next_variant_position + offset,
+                )
+                created += 1
+
+            if created == 0:
+                raise Exception("No image variants were generated successfully")
+
+            await self._log_activity(
+                bot_name,
+                video_id,
+                "completed",
+                f"Generated {created} variant(s) for scene {scene} image {index}",
+            )
+            return {"status": video.get("status"), "video_id": video_id, "variants_created": created}
+
+        except Exception as e:
             error_msg = str(e)
             await self._log_activity(bot_name, video_id, "failed", error_msg)
             return {"status": "failed", "error": error_msg}

--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -485,10 +485,10 @@ async def run_images(
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
-    if variants is not None and variants > 1:
+    if variants is not None and variants > 1 and (scene is None or index is None):
         raise HTTPException(
-            status_code=501,
-            detail="Image variants are not wired in the production backend yet.",
+            status_code=400,
+            detail="Image variants require both scene and index.",
         )
 
     if scene is None and not is_at_or_past_stage(video["status"], "ready_for_images"):
@@ -505,7 +505,10 @@ async def run_images(
     async def _run():
         try:
             executor = PipelineExecutor(tenant_id)
-            result = await executor.run_images(video_id, scene=scene, index=index)
+            if variants is not None and variants > 1:
+                result = await executor.run_image_variants(video_id, scene=scene, index=index, variants=variants)
+            else:
+                result = await executor.run_images(video_id, scene=scene, index=index)
             _set_task_status(video_id, result.get("status", "unknown"), result.get("error"))
         except Exception as e:
             _set_task_status(video_id, "failed", str(e))
@@ -515,7 +518,9 @@ async def run_images(
 
     background_tasks.add_task(_run)
 
-    if scene is not None and index is not None:
+    if variants is not None and variants > 1 and scene is not None and index is not None:
+        msg = f"Generating {variants} image variants for scene {scene} segment {index}"
+    elif scene is not None and index is not None:
         msg = f"Generating image for scene {scene} segment {index}"
     elif scene is not None:
         msg = f"Generating images for scene {scene}"

--- a/storyengine/backend/routes/videos.py
+++ b/storyengine/backend/routes/videos.py
@@ -276,8 +276,30 @@ async def get_video_assets(video_id: str, tenant_id: str = Depends(get_tenant_id
                   duration_seconds,
                   created_at::text
            FROM assets WHERE video_id = $1 AND tenant_id = $2
+             AND (generation_method IS NULL OR generation_method <> 'variant_candidate')
            ORDER BY scene, image_index""",
         video_id, tenant_id,
+    )
+    return rows
+
+
+@router.get("/{video_id}/assets/variants")
+async def get_video_asset_variants(
+    video_id: str,
+    scene: int = Query(...),
+    index: int = Query(...),
+    tenant_id: str = Depends(get_tenant_id),
+):
+    """Get variant candidate assets for a specific scene/index."""
+    rows = await fetch_all(
+        """SELECT id, video_id, scene, image_index, image_url, drive_image_url, image_prompt,
+                  status, shot_type, hero_shot, sentence_text, panel_position,
+                  generation_method, created_at::text
+           FROM assets
+           WHERE video_id = $1 AND tenant_id = $2 AND scene = $3 AND image_index = $4
+             AND generation_method = 'variant_candidate'
+           ORDER BY panel_position, created_at""",
+        video_id, tenant_id, scene, index,
     )
     return rows
 
@@ -508,6 +530,7 @@ async def get_scene_segments(
         "SELECT id, image_index, sentence_text, shot_type, status, "
         "duration_seconds, image_prompt "
         "FROM assets WHERE video_id = $1 AND scene = $2 AND tenant_id = $3 "
+        "AND (generation_method IS NULL OR generation_method <> 'variant_candidate') "
         "ORDER BY image_index",
         video_id, scene, tenant_id,
     )
@@ -541,7 +564,8 @@ async def update_scene_segments(
     for seg in body.segments:
         result = await execute(
             "UPDATE assets SET sentence_text = $1, updated_at = now() "
-            "WHERE video_id = $2 AND scene = $3 AND image_index = $4 AND tenant_id = $5",
+            "WHERE video_id = $2 AND scene = $3 AND image_index = $4 AND tenant_id = $5 "
+            "AND (generation_method IS NULL OR generation_method <> 'variant_candidate')",
             seg["sentence_text"], video_id, scene, seg["image_index"], tenant_id,
         )
         if result and "UPDATE 1" in result:

--- a/storyengine/frontend/src/components/video-detail/image-segment-card.tsx
+++ b/storyengine/frontend/src/components/video-detail/image-segment-card.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from "react";
 import { Loader2, RefreshCw, Image as ImageIcon, Star } from "lucide-react";
-import { Asset, runImageForSegment, runImageVariants } from "@/lib/api";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Asset, getImageVariants, runImageForSegment, runImageVariants } from "@/lib/api";
 import { PromptExpander } from "./prompt-expander";
 import { useTaskPoller } from "@/hooks/use-task-poller";
-import { useQueryClient } from "@tanstack/react-query";
 
 interface ImageSegmentCardProps {
   asset: Asset;
@@ -16,6 +16,14 @@ interface ImageSegmentCardProps {
 export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCardProps) {
   const [generating, setGenerating] = useState(false);
   const queryClient = useQueryClient();
+  const scene = asset.scene;
+  const imageIndex = asset.image_index;
+
+  const { data: variants = [] } = useQuery({
+    queryKey: ["image-variants", videoId, scene, imageIndex],
+    queryFn: () => getImageVariants(videoId, scene as number, imageIndex as number),
+    enabled: scene != null && imageIndex != null,
+  });
 
   useTaskPoller({
     videoId,
@@ -23,6 +31,7 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
     onComplete: () => {
       setGenerating(false);
       queryClient.invalidateQueries({ queryKey: ["video-assets", videoId] });
+      queryClient.invalidateQueries({ queryKey: ["image-variants", videoId, scene, imageIndex] });
       onRefresh();
     },
     onFailed: () => {
@@ -31,9 +40,9 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
   });
 
   const handleGenerate = async () => {
-    if (asset.scene == null || asset.image_index == null) return;
+    if (scene == null || imageIndex == null) return;
     try {
-      await runImageForSegment(videoId, asset.scene, asset.image_index);
+      await runImageForSegment(videoId, scene, imageIndex);
       setGenerating(true);
     } catch (err) {
       console.error("Failed to start image generation", err);
@@ -41,9 +50,9 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
   };
 
   const handleVariants = async () => {
-    if (asset.scene == null || asset.image_index == null) return;
+    if (scene == null || imageIndex == null) return;
     try {
-      await runImageVariants(videoId, asset.scene, asset.image_index);
+      await runImageVariants(videoId, scene, imageIndex);
       setGenerating(true);
     } catch (err) {
       console.error("Failed to start variants generation", err);
@@ -192,21 +201,49 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
               </button>
               <button
                 onClick={handleVariants}
-                disabled
+                disabled={generating}
                 className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded disabled:opacity-50"
                 style={{
                   border: "1px solid var(--border)",
                   color: "var(--text-secondary)",
                   background: "var(--bg-card-hover)",
                 }}
-                title="Image variants are not wired in the production backend yet."
               >
                 <Star size={11} />
-                Variants Soon
+                3 Variants · $0.075
               </button>
             </>
           )}
         </div>
+
+        {variants.length > 0 && (
+          <div className="flex gap-2 flex-wrap pt-1">
+            {variants.map((variant) => (
+              <a
+                key={variant.id}
+                href={variant.drive_image_url || variant.image_url || "#"}
+                target="_blank"
+                rel="noreferrer"
+                className="block rounded overflow-hidden"
+                style={{
+                  width: 72,
+                  height: 40,
+                  border: "1px solid var(--border)",
+                  background: "var(--bg-card-hover)",
+                }}
+                title={`Variant ${variant.panel_position || "?"}`}
+              >
+                {variant.image_url ? (
+                  <img
+                    src={variant.image_url}
+                    alt={`Variant ${variant.panel_position || ""}`}
+                    className="w-full h-full object-cover"
+                  />
+                ) : null}
+              </a>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/storyengine/frontend/src/lib/api.ts
+++ b/storyengine/frontend/src/lib/api.ts
@@ -59,6 +59,11 @@ export const rejectVideo = (id: string, reason?: string) =>
 
 export const getVideoAssets = (id: string) => fetchApi<Asset[]>(`/api/videos/${id}/assets`);
 
+export const getImageVariants = (videoId: string, scene: number, index: number) =>
+  fetchApi<ImageVariant[]>(
+    `/api/videos/${videoId}/assets/variants?scene=${scene}&index=${index}`
+  );
+
 export const getVideoScript = (id: string) => fetchApi<ScriptScene[]>(`/api/videos/${id}/script`);
 
 // Assets
@@ -463,6 +468,23 @@ export interface Asset {
   sound_prompt: string | null;
   sound_effect_url: string | null;
   sound_volume: number | null;
+  created_at: string | null;
+}
+
+export interface ImageVariant {
+  id: string;
+  video_id: string | null;
+  scene: number | null;
+  image_index: number | null;
+  image_url: string | null;
+  drive_image_url?: string | null;
+  image_prompt: string | null;
+  status: string | null;
+  shot_type: string | null;
+  hero_shot: boolean;
+  sentence_text: string | null;
+  panel_position?: number | null;
+  generation_method?: string | null;
   created_at: string | null;
 }
 


### PR DESCRIPTION
## Summary
- add targeted image variant generation for a scene/image segment through the existing FastAPI pipeline route
- persist generated variants to Google Drive and Supabase as separate `variant_candidate` asset rows
- exclude variant candidates from the main asset/segment feeds so render and editing flows stay stable
- surface saved variants in the image segment card UI

## Verification
- `python3 -m py_compile storyengine/backend/routes/pipeline.py storyengine/backend/routes/videos.py storyengine/backend/pipeline_executor.py storyengine/backend/models.py`
- `git diff --check`

## Notes
- variants are available from the detail image card UI via the existing `3 Variants` action
- variant rows are intentionally isolated from the main scene asset stream to avoid polluting render order