### PR TITLE
Fix malformed settings.json blocking Telegram bot startup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,12 @@
     "Stop": [
       {
         "matcher": "",
-        "command": "bash agents/verify.sh 2>&1 || true"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agents/verify.sh 2>&1 || true"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Fix malformed Stop hook in `.claude/settings.json` — used `{command: "..."}` instead of `{hooks: [{type: "command", command: "..."}]}`
- This caused Claude Code to show an interactive error prompt on every startup, permanently blocking the Telegram bot from initializing

## Root Cause

The settings.json hook format was wrong. Claude Code showed a "Settings Error" prompt requiring manual input to continue — but since the bot runs inside `tmux`/`script` with no interactive input, it was stuck forever.

https://claude.ai/code/session_01VRMERmkJhRjjKHxT3sRFFe