### PR TITLE
Fix telegram bot dying mid-day: healthcheck now detects zombie sessions

### DIFF
--- a/rubric/scaffold/telegram-healthcheck.sh
+++ b/rubric/scaffold/telegram-healthcheck.sh
@@ -13,8 +13,9 @@ LOG_FILE="/tmp/storyengine-agents/telegram-channel.log"
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 SYSTEM_PROMPT_FILE="$PROJECT_ROOT/rubric/scaffold/telegram-system-prompt.md"
 MODEL="${TELEGRAM_MODEL:-haiku}"
-# Restart every 4 hours to prevent context window overflow
-MAX_AGE_SECONDS=14400
+# Restart every 2 hours to prevent context window overflow and idle timeouts
+# Was 4 hours (14400s) but Claude Code sessions go unresponsive before that
+MAX_AGE_SECONDS=7200
 AGE_FILE="/tmp/storyengine-agents/telegram-channel-started"
 
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -22,11 +23,57 @@ mkdir -p "$(dirname "$LOG_FILE")"
 # Source Telegram helper for notify_telegram()
 source "$PROJECT_ROOT/storyengine/agents/notify-telegram.sh" 2>/dev/null || true
 
-# Check if tmux session exists and has a running process
+# Check if tmux session exists
+session_exists() {
+  tmux has-session -t "$TMUX_SESSION" 2>/dev/null
+}
+
+# Check if Claude process is actually running inside the session
+# The tmux session can stay alive (via 'script' wrapper) even after Claude exits/hangs.
+# This is the root cause of the mid-day timeout: healthcheck saw tmux alive but Claude was dead.
+claude_process_alive() {
+  # Get the PID of the tmux pane's shell, then check if claude/node is a descendant
+  local pane_pid
+  pane_pid=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_pid}' 2>/dev/null | head -1)
+  [ -z "$pane_pid" ] && return 1
+
+  # Look for claude or node process in the process tree under the tmux pane
+  pgrep -P "$(pgrep -P "$pane_pid" -d,)" -a 2>/dev/null | grep -qE 'claude|node' && return 0
+  # Also check direct children (process tree varies by OS)
+  pstree -p "$pane_pid" 2>/dev/null | grep -qE 'claude|node' && return 0
+
+  return 1
+}
+
+# Check if the log file has been written to recently (stale = bot is dead/hung)
+log_is_fresh() {
+  [ ! -f "$LOG_FILE" ] && return 1
+  local last_mod now age
+  last_mod=$(stat -c %Y "$LOG_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  age=$((now - last_mod))
+  # If log hasn't been touched in 30 minutes, consider it stale
+  # (Telegram plugin polls regularly, so a healthy session writes to log)
+  [ "$age" -lt 1800 ]
+}
+
+# Full liveness check: tmux exists AND (claude process alive OR log is fresh)
 session_is_alive() {
-  if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+  if ! session_exists; then
+    echo "[$(date)] tmux session does not exist"
+    return 1
+  fi
+
+  if claude_process_alive; then
     return 0
   fi
+
+  if log_is_fresh; then
+    # Log is fresh, Claude might be between operations — give benefit of doubt
+    return 0
+  fi
+
+  echo "[$(date)] tmux session exists but Claude process is dead and log is stale"
   return 1
 }
 
@@ -51,12 +98,20 @@ start_session() {
 
 # ─── Check 1: Is session alive? ──────────────────────────────────────────────
 if ! session_is_alive; then
-  echo "[$(date)] Telegram channel is DOWN — restarting..."
+  # Determine if this is a zombie (tmux alive but Claude dead) vs fully dead
+  if session_exists; then
+    echo "[$(date)] Telegram channel is ZOMBIE (tmux alive, Claude dead) — recycling..."
+    RESTART_REASON="zombie session (Claude process died inside tmux)"
+  else
+    echo "[$(date)] Telegram channel is DOWN — restarting..."
+    RESTART_REASON="session not running"
+  fi
+
   start_session
 
-  if session_is_alive; then
-    echo "[$(date)] Telegram channel restarted successfully (model=$MODEL)"
-    notify_telegram "Telegram channel was down — auto-restarted at $(date +%H:%M)" 2>/dev/null || true
+  if session_exists; then
+    echo "[$(date)] Telegram channel restarted successfully (model=$MODEL, reason=$RESTART_REASON)"
+    notify_telegram "Telegram bot restarted: $RESTART_REASON ($(date +%H:%M))" 2>/dev/null || true
   else
     echo "[$(date)] FAILED to restart Telegram channel"
     notify_telegram "CRITICAL: Telegram channel failed to restart. Manual intervention needed." 2>/dev/null || true


### PR DESCRIPTION
The healthcheck only checked if the tmux session existed, not if Claude Code
was actually alive inside it. When Claude crashed/timed out, the 'script'
wrapper kept tmux alive as a zombie — so the bot appeared healthy but was dead.

Fix: three-layer liveness check (process tree + log freshness + tmux session).
Also reduced max age from 4h to 2h since sessions go unresponsive before 4h.

https://claude.ai/code/session_01VRMERmkJhRjjKHxT3sRFFe