### PR TITLE
Restore legacy image prompt engine shim

### DIFF
--- a/skills/video-pipeline/image_prompt_engine/__init__.py
+++ b/skills/video-pipeline/image_prompt_engine/__init__.py
@@ -1,0 +1,10 @@
+"""Compatibility shim for legacy ``image_prompt_engine`` imports.
+
+The pipeline was renamed to ``image_prompts.engine`` during the StoryEngine
+migration, but a few production call sites still import the old package name.
+Re-export the public API here so older imports keep working until every caller
+is updated.
+"""
+
+from image_prompts.engine import *  # noqa: F401,F403
+


### PR DESCRIPTION
## Summary\n- restore the legacy  compatibility package\n- re-export the public API from \n- fix storyboard prompt generation imports that still use the old package name\n\n## Testing\n- cd skills/video-pipeline && python3 - <<'PY'\nfrom image_prompt_engine import resolve_accent_color, generate_prompts\nprint('accent:', resolve_accent_color(accent_color='cold teal'))\nprint('ok')\nPY\n- git diff --check