### PR TITLE
fix(vps): auto-stash before git pull so VPS never gets stuck

### DIFF
--- a/rubric/scaffold/telegram-healthcheck.sh
+++ b/rubric/scaffold/telegram-healthcheck.sh
@@ -47,6 +47,19 @@ ensure_cron_exists() {
 }
 ensure_cron_exists
 
+# ─── Auto-pull latest code ──────────────────────────────────────────────────
+# The healthcheck runs every 10min even when everything else is broken.
+# Make it pull latest code so VPS fixes itself when we push changes.
+# Auto-stash prevents local edits from blocking pull permanently.
+auto_pull() {
+  cd "$PROJECT_ROOT" 2>/dev/null || return
+  if ! timeout 30 git pull origin main --ff-only 2>/dev/null; then
+    git stash --include-untracked 2>/dev/null || true
+    timeout 30 git pull origin main --ff-only 2>/dev/null || true
+  fi
+}
+auto_pull
+
 # ─── Crash backoff ──────────────────────────────────────────────────────────
 # If we've crashed N times in a row, wait before retrying (prevents tight restart loops
 # that burn CPU/logs and never succeed because the underlying issue isn't transient)

--- a/skills/video-pipeline/infra/cron_wrapper.sh
+++ b/skills/video-pipeline/infra/cron_wrapper.sh
@@ -146,8 +146,16 @@ cd "$REPO_DIR" || {
 
 # Pull latest code — non-fatal if it fails (stale code is better than no run)
 # Timeout prevents hangs from git prompts or network issues
+# If pull fails due to local changes, auto-stash and retry (this is the #1 cause
+# of the VPS running stale code — manual edits on VPS block git pull forever)
 if ! timeout 30 git pull origin main --ff-only >> "$LOG_FILE" 2>&1; then
-    echo "[$(date)] WARNING: git pull failed or timed out — running with existing code" >> "$LOG_FILE"
+    echo "[$(date)] WARNING: git pull failed — attempting auto-stash and retry" >> "$LOG_FILE"
+    git stash --include-untracked >> "$LOG_FILE" 2>&1 || true
+    if ! timeout 30 git pull origin main --ff-only >> "$LOG_FILE" 2>&1; then
+        echo "[$(date)] WARNING: git pull still failed after stash — running with existing code" >> "$LOG_FILE"
+    else
+        echo "[$(date)] git pull succeeded after auto-stash" >> "$LOG_FILE"
+    fi
 fi
 
 # ── Run the command ──────────────────────────────────────────────────

--- a/storyengine/agents/run-agent.sh
+++ b/storyengine/agents/run-agent.sh
@@ -96,6 +96,9 @@ CURRENT_BRANCH=$(git branch --show-current)
 if [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
   git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH"
 fi
+# Auto-stash local changes before pull (prevents VPS from getting stuck on stale code
+# when someone edits files directly — the #1 cause of "git pull failed" on the VPS)
+git stash --include-untracked 2>/dev/null || true
 git pull --rebase origin "$BRANCH" 2>/dev/null || true
 
 # ─── Completion Check ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The VPS is stuck on stale code because local file edits block `git pull --ff-only`. This is why fixes you push never land — and why the Telegram bot stays broken even after we fix it here.

## What this does

Adds `git stash --include-untracked` before every `git pull` in 3 places:

1. **`cron_wrapper.sh`** — pipeline cron jobs (runs every few hours)
2. **`run-agent.sh`** — agent launcher (runs every 4 hours)  
3. **`telegram-healthcheck.sh`** — now also pulls code on every run (every 10 min)

This means: push a fix to main → within 10 minutes the VPS pulls it automatically, even if someone edited files directly on the VPS.

## The chicken-and-egg problem

The VPS can't pull THIS fix because the old code doesn't auto-stash. After merging, you need ONE of these to break the cycle:

- **Option A**: If Telegram bot comes up briefly, tell it: `run git stash && git pull origin main`
- **Option B**: If you can SSH even briefly: `cd ~/projects/economy-fastforward && git stash && git pull origin main`
- **Option C**: Wait — if any cron job happens to succeed (clean working dir), it'll pull this fix and everything self-heals from that point

After the cycle is broken once, it never happens again.

https://claude.ai/code/session_017YboWGq3kdEkmJjfgB9FWf