### PR TITLE
Add StoryEngine variant promotion

### DIFF
--- a/storyengine/backend/routes/assets.py
+++ b/storyengine/backend/routes/assets.py
@@ -58,3 +58,68 @@ async def batch_approve(body: BatchApproval, tenant_id: str = Depends(get_tenant
             count += 1
 
     return {"updated": count, "status": body.status}
+
+
+@router.post("/{asset_id}/promote-variant")
+async def promote_variant(asset_id: str, tenant_id: str = Depends(get_tenant_id)):
+    """Promote a variant candidate into the primary asset slot for its scene/index."""
+    variant = await fetch_one(
+        """SELECT id, video_id, scene, image_index, image_url, drive_image_url, image_prompt,
+                  shot_type, hero_shot, sentence_text, panel_position, generation_method
+           FROM assets
+           WHERE id = $1 AND tenant_id = $2""",
+        asset_id, tenant_id,
+    )
+    if not variant:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    if variant.get("generation_method") != "variant_candidate":
+        raise HTTPException(status_code=400, detail="Only variant candidate assets can be promoted")
+
+    base_asset = await fetch_one(
+        """SELECT id
+           FROM assets
+           WHERE video_id = $1 AND tenant_id = $2 AND scene = $3 AND image_index = $4
+             AND (generation_method IS NULL OR generation_method <> 'variant_candidate')
+           ORDER BY created_at
+           LIMIT 1""",
+        variant["video_id"], tenant_id, variant["scene"], variant["image_index"],
+    )
+    if not base_asset:
+        raise HTTPException(status_code=404, detail="Primary asset not found for this variant")
+
+    await execute(
+        """UPDATE assets
+           SET image_url = $1,
+               drive_image_url = $2,
+               image_prompt = $3,
+               shot_type = $4,
+               hero_shot = $5,
+               sentence_text = $6,
+               status = 'Done',
+               updated_at = now()
+           WHERE id = $7 AND tenant_id = $8""",
+        variant.get("image_url"),
+        variant.get("drive_image_url"),
+        variant.get("image_prompt"),
+        variant.get("shot_type"),
+        variant.get("hero_shot") or False,
+        variant.get("sentence_text"),
+        base_asset["id"],
+        tenant_id,
+    )
+
+    await execute(
+        """UPDATE assets
+           SET status = 'promoted',
+               generation_method = 'variant_promoted',
+               updated_at = now()
+           WHERE id = $1 AND tenant_id = $2""",
+        asset_id, tenant_id,
+    )
+
+    return {
+        "status": "promoted",
+        "asset_id": str(base_asset["id"]),
+        "variant_id": asset_id,
+    }

--- a/storyengine/frontend/src/components/video-detail/image-segment-card.tsx
+++ b/storyengine/frontend/src/components/video-detail/image-segment-card.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Loader2, RefreshCw, Image as ImageIcon, Star } from "lucide-react";
+import { Check, Loader2, RefreshCw, Image as ImageIcon, Star } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Asset, getImageVariants, runImageForSegment, runImageVariants } from "@/lib/api";
+import { Asset, getImageVariants, promoteVariantAsset, runImageForSegment, runImageVariants } from "@/lib/api";
 import { PromptExpander } from "./prompt-expander";
 import { useTaskPoller } from "@/hooks/use-task-poller";
 
@@ -15,6 +15,7 @@ interface ImageSegmentCardProps {
 
 export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCardProps) {
   const [generating, setGenerating] = useState(false);
+  const [promotingId, setPromotingId] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const scene = asset.scene;
   const imageIndex = asset.image_index;
@@ -60,6 +61,20 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
   };
 
   const hasImage = !!asset.image_url;
+
+  const handlePromoteVariant = async (variantId: string) => {
+    setPromotingId(variantId);
+    try {
+      await promoteVariantAsset(variantId);
+      queryClient.invalidateQueries({ queryKey: ["video-assets", videoId] });
+      queryClient.invalidateQueries({ queryKey: ["image-variants", videoId, scene, imageIndex] });
+      onRefresh();
+    } catch (err) {
+      console.error("Failed to promote variant", err);
+    } finally {
+      setPromotingId(null);
+    }
+  };
 
   return (
     <div
@@ -219,28 +234,46 @@ export function ImageSegmentCard({ asset, videoId, onRefresh }: ImageSegmentCard
         {variants.length > 0 && (
           <div className="flex gap-2 flex-wrap pt-1">
             {variants.map((variant) => (
-              <a
+              <div
                 key={variant.id}
-                href={variant.drive_image_url || variant.image_url || "#"}
-                target="_blank"
-                rel="noreferrer"
-                className="block rounded overflow-hidden"
-                style={{
-                  width: 72,
-                  height: 40,
-                  border: "1px solid var(--border)",
-                  background: "var(--bg-card-hover)",
-                }}
-                title={`Variant ${variant.panel_position || "?"}`}
+                className="flex flex-col gap-1"
               >
-                {variant.image_url ? (
-                  <img
-                    src={variant.image_url}
-                    alt={`Variant ${variant.panel_position || ""}`}
-                    className="w-full h-full object-cover"
-                  />
-                ) : null}
-              </a>
+                <a
+                  href={variant.drive_image_url || variant.image_url || "#"}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block rounded overflow-hidden"
+                  style={{
+                    width: 72,
+                    height: 40,
+                    border: "1px solid var(--border)",
+                    background: "var(--bg-card-hover)",
+                  }}
+                  title={`Variant ${variant.panel_position || "?"}`}
+                >
+                  {variant.image_url ? (
+                    <img
+                      src={variant.image_url}
+                      alt={`Variant ${variant.panel_position || ""}`}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : null}
+                </a>
+                <button
+                  onClick={() => handlePromoteVariant(variant.id)}
+                  disabled={promotingId === variant.id}
+                  className="flex items-center justify-center gap-1 text-[10px] px-2 py-1 rounded disabled:opacity-50"
+                  style={{
+                    border: "1px solid var(--border)",
+                    color: "var(--text-secondary)",
+                    background: "var(--bg-card-hover)",
+                  }}
+                  title="Replace the primary scene image with this variant"
+                >
+                  {promotingId === variant.id ? <Loader2 size={10} className="animate-spin" /> : <Check size={10} />}
+                  Pick
+                </button>
+              </div>
             ))}
           </div>
         )}

--- a/storyengine/frontend/src/lib/api.ts
+++ b/storyengine/frontend/src/lib/api.ts
@@ -79,6 +79,12 @@ export const batchApproveAssets = (assetIds: string[], status: "approved" | "rej
     body: JSON.stringify({ asset_ids: assetIds, status }),
   });
 
+export const promoteVariantAsset = (id: string) =>
+  fetchApi<{ status: string; asset_id: string; variant_id: string }>(
+    `/api/assets/${id}/promote-variant`,
+    { method: "POST" }
+  );
+
 // Review
 export const getPendingReview = () => fetchApi<PendingReview>("/api/review/pending");
 


### PR DESCRIPTION
## Summary
- add a backend route to promote a saved image variant into the primary scene asset
- keep the primary asset row id stable while replacing its image fields with the chosen variant
- mark the chosen variant as promoted so it leaves the candidate pool
- add a `Pick` action in the image segment card UI for saved variants

## Verification
- `python3 -m py_compile storyengine/backend/routes/assets.py storyengine/backend/routes/videos.py storyengine/backend/routes/pipeline.py storyengine/backend/pipeline_executor.py storyengine/backend/models.py`
- `git diff --check`

## Notes
- promotion preserves the base asset row so downstream clip/sound references are less likely to break
- the chosen variant is archived out of the variant candidate list after promotion