### PR TITLE
Fix storyboard task error reporting

### DIFF
--- a/storyengine/backend/pipeline_executor.py
+++ b/storyengine/backend/pipeline_executor.py
@@ -954,7 +954,7 @@ class PipelineExecutor:
             return {"status": to_supabase(new_status), "video_id": video_id}
 
         except Exception as e:
-            error_msg = str(e)
+            error_msg = str(e) or e.__class__.__name__
             await self._log_activity(bot_name, video_id, "failed", error_msg)
             return {"status": "failed", "error": error_msg}
 
@@ -987,7 +987,7 @@ class PipelineExecutor:
             return {"status": to_supabase(new_status), "video_id": video_id}
 
         except Exception as e:
-            error_msg = str(e)
+            error_msg = str(e) or e.__class__.__name__
             await self._log_activity(bot_name, video_id, "failed", error_msg)
             return {"status": "failed", "error": error_msg}
 
@@ -1020,7 +1020,7 @@ class PipelineExecutor:
             return {"status": to_supabase(new_status), "video_id": video_id}
 
         except Exception as e:
-            error_msg = str(e)
+            error_msg = str(e) or e.__class__.__name__
             await self._log_activity(bot_name, video_id, "failed", error_msg)
             return {"status": "failed", "error": error_msg}
 

--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -52,7 +52,12 @@ _running_tasks: dict[str, dict] = {}
 _STALE_TASK_SECONDS = 600
 
 
-def _set_task_status(video_id: str, status: str, message: Optional[str] = None):
+def _set_task_status(
+    video_id: str,
+    status: str,
+    message: Optional[str] = None,
+    error: Optional[str] = None,
+):
     """Update task status for polling.
 
     Normalizes status to: running | completed | failed
@@ -62,9 +67,14 @@ def _set_task_status(video_id: str, status: str, message: Optional[str] = None):
         normalized = "completed"
     else:
         normalized = status
+    resolved_error = error
+    resolved_message = message
+    if normalized == "failed" and not resolved_error:
+        resolved_error = message
     _running_tasks[video_id] = {
         "status": normalized,
-        "message": message,
+        "message": resolved_message,
+        "error": resolved_error,
         "started_at": _running_tasks.get(video_id, {}).get("started_at", _time.time()),
     }
 
@@ -370,9 +380,14 @@ async def run_storyboards(
         try:
             executor = PipelineExecutor(tenant_id)
             result = await executor.run_storyboard_prompts(video_id)
-            _set_task_status(video_id, result.get("status", "unknown"), result.get("error"))
+            _set_task_status(
+                video_id,
+                result.get("status", "unknown"),
+                result.get("message") or result.get("error"),
+                result.get("error"),
+            )
         except Exception as e:
-            _set_task_status(video_id, "failed", str(e))
+            _set_task_status(video_id, "failed", str(e), str(e))
         finally:
             await asyncio.sleep(30)
             _clear_task_status(video_id)
@@ -411,9 +426,14 @@ async def run_storyboard_images(
         try:
             executor = PipelineExecutor(tenant_id)
             result = await executor.run_storyboard_images(video_id)
-            _set_task_status(video_id, result.get("status", "unknown"), result.get("error"))
+            _set_task_status(
+                video_id,
+                result.get("status", "unknown"),
+                result.get("message") or result.get("error"),
+                result.get("error"),
+            )
         except Exception as e:
-            _set_task_status(video_id, "failed", str(e))
+            _set_task_status(video_id, "failed", str(e), str(e))
         finally:
             await asyncio.sleep(30)
             _clear_task_status(video_id)
@@ -452,9 +472,14 @@ async def run_storyboard_extract(
         try:
             executor = PipelineExecutor(tenant_id)
             result = await executor.run_storyboard_extract(video_id)
-            _set_task_status(video_id, result.get("status", "unknown"), result.get("error"))
+            _set_task_status(
+                video_id,
+                result.get("status", "unknown"),
+                result.get("message") or result.get("error"),
+                result.get("error"),
+            )
         except Exception as e:
-            _set_task_status(video_id, "failed", str(e))
+            _set_task_status(video_id, "failed", str(e), str(e))
         finally:
             await asyncio.sleep(30)
             _clear_task_status(video_id)
@@ -891,8 +916,12 @@ async def get_task_status(
     """
     task = _get_task_status(video_id)
     if not task:
-        return {"status": "idle", "message": None}
-    return {"status": task["status"], "message": task.get("message")}
+        return {"status": "idle", "message": None, "error": None}
+    return {
+        "status": task["status"],
+        "message": task.get("message"),
+        "error": task.get("error"),
+    }
 
 
 @router.get("/task/{video_id}/clear")


### PR DESCRIPTION
## Summary
- preserve task `error` separately from task `message` in pipeline background task tracking
- return the error field from `/api/pipeline/task/{video_id}` so the frontend poller can show the real failure reason
- improve storyboard executor fallback errors when exceptions stringify to an empty string

## Verification
- `python3 -m py_compile storyengine/backend/routes/pipeline.py storyengine/backend/pipeline_executor.py`
- `git diff --check`

## Why
Storyboard prompt generation was surfacing `Generation failed: Unknown error` even when the backend had a more specific failure reason. This change makes the real error reach the UI on the next failed run.