### PR TITLE
Add comprehensive StoryEngine wiring status audit document

### DIFF
--- a/storyengine/WIRING_STATUS.md
+++ b/storyengine/WIRING_STATUS.md
@@ -1,0 +1,250 @@
+# StoryEngine Wiring Status — Ground Truth Audit
+> Generated: 2026-03-31T04:07:11Z
+> Audited by: Claude Code
+> Branch: claude/audit-storyengine-wiring-0dPTs
+> Commit: d442dd112fe9f5745d9e35ab1918a537a9a09f22
+
+---
+
+## Pipeline Stage Matrix
+
+| Stage | Frontend Button | API Route | Execution | Polling | Tests |
+|-------|----------------|-----------|-----------|---------|-------|
+| **Create Idea** | WIRED — `/create` "Generate Story" → `POST /api/pipeline/create-idea` | WIRED — `routes/pipeline.py` registered in `main.py` | BROKEN — calls `executor.create_idea()` which calls `self._pipeline.run_idea_bot(topic)`, but `run_idea_bot` is never defined on LightPipeline → `AttributeError` at runtime | MISSING — no task poller, synchronous call | MISSING |
+| **Research** | WIRED — ResearchTab "Run Research" / "Regenerate Research" → `POST /api/pipeline/research/{videoId}` | WIRED — `routes/pipeline.py` | WIRED — BackgroundTasks, imports `research.agent.run_research`, calls it directly, writes payload to Supabase | WIRED — `useTaskPoller` polls `GET /api/pipeline/task/{videoId}` every 3s | MISSING |
+| **Script** | WIRED — ScriptVoiceTab "Regenerate Script" → `POST /api/pipeline/script/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_scripting` | WIRED — BackgroundTasks, imports `script.run.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Split** | WIRED — ScriptVoiceTab "Split Sentences" → `POST /api/pipeline/split/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_voice` | WIRED — Synchronous, imports `shared.clients.deterministic_splitter`, no external API | MISSING — synchronous (no polling needed) | MISSING |
+| **Voice** | WIRED — ScriptVoiceTab "Generate All Voice" + per-scene mic icon → `POST /api/pipeline/voice/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_voice` (bypassed if scene specified) | WIRED — BackgroundTasks, imports `voice.run.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Image Prompts** | WIRED — ScriptVoiceTab "Generate All Prompts" + per-scene/segment wand icons → `POST /api/pipeline/prompts/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_image_prompts` (bypassed if scene specified) | WIRED — BackgroundTasks, imports `image_prompts.run.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Story Bible** | WIRED — StoryboardVisualsTab "Story Bible" (when storyboard mode ON) → `POST /api/pipeline/story-bible/{videoId}` | WIRED — `routes/pipeline.py`, no status gate | WIRED — BackgroundTasks, imports `storyboard.bot._generate_story_bible_for_storyboard` directly | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Storyboard Prompts** | WIRED — StoryboardVisualsTab "Storyboards" (when storyboard mode ON) → `POST /api/pipeline/storyboards/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_storyboards` | WIRED — BackgroundTasks, imports `storyboard.run.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Storyboard Images** | WIRED — StoryboardVisualsTab "Generate Storyboard Grids" → `POST /api/pipeline/storyboard-images/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_storyboard_images` | WIRED — BackgroundTasks, imports `storyboard.run_images.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Storyboard Extract** | MISSING — no frontend button found | WIRED — `routes/pipeline.py`, status gate `ready_for_storyboard_extraction` | WIRED — BackgroundTasks, imports `storyboard.run_extract.run` via LightPipeline | N/A | MISSING |
+| **Images** | WIRED — StoryboardVisualsTab "Generate All Images" + per-segment refresh icon → `POST /api/pipeline/images/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_images` (bypassed if scene specified) | WIRED — BackgroundTasks, imports `images.run.run` via LightPipeline. Also supports variant generation via `ImageClient` directly | WIRED — `useTaskPoller` every 3s (bulk), synchronous per-segment regen | MISSING |
+| **Sound Prompts** | MISSING — no frontend button | WIRED — `routes/pipeline.py`, status gate `ready_for_sound_design` | WIRED — BackgroundTasks, imports `sound.run_design.run` via LightPipeline | N/A | MISSING |
+| **Sound Effects** | MISSING — no frontend button | WIRED — `routes/pipeline.py`, status gate `ready_for_sound_effects` | WIRED — BackgroundTasks, imports `sound.run_effects.run` via LightPipeline | N/A | MISSING |
+| **Video Scripts** | WIRED — VideoClipsTab "Generate Video Prompts" → `POST /api/pipeline/video-scripts/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_video_scripts` | WIRED — BackgroundTasks, imports `video_motion.run_scripts.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Video Generation** | WIRED — VideoClipsTab "Generate Clips" → `POST /api/pipeline/video-generation/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_video_generation` | WIRED — BackgroundTasks, imports `video_motion.run_generate.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Thumbnail** | WIRED — ThumbnailTab "Generate Thumbnail" / "Regenerate" → `POST /api/pipeline/thumbnail/{videoId}` | WIRED — `routes/pipeline.py`, status gate `ready_for_thumbnail` | WIRED — BackgroundTasks, imports `thumbnail.run.run` via LightPipeline | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Render** | PARTIAL — RenderTab has "Render Video" button → `POST /api/pipeline/render/{videoId}` (WIRED). Standalone `/render` page has "Render Now" buttons with NO onClick handlers (MOCK) | WIRED — `routes/pipeline.py`, status gate `ready_to_render` | WIRED — BackgroundTasks, imports `render.run.run` via LightPipeline | WIRED — `useTaskPoller` every 10s (RenderTab only) | MISSING |
+| **Upload** | WIRED — UploadTab "Upload to YouTube" → `POST /api/pipeline/upload/{videoId}` | STUB — no `/api/pipeline/upload` route exists in backend. Will 404 | MISSING — no upload route handler | MISSING — no polling | MISSING |
+| **Run Next** | WIRED — Video detail "Run Next Step" → `POST /api/pipeline/run-next/{videoId}` | WIRED — `routes/pipeline.py` | WIRED — BackgroundTasks, auto-routes to correct handler based on status. Has approval gates. Optional Claude orchestration via feature flag | WIRED — `useTaskPoller` every 3s | MISSING |
+| **Reset** | WIRED — Video detail reset dropdown → `POST /api/pipeline/reset/{videoId}` | WIRED — `routes/pipeline.py` | WIRED — Deletes scripts/assets, resets video status. No pipeline imports needed | N/A | MISSING |
+| **Orchestrate** | MISSING — no frontend button | WIRED — `routes/pipeline.py` (two endpoints: execute + decide-only) | WIRED — imports `claude_orchestrator.ClaudeOrchestrator` | N/A | MISSING |
+
+---
+
+## Page Wiring Status
+
+| Page | Status | Detail |
+|------|--------|--------|
+| `/` (root) | MOCK | Static mock data. No API calls. |
+| `/dashboard` | WIRED | Reads dashboard summary, videos, pending review. All navigation buttons. |
+| `/pipeline` | WIRED | Lists videos. Create modal → `POST /api/videos`. |
+| `/pipeline/[videoId]` | WIRED | Full video detail with 7 tab components. Run Next, Skip, Reset all wired. |
+| `/pipeline/[videoId]/storyboards` | STUB | Approve button is a mock (`setTimeout(500)`, TODO comment). |
+| `/create` | WIRED | "Generate Story" → `POST /api/pipeline/create-idea`. Note: backend handler is BROKEN (see bugs). |
+| `/analytics` | WIRED | Reads videos list, computes stats client-side. Read-only. |
+| `/autopilot` | WIRED | Reads summary, toggle ON/OFF, update target. Error handling: console.error only (no user feedback). |
+| `/competitors` | WIRED | Reads niche config + channels + candidates. Add channel, model candidate → create video. |
+| `/activity` | WIRED | Reads activity log + stats. Auto-polls every 10s. Read-only. |
+| `/review` | PARTIAL | Approve script/storyboard/thumbnail/images all WIRED. Storyboard "Reject" button has NO onClick handler. |
+| `/render` | MOCK | All buttons ("Render Now", "Preview Draft", "Upload to YouTube") have no onClick handlers. Uses mock data. |
+| `/storyboard` | MOCK | Uses mock data. "Regenerate" button has no onClick. "Approve" operates on local mock state only. |
+| `/visuals` | MOCK | Uses mock data. No API calls. |
+| `/settings` | WIRED | Channel name, niche, audience, frameworks → `PUT /api/projects/current`. Auto-save on blur. |
+| `/settings/keys` | WIRED | List/test/set API keys. Full CRUD via vault endpoints. |
+| `/profile` | WIRED | Visual styles CRUD. Character generation via Kie.ai. Image analysis via Gemini. |
+
+---
+
+## Auth Status
+
+**Mechanism:** Bearer token via FastAPI `HTTPBearer` dependency.
+
+**Frontend:** `api.ts` reads token from `localStorage`, falls back to `"dev-token"`. Sends `Authorization: Bearer <token>` on every request.
+
+**Backend:** `auth.py` extracts bearer token. Two paths:
+- **Dev mode (default):** If token is `"dev-token"` AND `ENV` env var equals `"development"` (the default when unset), returns hardcoded `AuthUser(id="dev-user", email="dev@local", tenant_id=DEV_TENANT_ID)`.
+- **Production:** Decodes Supabase JWT using `SUPABASE_JWT_SECRET`, validates HS256 signature and `"authenticated"` audience, extracts `sub` (user ID) and `email`. Looks up tenant via `memberships` table.
+
+**Coverage:** All 14 route files use `get_tenant_id` as a `Depends()`. Auth is applied to every route.
+
+**Exception:** `videos.py` has an audio proxy endpoint (`GET /api/videos/{videoId}/audio/{scene}`) that uses `DEV_TENANT_ID` directly because HTML `<audio>` elements cannot set Authorization headers.
+
+**Risk:** The `"dev-token"` backdoor is active whenever `ENV` is unset (defaults to `"development"`). Production deployments must explicitly set `ENV` to a non-development value.
+
+---
+
+## Database Connections
+
+**Connection:** `asyncpg` pool (min=2, max=10) via `DATABASE_URL` env var to Supabase PostgreSQL.
+
+**Query style:** 100% raw SQL with parameterized `$1, $2` placeholders. No ORM.
+
+**Tables actively queried:**
+
+| Table | Read | Write | Routes |
+|-------|------|-------|--------|
+| `videos` | Yes | Yes (INSERT, UPDATE, DELETE) | videos, pipeline, dashboard, review, agents, autopilot |
+| `scripts` | Yes | Yes (INSERT, UPDATE, DELETE) | pipeline, review, videos |
+| `assets` | Yes | Yes (INSERT, UPDATE, DELETE) | assets, pipeline, review, videos |
+| `bot_activity` | Yes | Yes (INSERT) | activity, agents, pipeline |
+| `stage_transitions` | Yes | Yes (INSERT) | videos, pipeline |
+| `autopilot_config` | Yes | Yes (UPSERT) | autopilot, niche |
+| `competitor_videos` | Yes | No | autopilot |
+| `competitor_channels` | Yes | Yes (INSERT, DELETE) | niche |
+| `learnings` | Yes | No | autopilot |
+| `projects` | Yes | Yes (INSERT, UPDATE) | projects, visual_styles, videos |
+| `visual_styles` | Yes | Yes (INSERT, UPDATE, DELETE) | visual_styles |
+| `style_characters` | Yes | Yes (INSERT, DELETE) | visual_styles |
+| `memberships` | Yes | No | auth.py (tenant lookup) |
+| `channel_profiles` | Yes | Yes (UPSERT) | channel_profile (legacy, superseded by projects) |
+
+**Pipeline writeback:** Yes. `pipeline_executor.py` writes results back: updates `videos.status`, deletes/recreates `scripts` and `assets` rows during resets, inserts `stage_transitions` and `bot_activity` records.
+
+**RLS:** Enabled on all tables with tenant isolation policies, but the backend likely connects via service role key (bypassing RLS). Tenant isolation is enforced in SQL WHERE clauses.
+
+**Schema staleness:** `schema.sql` is missing `visual_styles` and `style_characters` tables (only in migration 010). Also has a forward-reference FK issue (`videos.project_id` → `projects` before `projects` is defined) and a duplicate column `voice_duration_seconds` in `scripts`.
+
+---
+
+## Test Coverage
+
+**Backend tests:** NONE. Zero test files exist anywhere in `storyengine/`. `pytest` is not installed in the backend environment.
+
+**Frontend TypeScript check:** Cannot run — `node_modules` not installed. Running `npm install` first would be required. The last successful state is unknown.
+
+**Frontend test files:** NONE. No `.test.tsx`, `.spec.tsx`, or similar files found.
+
+**Total test count: 0**
+
+---
+
+## Import Graph
+
+`pipeline_executor.py` is the bridge between the StoryEngine backend and `skills/video-pipeline/`. It manipulates `sys.path` at import time:
+
+```
+sys.path[0] = skills/video-pipeline/
+sys.path += [script/, voice/, image_prompts/, images/, video_motion/,
+             thumbnail/, render/, sound/, storyboard/, research/,
+             upload/, analytics/]
+```
+
+**Direct imports from `skills/video-pipeline/`:**
+
+| Backend Module | Imports From Pipeline |
+|---------------|----------------------|
+| `pipeline_executor.py` | `research.agent.run_research`, `script.run.run`, `voice.run.run`, `image_prompts.run.run`, `images.run.run`, `video_motion.run_scripts.run`, `video_motion.run_generate.run`, `thumbnail.run.run`, `render.run.run`, `sound.run_design.run`, `sound.run_effects.run`, `storyboard.run.run`, `storyboard.run_images.run`, `storyboard.run_extract.run`, `storyboard.bot._generate_story_bible_for_storyboard`, `shared.clients.*` (airtable, anthropic, google, image, elevenlabs, gemini, slack, deterministic_splitter), `orchestrator.pipeline_config`, `orchestrator.pipeline_constants` |
+| `supabase_adapter.py` | `orchestrator.pipeline_constants` (IdeaFields, ScriptFields, ImageFields, Statuses) |
+| `claude_orchestrator.py` | Pipeline path (via `pipeline_executor`) |
+| `routes/skills.py` | `shared.skill_registry` |
+| `routes/agents.py` | `agents.pipeline.AgentPipeline`, `agents.config.QualityTier` |
+
+**No subprocess calls.** All pipeline execution is via direct Python imports in the same process.
+
+---
+
+## Known Bugs Found During Audit
+
+### Critical
+
+1. **`create_idea` → `AttributeError` at runtime**
+   - `pipeline_executor.py`: `create_idea()` calls `self._pipeline.run_idea_bot(topic)`, but `run_idea_bot` is never defined on LightPipeline during `_ensure_initialized()`. The 13 runner methods wired are: `run_brief_translator`, `run_voice_bot`, `run_styled_image_prompts`, `run_image_bot`, `run_video_script_bot`, `run_video_gen_bot`, `run_thumbnail_bot`, `run_render_bot`, `run_sound_prompt_bot`, `run_sound_bot`, `run_storyboard_prompts`, `run_storyboard_images`, `run_storyboard_extract`. `run_idea_bot` is missing.
+   - Impact: `/create` page "Generate Story" button will fail at runtime.
+
+2. **Upload route missing**
+   - Frontend `UploadTab` calls `POST /api/pipeline/upload/{videoId}`, but no such route exists in `routes/pipeline.py`. Will return 404.
+   - Impact: "Upload to YouTube" button in video detail will fail.
+
+3. **Skills route ordering bug**
+   - `routes/skills.py`: `GET /api/skills/{skill_id}` (line ~135) is defined before `GET /api/skills/pipeline/order` (line ~156) and `GET /api/skills/pipeline/cost` (line ~163). FastAPI matches routes in declaration order, so `/api/skills/pipeline/order` will be caught by `{skill_id}` with `skill_id="pipeline"`.
+   - Impact: Pipeline order and cost endpoints are unreachable.
+
+### Moderate
+
+4. **`reject_video` doesn't update status**
+   - `routes/videos.py`: `PATCH /api/videos/{videoId}/reject` logs a transition to 'rejected' but does NOT update the video's `status` column. The video remains at its current status.
+
+5. **Autopilot launch is a stub**
+   - `routes/autopilot.py`: `POST /api/autopilot/launch/{candidate_id}` marks candidate as `modeled=true` but has a `# TODO: Trigger actual pipeline execution` comment. No pipeline work is triggered.
+
+6. **Storyboard approve is a mock**
+   - `/pipeline/[videoId]/storyboards` page: Approve mutation is `await new Promise(resolve => setTimeout(resolve, 500))` — a hardcoded 500ms delay with no real API call. Has TODO comment.
+
+7. **Review page "Reject" storyboard button is dead**
+   - `/review` page: Storyboard "Reject" button has no onClick handler. It renders but does nothing.
+
+8. **Background task tracking is in-memory only**
+   - `pipeline_executor.py` tracks running tasks in a `_running_tasks` dict. Server restart loses all task status. Auto-clears after 10 minutes (stale threshold).
+
+### Low
+
+9. **Four mock pages with no API integration**
+   - `/` (root), `/render`, `/storyboard`, `/visuals` — all use hardcoded mock data. Buttons exist but are not wired.
+
+10. **Silent error handling on multiple pages**
+    - Autopilot toggle/config: errors go to `console.error` only, no user feedback.
+    - Settings auto-save: no error handling on blur saves.
+    - Competitors "Create Video" from candidate: error only logged to console, button stays in loading state forever.
+    - StoryboardVisualsTab per-segment regen + clear storyboard: errors silently swallowed in finally blocks.
+    - ThumbnailTab approve: empty catch block.
+
+11. **`channel_profile.py` runs DDL on every request**
+    - `_ensure_table()` calls `CREATE TABLE IF NOT EXISTS` on every GET/PUT. Legacy pattern superseded by `projects.py`.
+
+12. **`settings/keys/{name}/reveal` exposes full API keys**
+    - Returns unmasked key value with no additional auth beyond standard tenant check. Has a WARNING comment in code.
+
+---
+
+## Files Inventory
+
+### Frontend (`storyengine/frontend/src/`) — 96 files
+
+| Directory | Count | Purpose |
+|-----------|-------|---------|
+| `components/ui/` | 16 | Reusable UI primitives (Button, Card, Dialog, Badge, etc.) |
+| `components/video-detail/` | 14 | Video detail page sub-components |
+| `components/production/` | 13 | Pipeline production tabs (ResearchTab, ScriptVoiceTab, etc.) |
+| `components/forms/` | 6 | Form components |
+| `components/storyboard/` | 4 | Storyboard-specific components |
+| `components/autopilot/` | 4 | Autopilot UI (niche setup, playing cards) |
+| `components/dashboard/` | 3 | Dashboard widgets |
+| `components/nav/` | 2 | Sidebar + bottom bar navigation |
+| `components/layout/` | 1 | Layout wrapper |
+| `components/` (root) | 7 | Standalone components (StageAdvancer, etc.) |
+| `app/` | 20 | App Router pages (15 directories + layout, providers, globals) |
+| `lib/` | 5 | api.ts, types.ts, constants.ts, utils.ts, query-client.ts |
+| `hooks/` | 1 | use-task-poller.ts |
+
+### Backend (`storyengine/backend/`) — 24 files
+
+| Directory | Count | Purpose |
+|-----------|-------|---------|
+| `routes/` | 15 | 14 route modules + `__init__.py` |
+| Root | 9 | `main.py`, `models.py`, `database.py`, `auth.py`, `vault.py`, `supabase_adapter.py`, `status_map.py`, `pipeline_executor.py`, `claude_orchestrator.py` |
+
+### Migrations — 10 files
+
+`003` through `012` (001-002 presumably folded into `schema.sql`).
+
+### All 14 routers registered in `main.py`: YES
+
+| Router | Prefix | Registered |
+|--------|--------|------------|
+| dashboard | `/api` | Yes |
+| videos | `/api` | Yes |
+| assets | `/api` | Yes |
+| activity | `/api` | Yes |
+| review | `/api` | Yes |
+| pipeline | `/api` | Yes |
+| settings | `/api` | Yes |
+| autopilot | `/api` | Yes |
+| skills | `/api` | Yes |
+| agents | `/api` | Yes |
+| niche | `/api` | Yes |
+| channel_profile | `/api` | Yes |
+| projects | `/api` | Yes |
+| visual_styles | `/api` | Yes |


### PR DESCRIPTION
## Summary

This PR adds a detailed ground-truth audit document (`WIRING_STATUS.md`) that comprehensively catalogs the current state of frontend-to-backend integration across the entire StoryEngine application. The document serves as a reference for developers to understand which features are fully wired, partially implemented, stubbed, or broken.

## Key Changes

- **Pipeline Stage Matrix**: Documents wiring status for all 20 pipeline stages (Create Idea through Upload), tracking frontend buttons, API routes, execution logic, polling mechanisms, and test coverage
- **Page Wiring Status**: Audits all 17 application pages, categorizing each as WIRED, PARTIAL, STUB, or MOCK
- **Auth Status**: Details the Bearer token authentication mechanism, dev-mode backdoor behavior, and production JWT validation flow
- **Database Connections**: Maps all 14 actively-queried tables with read/write operations and identifies schema staleness issues
- **Test Coverage**: Confirms zero test files exist (0 backend tests, 0 frontend tests)
- **Import Graph**: Visualizes how `pipeline_executor.py` bridges StoryEngine backend to the `skills/video-pipeline/` module
- **Known Bugs**: Identifies 12 bugs across critical, moderate, and low severity:
  - **Critical**: `create_idea` missing `run_idea_bot` method (AttributeError), Upload route missing (404), Skills route ordering bug
  - **Moderate**: `reject_video` doesn't update status, Autopilot launch is stubbed, Storyboard approve is mocked, Review page Reject button is dead, Background task tracking is in-memory only
  - **Low**: Four mock pages, silent error handling patterns, legacy DDL-on-request pattern, exposed API keys
- **Files Inventory**: Catalogs 96 frontend files, 24 backend files, and 10 migration files with directory breakdown

## Notable Implementation Details

- The audit identifies that 13 of 14 pipeline runner methods are wired on `LightPipeline`, but `run_idea_bot` is conspicuously missing, causing the `/create` page to fail at runtime
- Documents that the dev-mode auth backdoor (`"dev-token"` → hardcoded user) is active whenever `ENV` is unset, defaulting to `"development"`
- Reveals that background task tracking is entirely in-memory with no persistence, causing task status to be lost on server restart
- Confirms all 14 route modules are properly registered in `main.py` despite individual endpoint issues
- Notes that `schema.sql` is stale and missing tables that exist only in migration 010

This audit provides a single source of truth for the current state of the codebase and serves as a roadmap for prioritizing fixes and completing partial implementations.

https://claude.ai/code/session_017tSnv7Xm1TSkkPusgpd3kn