### PR TITLE
feat(orchestrator): add product brain system for autonomous PRD generation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "bash agents/verify.sh 2>&1 || true"
+          },
+          {
+            "type": "command",
+            "command": "bash agents/refresh-product-brain.sh 2>&1 || true"
           }
         ]
       }

--- a/agents/TEAM.md
+++ b/agents/TEAM.md
@@ -25,10 +25,26 @@
 - Never combine "find the problem" with "fix the problem" in one task
 - Each task addresses exactly ONE concern
 
+### The "Done" Standard (read this before marking anything done)
+
+**Two levels — both required:**
+
+| Level | Who sets it | What it means |
+|-------|-------------|---------------|
+| `done` | Implementing agent self-reports | Code committed, acceptance criteria run locally |
+| `verified` | QA/Verifier independently confirms | Playwright clicked the UI, screenshots taken, state changes observed |
+
+**`done` ≠ `verified`.** A PRD is only complete when the final QA task reaches `verified`.
+
+**The "buttons work" rule:** For any frontend task, the implementing agent MUST verify that every interactive element (buttons, forms, dropdowns) triggers a visible state change before marking `done`. If you added a button, click it yourself before committing. If it does nothing: it's not done.
+
+**QA is not optional.** Every PRD ends with a mandatory qa-engineer task. It runs Playwright, takes screenshots, and writes a smoke test file. The PRD cannot advance until this task is `verified`.
+
 ### Quality Gates (enforced by hooks — agents cannot bypass)
 - TypeScript must compile: `npx tsc --noEmit`
 - Tests must pass: `npm test` / `pytest`
 - No lint errors: `npx eslint . --max-warnings 0`
+- Playwright smoke test passes: `npx playwright test tests/prd-N-smoke.spec.ts` (written by QA task)
 
 ### Git Rules
 - Every completed task gets its own commit with a descriptive message

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -55,6 +55,78 @@ The product brain is your substitute for the operator. It answers: "What would t
 
 ---
 
+## Superpowers Library — Invoke Before Generating PRDs
+
+Before calling `prd-generator.sh` for a new PRD, do two things:
+
+### Step A: Invoke the thinking-partner skill
+```
+Use the thinking-partner skill to think through what the product needs next.
+Don't just execute the roadmap — ask: "Is this the most valuable thing to build right now?"
+Challenge assumptions. Surface the non-obvious insight first.
+```
+
+The thinking-partner skill lives at `.claude/skills/thinking-partner/`. Invoke it via the Skill tool or read it directly for its prompting pattern.
+
+### Step B: Check if a superpowers plan applies
+The `docs/superpowers/` directory contains deep feature specifications written by the operator. These are authoritative design docs — when a plan exists for a feature area, **use it**. Don't invent from scratch.
+
+**Plans index (`docs/superpowers/plans/`):**
+
+| File | Topic | Use when PRD involves... |
+|------|-------|--------------------------|
+| `2026-03-18-autopilot-chunk1-foundation.md` | Autopilot state machine, scoring, cadence | Autopilot scheduling, candidate scoring, production cadence |
+| `2026-03-18-autopilot-chunk2-thumbnail-memory.md` | Thumbnail vision analysis, pattern memory | Thumbnail generation, visual memory, CTR-driven style selection |
+| `2026-03-18-autopilot-chunk3-ctr-learning.md` | CTR monitoring, learning extraction, memory writer | Learning loop, CTR tracking at 6h/24h/48h, LEARNINGS.md |
+| `2026-03-18-competitor-title-analyzer.md` | Competitor title formula extraction | Competitor intelligence, title pattern detection |
+| `2026-03-18-per-act-background-music.md` | Music selector, Remotion MusicBed | Background music per scene/act, audio layering |
+| `2026-03-20-curiosity-gap-phase1-competitor-analysis.md` | Competitor analysis, gap seeding | Title research, curiosity gap data collection |
+| `2026-03-20-curiosity-gap-phase2-generation.md` | Gap-based title + thumbnail generation | Curiosity-gap title writing, 5 gap structures |
+| `2026-03-20-curiosity-gap-phase2-integration.md` | Curiosity gap pipeline integration | Wiring gap titles into the pipeline |
+| `2026-03-20-curiosity-gap-phase3-learning.md` | Learning loop for gap structures | Which gap structures perform best |
+| `2026-03-23-module0-supabase-parity.md` | DB migration, Supabase parity | Database migrations, schema changes, Supabase alignment |
+| `2026-03-24-module1-design-dashboard-pipeline.md` | Dashboard UX, pipeline UI redesign | Dashboard, pipeline page, video list improvements |
+| `2026-03-24-module2-video-detail-create.md` | Video detail tabs, create flow | Video detail page, create video flow, 3-click creation |
+| `2026-03-24-module3-interactive-features.md` | Real-time collaboration, comments | SSE, live updates, multi-user features |
+| `2026-03-24-module4-autopilot-analytics.md` | Autopilot analytics dashboard | Analytics for autopilot performance, A/B testing |
+| `2026-03-24-module5-niche-discovery.md` | Niche discovery engine | Niche market analysis, topic clustering, audience profiling |
+
+**Specs index (`docs/superpowers/specs/`):**
+
+| File | Topic |
+|------|-------|
+| `2026-03-18-autopilot-brain-design.md` | Full autopilot brain architecture |
+| `2026-03-20-curiosity-gap-title-system.md` | Curiosity gap title system design |
+| `2026-03-23-storyengine-productization-design.md` | SaaS productization — pages, features, mobile-first UX |
+| `2026-03-24-module3-interactive-features-design.md` | Interactive features full spec |
+| `2026-03-24-module5-niche-discovery-design.md` | Niche discovery full spec |
+
+**How to use a plan when generating a PRD:**
+
+```bash
+# 1. Identify which plan applies to the next PRD topic
+# 2. Read the relevant plan
+cat docs/superpowers/plans/2026-03-24-module1-design-dashboard-pipeline.md
+
+# 3. Pass it to prd-generator.sh via the --plan flag (see prd-generator.sh docs)
+./agents/prd-generator.sh --plan docs/superpowers/plans/2026-03-24-module1-design-dashboard-pipeline.md
+
+# 4. The generator will include the plan as authoritative design context
+```
+
+**Domain-specific skills** — tell agents to use these when their task falls in the domain:
+
+| Domain | Skill | When to invoke |
+|--------|-------|----------------|
+| React components, hooks, state | `react-best-practices` | Any frontend component task |
+| Next.js pages, routes, RSC | `next-best-practices` | App router pages, data fetching |
+| Component architecture | `composition-patterns` | Building reusable/flexible components |
+| DB schema, queries, Postgres | `supabase-postgres-best-practices` | Migrations, queries, RLS |
+| UI testing, frontend verification | `webapp-testing` | QA tasks, Playwright tests |
+| UI review, design audit | `web-design-guidelines` | Visual review, accessibility |
+
+---
+
 ## Session End Protocol
 
 **Before finishing ANY session, refresh the product brain:**

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -1,9 +1,28 @@
 # Orchestrator Memory
 
+## Product Brain — Read First
+
+**Before anything else, read the product brain:**
+
+```bash
+cat agents/product-brain.md
+```
+
+This tells you what's actually built (don't re-spec it), which roadmap days are done, and what to build next. If it's missing or >24h stale, regenerate it first:
+
+```bash
+./agents/refresh-product-brain.sh
+```
+
+The product brain is your substitute for the operator. It answers: "What would the owner want built today?"
+
+---
+
 ## PRD Queue — Session Startup Protocol
 
-**Every session MUST start here.** Before touching any code:
+**Every session MUST run these steps (in order):**
 
+0. `cat agents/product-brain.md`       → Read product state, gap queue, and PRD guidelines
 1. `./agents/prd-loader.sh --status`   → See which PRD is active and what's left
 2. `./agents/prd-loader.sh --what-next` → See exact unblocked tasks to assign agents now
 3. `./agents/prd-loader.sh`            → Write prd.json from active PRD for swarm execution
@@ -26,11 +45,30 @@
 - **PRD 4 — Growth & Launch:** 🔵 ACTIVE (10/15 done) — remaining: T11, T12, T13, T14, T15
 
 **Key files:**
+- `agents/product-brain.md` — **LIVING product state** (what's built, gaps, priorities) — read first
+- `agents/refresh-product-brain.sh` — regenerates product-brain.md from live codebase
 - `agents/prd-queue.json` — machine-readable queue state (source of truth)
 - `agents/prd-loader.sh`  — queue manager (status / what-next / load / advance)
-- `agents/prd-generator.sh` — PRD inventor (reads roadmap, writes prd-N-*.md via Claude)
+- `agents/prd-generator.sh` — PRD inventor (reads product-brain + roadmap → writes prd-N-*.md)
 - `agents/prds/prd-N-*.md` — PRD documents (human-readable specs for each chunk of work)
 - `agents/prd.json`       — generated task file consumed by swarm/agents (gitignored)
+
+---
+
+## Session End Protocol
+
+**Before finishing ANY session, refresh the product brain:**
+
+```bash
+./agents/refresh-product-brain.sh
+```
+
+This ensures the next autonomous session starts with an accurate picture of what was built. Without this, the next session's PRD generation is blind to today's progress.
+
+Also run the normal end-of-session checklist:
+- `tasks/todo.md` — update with current progress and clear handoff
+- `tasks/lessons.md` — capture any corrections or new patterns
+- `tasks/decisions.md` — append any architectural choices made
 
 ---
 

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -28,15 +28,28 @@ The product brain is your substitute for the operator. It answers: "What would t
 3. `./agents/prd-loader.sh`            → Write prd.json from active PRD for swarm execution
 4. `./agents/prd-loader.sh --advance`  → When PRD is fully done, advance queue to next PRD
 
-**When the queue runs low (< 2 pending PRDs):**
-- `./agents/prd-generator.sh` — Auto-invents the next PRD from `tasks/roadmap.md` using Claude
-- `./agents/prd-generator.sh --preview` — See what the next PRD would cover without writing it
-- `prd-loader.sh` triggers this automatically when it detects low queue depth
+**Queue auto-health check (run after step 1 every session):**
+
+```bash
+PENDING=$(python3 -c "
+import json
+q = json.load(open('agents/prd-queue.json'))
+print(sum(1 for p in q.get('prds',[]) if p.get('status') == 'pending'))
+" 2>/dev/null || echo "0")
+
+if [ "$PENDING" -lt 2 ]; then
+  echo "Queue low ($PENDING pending PRDs) — generating next PRD before dispatching agents"
+  # See Superpowers Library below for --plan flag
+  ./agents/prd-generator.sh
+fi
+```
+
+This ensures agents always have upcoming work queued. `prd-watcher.sh` does this automatically when running as a daemon — for interactive sessions, run this check manually.
 
 **Product roadmap (source of truth for new PRDs):** `tasks/roadmap.md`
 - 18-day SaaS plan: Week 1 (payable) → Week 2 (core UX) → Week 3 (reliable) → Week 4 (launchable)
-- prd-generator.sh reads this + existing PRDs to invent the next logical chunk of work
-- It uses Claude to write a full PRD in the same style as prd-1 through prd-4
+- Next up: Week 3 (Days 11-14) — Job Queue, Per-tenant Storage, Error Monitoring, Security Hardening
+- prd-generator.sh reads product-brain.md (live state) + roadmap to invent next logical chunk
 
 **Current Queue Snapshot:**
 - **PRD 1 — UX Polish:** ✅ COMPLETE (10/10 tasks, 2026-04-08)

--- a/agents/prd-generator.sh
+++ b/agents/prd-generator.sh
@@ -108,6 +108,28 @@ print('\n'.join(lines))
 
 ROADMAP_CONTENT=$(cat "$ROADMAP_FILE")
 
+# ─── Load product brain (live codebase state) ─────────────────────────────────
+PRODUCT_BRAIN=""
+BRAIN_FILE="$AGENTS_DIR/product-brain.md"
+if [ -f "$BRAIN_FILE" ]; then
+  PRODUCT_BRAIN=$(cat "$BRAIN_FILE")
+  BRAIN_AGE_HOURS=$(python3 -c "
+import os, time
+mtime = os.path.getmtime('$BRAIN_FILE')
+age_h = (time.time() - mtime) / 3600
+print(f'{age_h:.0f}')
+" 2>/dev/null || echo "?")
+  echo "  Product brain loaded (${BRAIN_AGE_HOURS}h old): $BRAIN_FILE"
+  if [ "${BRAIN_AGE_HOURS}" != "?" ] && [ "${BRAIN_AGE_HOURS}" -gt 24 ] 2>/dev/null; then
+    echo "  WARNING: product-brain.md is >24h old. Consider running ./agents/refresh-product-brain.sh"
+  fi
+else
+  echo "  WARNING: agents/product-brain.md not found."
+  echo "  Run ./agents/refresh-product-brain.sh to generate it."
+  echo "  Falling back to roadmap-only PRD generation (less accurate)."
+fi
+echo ""
+
 # Also pull any existing PRD files for context on scope/style
 EXISTING_PRD_SAMPLE=""
 HIGHEST_PRD="$PRDS_DIR/prd-${MAX_ID}-*.md"
@@ -146,21 +168,10 @@ Your job: Write PRD ${NEXT_PRD_ID} for the autonomous agent team.
 
 ## What You Know About StoryEngine
 
-### The Product
-StoryEngine is a multi-tenant SaaS where creators log in, type a video topic, and the AI pipeline handles everything: research → script → voice → images → video clips → thumbnail → render. Users review stages and publish directly to YouTube.
+### Current Product State (AUTHORITATIVE — generated from live codebase)
+${PRODUCT_BRAIN:-"⚠️  product-brain.md not available. Use roadmap + existing PRDs as fallback."}
 
-**Stack:** Next.js 16 + React 19 + TypeScript + TailwindCSS 4 + Framer Motion | FastAPI + asyncpg + Supabase PostgreSQL
-
-**Design system (MANDATORY for all UI work):**
-- Background: var(--bg-void) (#0A0A0B), cards: glass-card class
-- Primary accent: var(--turquoise) (#00D4AA), secondary: var(--orange), gold: var(--gold)
-- Text: var(--text-primary), var(--text-secondary), var(--text-tertiary)
-- Red for errors: var(--red)
-- Font: font-display for headings
-- Existing components: GlassCard, ActionButton, StatusPill, Spinner, Modal, FilterSelect
-- Motion: Framer Motion with container/item stagger pattern
-
-### Product Roadmap (authoritative)
+### Product Roadmap (18-day plan — use product state above to check which days are done)
 ${ROADMAP_CONTENT}
 
 ### PRDs Already Written (DO NOT repeat this work)
@@ -189,16 +200,17 @@ ${FORCE_TITLE:+## Requested Title: $FORCE_TITLE}
 Write **PRD ${NEXT_PRD_ID}** as a complete markdown document.
 
 **Rules:**
-1. Pick the highest-priority UNADDRESSED items from the roadmap that logically follow what PRDs 1-${MAX_ID} already shipped
-2. Group related features into parallel execution lanes (backend-dev and frontend-dev can run simultaneously)
-3. 8-15 tasks total — enough for 1-2 days of agent work
-4. Every task must reference exact file paths in the StoryEngine repo (storyengine/backend/ or storyengine/frontend/src/)
-5. Backend tasks come before frontend tasks that depend on them
-6. QA/security tasks come last (after all implementation)
-7. Be SPECIFIC — not "add endpoint" but "add POST /api/endpoint to routes/X.py that..."
-8. The acceptance criteria must be verifiable (checkboxes that can be converted to shell commands)
-9. Do NOT include items already shipped in PRDs 1-${MAX_ID}
-10. Invent the right next step based on the roadmap — use your PM judgment
+1. Check the "Implementation Inventory" in the Current Product State first — DO NOT spec anything marked ✅ Done
+2. Check the "Current Priority Gap Queue" — work from Tier 2 downward (Tier 1 = active PRD, don't duplicate it)
+3. Pick the highest-priority UNADDRESSED items. Group related features into parallel lanes (backend + frontend can run simultaneously)
+4. 8-15 tasks total — enough for 1-2 days of agent work
+5. Every task must reference exact file paths in the StoryEngine repo (storyengine/backend/ or storyengine/frontend/src/)
+6. Backend tasks come before frontend tasks that depend on them
+7. QA/security tasks come last (after all implementation)
+8. Be SPECIFIC — not "add endpoint" but "add POST /api/endpoint to routes/X.py that does X, Y, Z"
+9. Acceptance criteria must be verifiable shell commands (curl, psql, tsc, grep, test -f)
+10. The "What NOT to spec" list in the product state is your guard rail — check it before every task
+11. Use the roadmap's tier analysis (Week 1 = payable, Week 2 = UX, Week 3 = reliable, Week 4 = launchable) to pick the right focus
 
 Write the complete PRD now. Output ONLY the markdown document, no preamble.
 PROMPT_EOF

--- a/agents/prd-generator.sh
+++ b/agents/prd-generator.sh
@@ -30,19 +30,23 @@ RUBRIC_URL="${RUBRIC_URL:-http://localhost:5050}"
 PREVIEW=false
 FORCE_PRD_ID=""
 FORCE_TITLE=""
+PLAN_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --preview)        PREVIEW=true; shift ;;
     --prd)            FORCE_PRD_ID="$2"; shift 2 ;;
     --title)          FORCE_TITLE="$2"; shift 2 ;;
+    --plan)           PLAN_FILE="$2"; shift 2 ;;
     --help|-h)
-      echo "Usage: $0 [--preview] [--prd N] [--title 'Title']"
+      echo "Usage: $0 [--preview] [--prd N] [--title 'Title'] [--plan PATH]"
       echo ""
       echo "  (no args)       Auto-detect next PRD number and invent it from roadmap"
       echo "  --preview       Show what the next PRD would cover (dry run, no write)"
       echo "  --prd N         Force the PRD ID number (e.g., --prd 5)"
       echo "  --title TEXT    Override the PRD title"
+      echo "  --plan PATH     Path to a superpowers plan/spec to use as authoritative design context"
+      echo "                  e.g., --plan docs/superpowers/plans/2026-03-24-module1-design-dashboard-pipeline.md"
       exit 0 ;;
     *)                echo "Unknown arg: $1"; exit 1 ;;
   esac
@@ -130,6 +134,39 @@ else
 fi
 echo ""
 
+# ─── Load superpowers plan (operator's authoritative design doc) ──────────────
+SUPERPOWERS_PLAN_CONTENT=""
+SUPERPOWERS_PLAN_NAME=""
+SUPERPOWERS_DIR="$PROJECT_ROOT/docs/superpowers"
+
+if [ -n "$PLAN_FILE" ]; then
+  # Explicit plan passed via --plan flag
+  if [ -f "$PLAN_FILE" ]; then
+    SUPERPOWERS_PLAN_CONTENT=$(cat "$PLAN_FILE")
+    SUPERPOWERS_PLAN_NAME=$(basename "$PLAN_FILE")
+    echo "  Superpowers plan loaded: $PLAN_FILE"
+  elif [ -f "$PROJECT_ROOT/$PLAN_FILE" ]; then
+    SUPERPOWERS_PLAN_CONTENT=$(cat "$PROJECT_ROOT/$PLAN_FILE")
+    SUPERPOWERS_PLAN_NAME=$(basename "$PLAN_FILE")
+    echo "  Superpowers plan loaded: $PROJECT_ROOT/$PLAN_FILE"
+  else
+    echo "  WARNING: --plan file not found: $PLAN_FILE"
+  fi
+fi
+
+# Build index of all available plans for Claude to reference
+SUPERPOWERS_INDEX=""
+if [ -d "$SUPERPOWERS_DIR" ]; then
+  SUPERPOWERS_INDEX=$(echo "Available superpowers plans (operator-authored design docs):" && \
+    echo "" && \
+    echo "Plans:" && \
+    ls "$SUPERPOWERS_DIR/plans/" 2>/dev/null | grep '\.md$' | sed 's/^/  - docs\/superpowers\/plans\//' && \
+    echo "" && \
+    echo "Specs:" && \
+    ls "$SUPERPOWERS_DIR/specs/" 2>/dev/null | grep '\.md$' | sed 's/^/  - docs\/superpowers\/specs\//')
+fi
+echo ""
+
 # Also pull any existing PRD files for context on scope/style
 EXISTING_PRD_SAMPLE=""
 HIGHEST_PRD="$PRDS_DIR/prd-${MAX_ID}-*.md"
@@ -171,6 +208,17 @@ Your job: Write PRD ${NEXT_PRD_ID} for the autonomous agent team.
 ### Current Product State (AUTHORITATIVE — generated from live codebase)
 ${PRODUCT_BRAIN:-"⚠️  product-brain.md not available. Use roadmap + existing PRDs as fallback."}
 
+### Operator's Design Document (AUTHORITATIVE — use this if provided)
+${SUPERPOWERS_PLAN_CONTENT:+"**Active plan: ${SUPERPOWERS_PLAN_NAME}**
+
+${SUPERPOWERS_PLAN_CONTENT}
+
+---"}
+${SUPERPOWERS_PLAN_CONTENT:-"No specific design doc provided. Invent from product state + roadmap."}
+
+### Available Superpowers Library (operator-authored specs — reference these by name in your PRD)
+${SUPERPOWERS_INDEX:-"(docs/superpowers/ directory not found)"}
+
 ### Product Roadmap (18-day plan — use product state above to check which days are done)
 ${ROADMAP_CONTENT}
 
@@ -211,6 +259,9 @@ Write **PRD ${NEXT_PRD_ID}** as a complete markdown document.
 9. Acceptance criteria must be verifiable shell commands (curl, psql, tsc, grep, test -f)
 10. The "What NOT to spec" list in the product state is your guard rail — check it before every task
 11. Use the roadmap's tier analysis (Week 1 = payable, Week 2 = UX, Week 3 = reliable, Week 4 = launchable) to pick the right focus
+12. If an operator design doc was provided (see "Operator's Design Document" above), follow its architecture decisions exactly — do not deviate from the specified approach
+13. If NO design doc was provided but a relevant one exists in the Superpowers Library, call it out at the top of your PRD: "NOTE: docs/superpowers/plans/FILENAME.md contains design context for this feature — orchestrator should pass it via --plan flag"
+14. Include a "Skills" section at the end of each task listing which .claude/skills/ the implementing agent should invoke (react-best-practices for frontend, supabase-postgres-best-practices for DB, webapp-testing for QA, next-best-practices for App Router pages)
 
 Write the complete PRD now. Output ONLY the markdown document, no preamble.
 PROMPT_EOF

--- a/agents/prd-generator.sh
+++ b/agents/prd-generator.sh
@@ -241,6 +241,30 @@ Each task:
 - Addresses ONE concern (no "build X AND wire Y" — those are two tasks)
 - Is sized at 15-45 minutes of agent effort
 
+**ACCEPTANCE CRITERIA RULES — READ CAREFULLY:**
+
+For backend tasks, criteria must verify BEHAVIOR not just file existence:
+- ✅ GOOD: `curl -s http://localhost:8001/api/billing/plan -H 'Authorization: Bearer ...' | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'plan' in d and d['plan'] in ('starter','creator','studio'), 'missing or invalid plan field'"`
+- ✅ GOOD: `curl -s -X POST http://localhost:8001/api/videos -H ... -d '{"topic":"test"}' | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'id' in d, 'no id in response'"`
+- ❌ BAD: `test -f storyengine/backend/routes/billing.py` (file existing ≠ working)
+- ❌ BAD: `curl ... | grep -q 200` (HTTP 200 ≠ correct data)
+
+For frontend tasks, criteria MUST include at least one behavioral Playwright test:
+- ✅ GOOD: `cd storyengine/frontend && npx playwright test --grep "upgrade button triggers Stripe checkout"`
+- ✅ GOOD: `cd storyengine/frontend && npx playwright test --grep "submit form shows success toast"`
+- ❌ BAD: `test -f storyengine/frontend/src/app/billing/page.tsx` (file ≠ buttons work)
+- ❌ BAD: `cd storyengine/frontend && npx tsc --noEmit` alone (types passing ≠ UI working)
+
+Every PRD MUST end with a mandatory QA task (role: qa-engineer) as the final task:
+- It depends on ALL other tasks
+- It uses the webapp-testing skill (Playwright)
+- It does a full user flow walkthrough: navigate → interact → verify state changes
+- It takes screenshots as evidence
+- Its acceptance criteria: `cd storyengine/frontend && npx playwright test tests/prd-N-smoke.spec.ts`
+  (the QA agent writes this test file as part of the task)
+
+The QA task is the GATE. A PRD is not complete until the QA task is verified.
+
 ${FORCE_TITLE:+## Requested Title: $FORCE_TITLE}
 
 ## Your Task
@@ -256,7 +280,7 @@ Write **PRD ${NEXT_PRD_ID}** as a complete markdown document.
 6. Backend tasks come before frontend tasks that depend on them
 7. QA/security tasks come last (after all implementation)
 8. Be SPECIFIC — not "add endpoint" but "add POST /api/endpoint to routes/X.py that does X, Y, Z"
-9. Acceptance criteria must be verifiable shell commands (curl, psql, tsc, grep, test -f)
+9. Acceptance criteria must test BEHAVIOR: response shape (not just 200), Playwright click-and-verify (not just page load), DB record contents (not just column existence). File existence tests (`test -f`) are forbidden as the ONLY criterion for a task — always pair with a behavior test.
 10. The "What NOT to spec" list in the product state is your guard rail — check it before every task
 11. Use the roadmap's tier analysis (Week 1 = payable, Week 2 = UX, Week 3 = reliable, Week 4 = launchable) to pick the right focus
 12. If an operator design doc was provided (see "Operator's Design Document" above), follow its architecture decisions exactly — do not deviate from the specified approach

--- a/agents/product-brain.md
+++ b/agents/product-brain.md
@@ -1,0 +1,225 @@
+# StoryEngine Product Brain
+
+_Last refreshed: 2026-04-09 (handcrafted from live codebase audit)_
+_Next refresh: run `./agents/refresh-product-brain.sh` after any session_
+
+---
+
+## Product Identity
+
+**What it is:** StoryEngine — "topic in, video out." Multi-tenant SaaS where creators type a topic and the AI pipeline handles everything: research → script → voice → custom images → video clips → thumbnail → render → YouTube upload.
+
+**The moat:** The learning loop. After 10 videos, the AI knows the user's audience. CTR improves automatically. No competitor has this.
+
+**Pricing tiers:**
+| Tier | Price | Videos/mo | Key features |
+|------|-------|-----------|--------------|
+| Starter | $25/mo | 4 | 1 visual style, standard render |
+| Creator | $40/mo | 15 | 3 styles, autopilot, full learning loop |
+| Studio | $75/mo | 50 | All styles, API access, voice clone, 3 seats |
+
+**UX principles:** Action-first dashboard, 3-click video creation, visible pipeline progress, AI insights surface, empty states sell, errors are helpful, mobile-aware.
+
+**Stack:** Next.js 16 + React 19 + TypeScript + TailwindCSS 4 + Framer Motion | FastAPI + asyncpg + Supabase PostgreSQL
+**Design tokens:** `--turquoise` (#00D4AA), `--gold`, `--orange`, `--bg-void` (#0A0A0B), `GlassCard`, `ActionButton`, `StatusPill`, `Spinner`, `Modal`
+
+---
+
+## Implementation Inventory
+
+### Auth & Access
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Email/password auth (PBKDF2-SHA256) | ✅ Done | `routes/settings.py`, `routes/google_auth.py` |
+| Google OAuth | ✅ Done | `routes/google_auth.py`, `/login` page |
+| JWT 30-day sessions | ✅ Done | auth middleware in `main.py` |
+| AuthenticatedShell route protection | ✅ Done | `frontend/src/components/` |
+| dev-token bypass (disabled in prod) | ✅ Done | env-gated |
+| Onboarding wizard (3-step: channel → keys → done) | ✅ Done | `frontend/src/app/onboarding/` |
+| Password reset flow (token → email → page) | ✅ Done | `password_reset_tokens` table, `/forgot-password`, `/reset-password` |
+| Multi-tenant isolation (tenant_id scoping) | ✅ Done | `tenants` + `memberships` tables, RLS |
+
+### Billing & Plans
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Stripe checkout + webhooks + portal | ✅ Done | `routes/billing.py` |
+| `/billing` page (plan display, usage bars, upgrade CTA) | ✅ Done | `frontend/src/app/billing/` |
+| `/pricing` public page (3 tiers, feature grid, CTA) | ✅ Done | `frontend/src/app/pricing/` |
+| Plan enforcement middleware (`check_plan_limits`) | ✅ Done | `tenant_usage` table, usage hooks |
+| Free trial logic (14-day Creator trial on signup) | ✅ Done | `accounts` table, trial countdown |
+| Trial countdown badge + banner | ✅ Done | frontend components |
+| Transactional email (welcome, reset, trial warning) | ✅ Done | `email_service.py`, `email_tasks.py` |
+| Billing receipt email on checkout | ✅ Done | wired in `routes/billing.py` |
+
+### Core Pipeline & UI
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Full video pipeline (research→render→upload) | ✅ Done | 13 stages, all with `run.py` entry points |
+| Pipeline dashboard (all stages, status tabs) | ✅ Done | `frontend/src/app/pipeline/` |
+| Video detail page (all production tabs) | ✅ Done | `frontend/src/components/production/` |
+| Pipeline progress UX (SSE real-time stage tracking) | ✅ Done | `/api/activity/stream` SSE, `stage_transitions` table |
+| Script review + approval | ✅ Done | `routes/review.py`, `/review` page |
+| Render tab + `RenderTab.tsx` | ✅ Done | component exists |
+| System prompt editors (per pipeline stage) | ✅ Done | `routes/system_prompts.py`, `/system-prompts` |
+| Storyboard viewer | ✅ Done | `frontend/src/app/storyboard/` |
+| Visuals page | ✅ Done | `frontend/src/app/visuals/` |
+
+### Discovery & Competitors
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Competitors page (pagination, filters, scrape progress) | ✅ Done | `frontend/src/app/competitors/`, `routes/` |
+| Discovery page | ✅ Done | `frontend/src/app/discovery/`, `routes/discovery.py` |
+| Autopilot page + controls | ✅ Done | `frontend/src/app/autopilot/`, `routes/autopilot.py` |
+| Calendar page | ✅ Done | `frontend/src/app/calendar/` |
+
+### Analytics & Learning
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Analytics page (overview, CTR timeline, framework perf) | ✅ Done | `frontend/src/app/analytics/`, `routes/analytics.py` |
+| Learnings page (pattern cards, extract/analyze actions) | ✅ Done | `frontend/src/app/learnings/`, `routes/learning_extraction.py` |
+| Learnings insights redesign (hero stats, recommendations, topic perf) | 🔵 PRD 4 T1 | `frontend/src/app/learnings/page.tsx` |
+| Analytics 2.0 (topic heatmap, competitor benchmark) | 🔵 PRD 4 T2 | `routes/analytics.py` + analytics page |
+| Video preview player (in-app, RenderTab) | 🔵 PRD 4 T3 | `components/production/RenderTab.tsx` |
+
+### Marketing & Legal
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Landing page (hero, features, pricing, CTA) | ✅ Done | `frontend/src/app/page.tsx` |
+| `/terms` and `/privacy` legal pages | ✅ Done | `frontend/src/app/terms/`, `privacy/` |
+| `/demo` page | ✅ Done | `frontend/src/app/demo/` |
+| `/docs` page | ✅ Done | `frontend/src/app/docs/` |
+
+### Infrastructure (Gaps — Week 3 of roadmap)
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Job Queue (Redis + arq/dramatiq, persistent pipeline jobs) | ❌ Missing | No Redis setup. Pipeline uses in-process asyncio. Server restart = lost jobs. |
+| Per-tenant storage (Supabase Storage, signed URLs) | ❌ Missing | Assets use Kie.ai URLs (expire) and Google Drive (not isolated). |
+| Error monitoring (Sentry, backend + frontend) | ❌ Missing | Console only. No structured error tracking. |
+| Security hardening (CORS lockdown, SQL audit, CSRF) | ❌ Missing | SEC-1 through SEC-6 open in todo.md |
+| Rate limiting per plan (concurrent job limits) | ❌ Missing | No per-tenant API rate limits |
+| Storyboard extraction V2 (Supabase rewrite) | ❌ Blocked | T27-003: `extraction.py` not wired into pipeline for Supabase videos |
+| Permanent asset storage (all image gen steps) | ❌ Missing | T27-008: Kie.ai URLs expire |
+
+### Polish & Launch (Week 4 of roadmap)
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| Getting started guide (help docs, FAQ) | 🔵 PRD 4 (T9 pending) | `/docs` page exists but needs content |
+| Brand kit (logo, accent color, intro/outro per channel) | 📋 Planned | Week 4 Day 10 |
+| Load testing (k6), backup strategy | 📋 Planned | Week 4 Day 18 |
+| Webhook API (Zapier, Make.com) | 📋 Planned | Tier 4 |
+| GDPR / data export | 📋 Planned | Tier 4 |
+
+---
+
+## Roadmap Progress (18-Day Plan)
+
+| Day | Date | Focus | Status |
+|-----|------|-------|--------|
+| 1 | Apr 7 | Public pricing + plan enforcement | ✅ Done |
+| 2 | Apr 8 | Trial + password reset + email + dev-token | ✅ Done |
+| 3 | Apr 9 | Create video simplification | 🔵 In progress (PRD 4 T4-T7) |
+| 4 | Apr 10 | Empty states + error handling | ✅ Done (PRD 1) |
+| 5 | Apr 11 | Pipeline progress UX | ✅ Done (PRD 2) |
+| 6 | Apr 14 | Landing page | ✅ Done |
+| 7 | Apr 15 | Dashboard redesign | 📋 Pending |
+| 8 | Apr 16 | Learning insights dashboard | 🔵 In progress (PRD 4 T1) |
+| 9 | Apr 17 | Analytics 2.0 | 🔵 In progress (PRD 4 T2) |
+| 10 | Apr 18 | Settings completion + brand kit | 📋 Pending |
+| 11 | Apr 21 | Job queue (Part 1) | ❌ Not started |
+| 12 | Apr 22 | Job queue (Part 2) + rate limiting | ❌ Not started |
+| 13 | Apr 23 | Per-tenant storage | ❌ Not started |
+| 14 | Apr 24 | Error monitoring + logging | ❌ Not started |
+| 15 | Apr 25 | Security hardening | ❌ Not started |
+| 16 | Apr 28 | Video preview + UI polish | 🔵 In progress (PRD 4 T3) |
+| 17 | Apr 29 | Documentation + demo | 🔵 In progress (PRD 4 T9) |
+| 18 | Apr 30 | Beta launch prep | 📋 Pending |
+
+---
+
+## Current Priority Gap Queue
+
+### Tier 1 — Active (PRD 4 remaining tasks T11-T15)
+PRD 4 is the active PRD. Complete these before generating PRD 5.
+
+### Tier 2 — Next PRD (Week 3: Infrastructure)
+1. **Job Queue** — Redis + arq. Pipeline stages as persistent jobs. Retry, dead letter. Server restart kills jobs today.
+2. **Per-tenant Storage** — Supabase Storage for SaaS. Kie.ai URLs expire and aren't tenant-isolated.
+3. **Error Monitoring** — Sentry (backend + frontend). No visibility into production errors.
+4. **Security Hardening** — SEC-1 (dev-token in dev), SEC-4 (hardcoded CORS IP), SEC-5 (f-string SQL), rate limiting on auth.
+
+### Tier 3 — Week 4: Polish & Launch
+5. **Dashboard redesign** — Action-first: active video cards, pending approvals, quick-start CTA, usage meter.
+6. **Brand kit** — Logo, accent color, intro/outro, watermark per channel. Persist to render.
+7. **Settings completion** — API key validation feedback, integration status indicators.
+8. **Beta launch prep** — Load test (k6), ToS/Privacy complete, invite 10 beta creators.
+
+### Tier 4 — Post-Beta
+9. Webhook API (Zapier, Make.com)
+10. GDPR / data export
+11. Team collaboration (invite flow, role enforcement — schema supports it)
+12. Voice clone per channel
+
+---
+
+## Live Codebase Snapshot
+
+**Frontend pages (26):** activity, analytics, autopilot, billing, calendar, competitors, dashboard, demo, discovery, docs, forgot-password, learnings, login, onboarding, pipeline, pricing, privacy, profile, render, reset-password, review, settings, storyboard, system-prompts, terms, visuals + landing (page.tsx)
+
+**Backend route files (24):** activity, analytics, assets, autopilot, billing, channel_profile, dashboard, demo, discovery, google_auth, learning_extraction, niche, pipeline, preferences, profile, projects, review, settings, skills, system_prompts, videos, visual_styles, youtube_sync, agents
+
+**DB tables (22):** tenants, users, memberships, videos, scripts, assets, competitor_channels, competitor_videos, learnings, title_insights, title_tests, autopilot_config, discovery_ideas, channel_profiles, accounts, projects, user_preferences, tenant_prompt_defaults, stage_transitions, bot_activity, tenant_usage, password_reset_tokens
+
+---
+
+## PRD Writing Guidelines for This Product
+
+### Task Structure
+Each task: single role (backend-dev | frontend-dev | qa-engineer | security-auditor), 15-45 min effort, ONE concern. 8-15 tasks per PRD.
+
+### File Conventions
+- Backend: `storyengine/backend/routes/<name>.py` — register in `storyengine/backend/main.py`
+- Frontend pages: `storyengine/frontend/src/app/<page>/page.tsx`
+- Frontend components: `storyengine/frontend/src/components/<category>/<Name>.tsx`
+- API layer: `storyengine/frontend/src/lib/api.ts`
+- Types: `storyengine/frontend/src/lib/types.ts`
+- DB migrations: `storyengine/backend/migrations/<NNN>_<name>.sql` + update `storyengine/schema.sql`
+- Pydantic models: `storyengine/backend/models.py`
+
+### Acceptance Criteria Patterns
+```bash
+# API endpoint exists
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8001/api/endpoint | grep -q 200
+
+# DB column exists
+psql "$DATABASE_URL" -c "SELECT column_name FROM information_schema.columns WHERE table_name='videos'" | grep -q new_column
+
+# TypeScript compiles
+cd storyengine/frontend && npx tsc --noEmit
+
+# File exists
+test -f storyengine/backend/routes/new_route.py
+
+# Router registered in main.py
+grep -q "new_route" storyengine/backend/main.py
+```
+
+### Wiring Checklist (every feature must pass)
+- DB column exists (migrated, not just in schema.sql)
+- Route registered in `main.py`
+- Pydantic model matches route response
+- Frontend fetchApi calls correct endpoint path
+- TypeScript types match backend response fields
+- Component wired to real API data (not mock)
+- Loading + error + empty states handled
+- `npx tsc --noEmit` passes
+
+### Design System (mandatory for all UI tasks)
+- Dark background: `var(--bg-void)` (#0A0A0B), cards: `glass-card` class
+- Accents: `var(--turquoise)` (#00D4AA), `var(--gold)`, `var(--orange)`, `var(--red)` for errors
+- Text: `var(--text-primary)`, `var(--text-secondary)`, `var(--text-tertiary)`
+- Font: `font-display` for headings
+- Components: `GlassCard`, `ActionButton`, `StatusPill`, `Spinner`, `Modal`, `FilterSelect`, `VerdictBadge`
+- Motion: Framer Motion with container/item stagger pattern
+
+### What NOT to Spec (already built — do not duplicate)
+Auth, billing UI, Stripe, plan enforcement, trial logic, password reset, email service, landing page, pricing page, legal pages, pipeline core, SSE progress tracking, toast system, error boundaries, empty states, onboarding wizard, competitors page, discovery, analytics baseline, learnings baseline.

--- a/agents/refresh-product-brain.sh
+++ b/agents/refresh-product-brain.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# refresh-product-brain.sh — Regenerates agents/product-brain.md from live codebase state
+#
+# Reads the actual codebase (pages, routes, DB tables), current PRD queue, latest handoff,
+# and roadmap, then calls Claude to synthesize a fresh product-brain.md.
+#
+# Usage:
+#   ./agents/refresh-product-brain.sh             # Regenerate product-brain.md
+#   ./agents/refresh-product-brain.sh --dry-run   # Preview prompt without writing
+#
+# Called automatically by the Stop hook in .claude/settings.json.
+# Run manually when starting a new session on a stale brain (>24h old).
+
+set -euo pipefail
+
+AGENTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$AGENTS_DIR/.." && pwd)"
+BRAIN_FILE="$AGENTS_DIR/product-brain.md"
+QUEUE_FILE="$AGENTS_DIR/prd-queue.json"
+ROADMAP_FILE="$PROJECT_ROOT/tasks/roadmap.md"
+TODO_FILE="$PROJECT_ROOT/tasks/todo.md"
+SCHEMA_FILE="$PROJECT_ROOT/storyengine/schema.sql"
+FRONTEND_APP="$PROJECT_ROOT/storyengine/frontend/src/app"
+BACKEND_ROUTES="$PROJECT_ROOT/storyengine/backend/routes"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || echo "$HOME/.npm-global/bin/claude")}"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[ -f "$QUEUE_FILE" ] || die "prd-queue.json not found"
+[ -f "$ROADMAP_FILE" ] || die "roadmap.md not found"
+
+echo "=== Refreshing Product Brain ==="
+echo ""
+
+# ─── 1. Introspect live codebase ─────────────────────────────────────────────
+
+FRONTEND_PAGES=$(ls "$FRONTEND_APP" 2>/dev/null \
+  | grep -v '\.' \
+  | grep -v 'layout\|providers\|global\|globals\|error\|not-found' \
+  | sort | tr '\n' ', ' | sed 's/,$//')
+
+BACKEND_ROUTE_FILES=$(ls "$BACKEND_ROUTES" 2>/dev/null \
+  | grep '\.py$' | grep -v '__init__' \
+  | sed 's/\.py$//' | sort | tr '\n' ', ' | sed 's/,$//')
+
+DB_TABLES=$(grep -E "^CREATE TABLE" "$SCHEMA_FILE" 2>/dev/null \
+  | sed 's/CREATE TABLE IF NOT EXISTS //' | sed 's/CREATE TABLE //' \
+  | sed 's/ (.*//' | sort | tr '\n' ', ' | sed 's/,$//' || echo "schema.sql not found")
+
+echo "  Frontend pages: $(echo "$FRONTEND_PAGES" | tr ',' '\n' | wc -l | tr -d ' ') found"
+echo "  Backend routes: $(echo "$BACKEND_ROUTE_FILES" | tr ',' '\n' | wc -l | tr -d ' ') found"
+echo "  DB tables: $(echo "$DB_TABLES" | tr ',' '\n' | wc -l | tr -d ' ') found"
+echo ""
+
+# ─── 2. Read state files ──────────────────────────────────────────────────────
+
+PRD_QUEUE_STATE=$(python3 -c "
+import json
+q = json.load(open('$QUEUE_FILE'))
+prds = q.get('prds', [])
+lines = []
+for p in prds:
+    tasks = p.get('tasks', [])
+    done = sum(1 for t in tasks if t.get('status') in ('done', 'verified'))
+    total = len(tasks)
+    status = p.get('status', '?')
+    lines.append(f\"PRD {p['id']}: {p['title']} [{status}] — {done}/{total} tasks done\")
+    if status == 'active':
+        pending = [t for t in tasks if t.get('status') == 'pending']
+        if pending:
+            lines.append(f\"  Remaining: {', '.join(t.get('id','?') for t in pending[:10])}\")
+print('\n'.join(lines))
+" 2>/dev/null || cat "$QUEUE_FILE")
+
+TODO_CONTENT=$(cat "$TODO_FILE" 2>/dev/null | head -80 || echo "todo.md not found")
+ROADMAP_CONTENT=$(cat "$ROADMAP_FILE" 2>/dev/null || echo "roadmap.md not found")
+
+# Check staleness
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M')
+LAST_REFRESH="unknown"
+if [ -f "$BRAIN_FILE" ]; then
+  LAST_REFRESH=$(head -3 "$BRAIN_FILE" | grep "Last refreshed" | sed 's/.*Last refreshed: //' | sed 's/ (.*//' || echo "unknown")
+  echo "  Current brain: $LAST_REFRESH"
+fi
+echo "  Regenerating at: $TIMESTAMP"
+echo ""
+
+# ─── 3. Build Claude prompt ───────────────────────────────────────────────────
+
+PROMPT_FILE=$(mktemp /tmp/brain-refresh-XXXXXX.txt)
+
+cat > "$PROMPT_FILE" << PROMPT_EOF
+You are regenerating product-brain.md — the single source of truth for an autonomous agent team building StoryEngine, an AI video SaaS.
+
+Your output will be read by the orchestrator agent at the start of every session. It tells the orchestrator what's been built, what's missing, and what to build next. Keep it accurate, compact, and actionable.
+
+## Live Codebase State (source of truth)
+
+Frontend pages detected: ${FRONTEND_PAGES}
+Backend route files detected: ${BACKEND_ROUTE_FILES}
+DB tables detected: ${DB_TABLES}
+
+## PRD Queue State
+${PRD_QUEUE_STATE}
+
+## Latest Handoff (tasks/todo.md)
+${TODO_CONTENT}
+
+## Product Roadmap (tasks/roadmap.md)
+${ROADMAP_CONTENT}
+
+---
+
+## Instructions
+
+Generate a complete product-brain.md document. The document MUST have these 5 sections, in this order:
+
+### Section 1: Product Identity
+- 1 paragraph: what StoryEngine is, who it's for, the moat (learning loop)
+- Pricing table: Starter/Creator/Studio with prices and key differentiators
+- UX principles (action-first, 3-click creation, etc.)
+- Stack line + design tokens (--turquoise, --gold, --bg-void, GlassCard, etc.)
+
+### Section 2: Implementation Inventory
+A table grouped by category. Each row: Feature | Status | Evidence (file path, 1 line max).
+Status icons: ✅ Done | 🔵 Active (in current PRD) | ❌ Missing (on roadmap, not built) | 📋 Planned (post-launch)
+
+Categories: Auth & Access, Billing & Plans, Core Pipeline & UI, Discovery & Competitors, Analytics & Learning, Marketing & Legal, Infrastructure (gaps), Polish & Launch
+
+**Rules for this section:**
+- ✅ Done rows: 1 line max, just the file path evidence
+- ❌ Missing rows: 1 line explanation of WHY it matters
+- Total rows: 30-45 features. Do not pad with trivia.
+
+### Section 3: Roadmap Progress
+The 18-day plan from roadmap.md as a compact table: Day | Date | Focus | Status (✅ Done / 🔵 In Progress / ❌ Not Started / 📋 Pending)
+
+### Section 4: Current Priority Gap Queue
+Ordered list of what to build next. Group by tier:
+- Tier 1: Active PRD tasks remaining (complete these first)
+- Tier 2: Next PRD scope (highest impact unbuilt items)
+- Tier 3: Week 4 polish
+- Tier 4: Post-beta
+
+For Tier 2, be SPECIFIC: "Job Queue — Redis + arq, pipeline stages as persistent jobs, server restart = lost jobs today"
+
+### Section 5: PRD Writing Guidelines
+- Task structure (role, sizing, one concern per task)
+- File conventions (backend/frontend/api/types/migrations paths)
+- Acceptance criteria patterns (curl, psql, tsc, grep, test -f)
+- Wiring checklist (8 checkboxes)
+- Design system (mandatory for UI tasks)
+- What NOT to spec (already built — 1-line list to avoid duplicates)
+
+---
+
+## Output Rules
+
+1. Start with: "# StoryEngine Product Brain"
+2. Second line: "_Last refreshed: ${TIMESTAMP} (auto-generated from live codebase)_"
+3. Use compact tables — no redundant prose
+4. Total document: 200-350 lines. Do NOT exceed 400 lines.
+5. The "What NOT to spec" list at the end is critical — list every completed feature so the orchestrator doesn't re-build it
+6. Output ONLY the markdown document, no preamble or explanation
+
+PROMPT_EOF
+
+if [ "$DRY_RUN" = true ]; then
+  echo "=== DRY RUN: Prompt preview ==="
+  cat "$PROMPT_FILE"
+  rm -f "$PROMPT_FILE"
+  exit 0
+fi
+
+# ─── 4. Call Claude to generate ───────────────────────────────────────────────
+
+echo "Calling Claude (sonnet) to synthesize product brain..."
+echo "(Takes 20-40 seconds)"
+echo ""
+
+TEMP_OUTPUT=$(mktemp /tmp/brain-output-XXXXXX.md)
+
+set +e
+"$CLAUDE_BIN" -p --model sonnet --dangerously-skip-permissions < "$PROMPT_FILE" > "$TEMP_OUTPUT" 2>/dev/null
+GEN_EXIT=$?
+set -e
+
+rm -f "$PROMPT_FILE"
+
+if [ $GEN_EXIT -ne 0 ] || [ ! -s "$TEMP_OUTPUT" ]; then
+  echo "ERROR: Claude failed to generate product brain (exit $GEN_EXIT)."
+  echo "Keeping existing product-brain.md unchanged."
+  rm -f "$TEMP_OUTPUT"
+  exit 1
+fi
+
+# Validate output looks like a product brain (not an error message)
+if ! head -5 "$TEMP_OUTPUT" | grep -q "StoryEngine"; then
+  echo "ERROR: Output doesn't look like a valid product brain. Keeping existing."
+  rm -f "$TEMP_OUTPUT"
+  exit 1
+fi
+
+mv "$TEMP_OUTPUT" "$BRAIN_FILE"
+
+LINE_COUNT=$(wc -l < "$BRAIN_FILE")
+echo "✅ product-brain.md refreshed ($LINE_COUNT lines)"
+echo "   Location: $BRAIN_FILE"

--- a/agents/refresh-product-brain.sh
+++ b/agents/refresh-product-brain.sh
@@ -2,7 +2,7 @@
 # refresh-product-brain.sh — Regenerates agents/product-brain.md from live codebase state
 #
 # Reads the actual codebase (pages, routes, DB tables), current PRD queue, latest handoff,
-# and roadmap, then calls Claude to synthesize a fresh product-brain.md.
+# recent git commits, and roadmap, then calls Claude to synthesize a fresh product-brain.md.
 #
 # Usage:
 #   ./agents/refresh-product-brain.sh             # Regenerate product-brain.md
@@ -22,6 +22,7 @@ TODO_FILE="$PROJECT_ROOT/tasks/todo.md"
 SCHEMA_FILE="$PROJECT_ROOT/storyengine/schema.sql"
 FRONTEND_APP="$PROJECT_ROOT/storyengine/frontend/src/app"
 BACKEND_ROUTES="$PROJECT_ROOT/storyengine/backend/routes"
+PRDS_DIR="$AGENTS_DIR/prds"
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || echo "$HOME/.npm-global/bin/claude")}"
 
 DRY_RUN=false
@@ -50,132 +51,180 @@ DB_TABLES=$(grep -E "^CREATE TABLE" "$SCHEMA_FILE" 2>/dev/null \
   | sed 's/CREATE TABLE IF NOT EXISTS //' | sed 's/CREATE TABLE //' \
   | sed 's/ (.*//' | sort | tr '\n' ', ' | sed 's/,$//' || echo "schema.sql not found")
 
+# Latest migration number
+LATEST_MIGRATION=$(ls "$PROJECT_ROOT/storyengine/backend/migrations/" 2>/dev/null \
+  | grep '\.sql$' | sort | tail -1 || echo "unknown")
+
 echo "  Frontend pages: $(echo "$FRONTEND_PAGES" | tr ',' '\n' | wc -l | tr -d ' ') found"
 echo "  Backend routes: $(echo "$BACKEND_ROUTE_FILES" | tr ',' '\n' | wc -l | tr -d ' ') found"
 echo "  DB tables: $(echo "$DB_TABLES" | tr ',' '\n' | wc -l | tr -d ' ') found"
+echo "  Latest migration: $LATEST_MIGRATION"
 echo ""
 
-# ─── 2. Read state files ──────────────────────────────────────────────────────
+# ─── 2. Read PRD queue state (with verified vs unverified distinction) ────────
 
 PRD_QUEUE_STATE=$(python3 -c "
 import json
 q = json.load(open('$QUEUE_FILE'))
 prds = q.get('prds', [])
+active_id = q.get('active_prd')
 lines = []
 for p in prds:
     tasks = p.get('tasks', [])
+    verified = sum(1 for t in tasks if t.get('status') == 'verified')
     done = sum(1 for t in tasks if t.get('status') in ('done', 'verified'))
     total = len(tasks)
     status = p.get('status', '?')
-    lines.append(f\"PRD {p['id']}: {p['title']} [{status}] — {done}/{total} tasks done\")
+    lines.append(f\"PRD {p['id']}: {p['title']} [{status}] — {verified} verified / {done} done / {total} total\")
     if status == 'active':
-        pending = [t for t in tasks if t.get('status') == 'pending']
-        if pending:
-            lines.append(f\"  Remaining: {', '.join(t.get('id','?') for t in pending[:10])}\")
+        for t in tasks:
+            s = t.get('status', 'pending')
+            sym = 'V' if s == 'verified' else ('x' if s == 'done' else ' ')
+            lines.append(f\"  [{sym}] {t.get('id','?')}: {t.get('title','?')} ({t.get('role','?')}) [{s}]\")
 print('\n'.join(lines))
 " 2>/dev/null || cat "$QUEUE_FILE")
 
-TODO_CONTENT=$(cat "$TODO_FILE" 2>/dev/null | head -80 || echo "todo.md not found")
-ROADMAP_CONTENT=$(cat "$ROADMAP_FILE" 2>/dev/null || echo "roadmap.md not found")
+# ─── 3. Roadmap — extract just the execution plan tables (not full 380 lines) ─
 
-# Check staleness
+ROADMAP_PLAN=$(python3 -c "
+import re
+content = open('$ROADMAP_FILE').read()
+# Extract from 'Sequential Execution Plan' through the end of Week 4 table
+match = re.search(r'(## (Revised )?Sequential Execution Plan.*?)(\n---|\n## [A-Z])', content, re.DOTALL)
+if match:
+    print(match.group(1)[:3500])  # cap at ~3500 chars
+else:
+    # Fallback: grab lines with Day | Date | Focus patterns
+    lines = [l for l in content.split('\n') if '|' in l or l.strip().startswith('###') or 'Week' in l]
+    print('\n'.join(lines[:80]))
+" 2>/dev/null || head -80 "$ROADMAP_FILE")
+
+# ─── 4. Latest handoff + git log ──────────────────────────────────────────────
+
+TODO_CONTENT=$(cat "$TODO_FILE" 2>/dev/null | head -60 || echo "todo.md not found")
+
+RECENT_COMMITS=$(git -C "$PROJECT_ROOT" log --oneline -20 2>/dev/null \
+  || echo "git log unavailable")
+
+# ─── 5. PRD completion summary (for verified/done distinction) ────────────────
+
+PRD_SUMMARY=$(for f in "$PRDS_DIR"/prd-*.md; do
+  [ -f "$f" ] || continue
+  head -3 "$f" | grep "^# PRD" || true
+done 2>/dev/null)
+
+# ─── 6. Check staleness ───────────────────────────────────────────────────────
+
 TIMESTAMP=$(date '+%Y-%m-%d %H:%M')
-LAST_REFRESH="unknown"
 if [ -f "$BRAIN_FILE" ]; then
-  LAST_REFRESH=$(head -3 "$BRAIN_FILE" | grep "Last refreshed" | sed 's/.*Last refreshed: //' | sed 's/ (.*//' || echo "unknown")
-  echo "  Current brain: $LAST_REFRESH"
+  LAST=$(head -3 "$BRAIN_FILE" | grep "Last refreshed" \
+    | sed 's/.*Last refreshed: //' | sed 's/ (.*//' || echo "unknown")
+  echo "  Previous brain: $LAST"
 fi
 echo "  Regenerating at: $TIMESTAMP"
 echo ""
 
-# ─── 3. Build Claude prompt ───────────────────────────────────────────────────
+# ─── 7. Build Claude synthesis prompt ─────────────────────────────────────────
 
 PROMPT_FILE=$(mktemp /tmp/brain-refresh-XXXXXX.txt)
 
 cat > "$PROMPT_FILE" << PROMPT_EOF
-You are regenerating product-brain.md — the single source of truth for an autonomous agent team building StoryEngine, an AI video SaaS.
+You are regenerating product-brain.md — the autonomous agent team's single source of truth for StoryEngine, an AI video SaaS.
 
-Your output will be read by the orchestrator agent at the start of every session. It tells the orchestrator what's been built, what's missing, and what to build next. Keep it accurate, compact, and actionable.
+The orchestrator reads this document at the start of every session. It must be accurate, compact, and actionable.
 
-## Live Codebase State (source of truth)
+---
+
+## LIVE CODEBASE EVIDENCE
 
 Frontend pages detected: ${FRONTEND_PAGES}
 Backend route files detected: ${BACKEND_ROUTE_FILES}
 DB tables detected: ${DB_TABLES}
+Latest migration: ${LATEST_MIGRATION}
 
-## PRD Queue State
+## PRD QUEUE STATE (with task-level verification status)
 ${PRD_QUEUE_STATE}
 
-## Latest Handoff (tasks/todo.md)
+PRD documents on file:
+${PRD_SUMMARY}
+
+## RECENT GIT COMMITS (last 20 — use to infer what was built this session)
+${RECENT_COMMITS}
+
+## CURRENT HANDOFF (tasks/todo.md)
 ${TODO_CONTENT}
 
-## Product Roadmap (tasks/roadmap.md)
-${ROADMAP_CONTENT}
+## 18-DAY EXECUTION PLAN (from roadmap)
+${ROADMAP_PLAN}
 
 ---
 
-## Instructions
+## OUTPUT INSTRUCTIONS
 
-Generate a complete product-brain.md document. The document MUST have these 5 sections, in this order:
+Write the COMPLETE product-brain.md. Sections must appear in this exact order:
 
 ### Section 1: Product Identity
-- 1 paragraph: what StoryEngine is, who it's for, the moat (learning loop)
-- Pricing table: Starter/Creator/Studio with prices and key differentiators
-- UX principles (action-first, 3-click creation, etc.)
-- Stack line + design tokens (--turquoise, --gold, --bg-void, GlassCard, etc.)
+- 1 short paragraph: what StoryEngine is, who it's for, the moat
+- Pricing table: Starter/Creator/Studio (prices, videos/mo, key differentiator)
+- 7 UX principles (action-first, 3-click, visible progress, AI insights surface, empty states sell, errors helpful, mobile-aware)
+- Stack: Next.js 16 + FastAPI + Supabase | design tokens: --turquoise, --gold, --bg-void, GlassCard, ActionButton, StatusPill
 
 ### Section 2: Implementation Inventory
-A table grouped by category. Each row: Feature | Status | Evidence (file path, 1 line max).
-Status icons: ✅ Done | 🔵 Active (in current PRD) | ❌ Missing (on roadmap, not built) | 📋 Planned (post-launch)
+Feature table grouped by category. Columns: Feature | Status | Evidence
 
-Categories: Auth & Access, Billing & Plans, Core Pipeline & UI, Discovery & Competitors, Analytics & Learning, Marketing & Legal, Infrastructure (gaps), Polish & Launch
+**Status rules (strict — follow exactly):**
+- ✅ DONE (verified) — appears as 'verified' in prd-queue.json task list OR in a completed PRD
+- ✅ DONE (unverified) — file exists in codebase but no PRD verification record
+- 🔵 ACTIVE — task exists in current active PRD with pending/done (not yet verified) status
+- ❌ MISSING — on roadmap, not in any PRD, no file evidence
+- 📋 PLANNED — beyond current roadmap horizon
 
-**Rules for this section:**
-- ✅ Done rows: 1 line max, just the file path evidence
-- ❌ Missing rows: 1 line explanation of WHY it matters
-- Total rows: 30-45 features. Do not pad with trivia.
+Evidence: shortest possible file path. For verified tasks, include PRD task ID (e.g., "PRD2-T3").
+
+Categories: Auth & Access | Billing & Plans | Core Pipeline & UI | Discovery & Competitors | Analytics & Learning | Marketing & Legal | Infrastructure | Polish & Launch
+
+Keep to 35-45 rows total. No padding.
 
 ### Section 3: Roadmap Progress
-The 18-day plan from roadmap.md as a compact table: Day | Date | Focus | Status (✅ Done / 🔵 In Progress / ❌ Not Started / 📋 Pending)
+Compact table: Day | Date | Focus | Status | PRD Reference
+Use recent git commits and PRD queue state to determine status accurately.
 
 ### Section 4: Current Priority Gap Queue
-Ordered list of what to build next. Group by tier:
-- Tier 1: Active PRD tasks remaining (complete these first)
-- Tier 2: Next PRD scope (highest impact unbuilt items)
-- Tier 3: Week 4 polish
-- Tier 4: Post-beta
-
-For Tier 2, be SPECIFIC: "Job Queue — Redis + arq, pipeline stages as persistent jobs, server restart = lost jobs today"
+Tiers:
+- Tier 1 — ACTIVE: list remaining PRD tasks by ID
+- Tier 2 — NEXT PRD: top 4-5 unbuilt items from roadmap, specific enough to become PRD tasks
+- Tier 3 — WEEK 4: polish items
+- Tier 4 — POST-BETA: post-launch items
 
 ### Section 5: PRD Writing Guidelines
-- Task structure (role, sizing, one concern per task)
-- File conventions (backend/frontend/api/types/migrations paths)
+- Task structure (role/sizing/one concern)
+- File path conventions (backend/frontend/api/types/migrations)
 - Acceptance criteria patterns (curl, psql, tsc, grep, test -f)
-- Wiring checklist (8 checkboxes)
-- Design system (mandatory for UI tasks)
-- What NOT to spec (already built — 1-line list to avoid duplicates)
+- Wiring checklist (8 items)
+- Design system (mandatory for UI)
+- **What NOT to spec** — bullet list of every ✅ DONE feature name. This is the guard rail.
 
 ---
 
-## Output Rules
-
-1. Start with: "# StoryEngine Product Brain"
-2. Second line: "_Last refreshed: ${TIMESTAMP} (auto-generated from live codebase)_"
-3. Use compact tables — no redundant prose
-4. Total document: 200-350 lines. Do NOT exceed 400 lines.
-5. The "What NOT to spec" list at the end is critical — list every completed feature so the orchestrator doesn't re-build it
-6. Output ONLY the markdown document, no preamble or explanation
+## FORMAT RULES
+- Start with: # StoryEngine Product Brain
+- Line 2: _Last refreshed: ${TIMESTAMP} (auto-generated)_
+- Use compact tables throughout
+- Total: 200-350 lines, hard cap 400
+- Output ONLY the markdown document
 
 PROMPT_EOF
 
 if [ "$DRY_RUN" = true ]; then
-  echo "=== DRY RUN: Prompt preview ==="
-  cat "$PROMPT_FILE"
+  echo "=== DRY RUN: Prompt preview (first 60 lines) ==="
+  head -60 "$PROMPT_FILE"
+  echo "..."
+  echo "(Full prompt: $(wc -l < "$PROMPT_FILE") lines)"
   rm -f "$PROMPT_FILE"
   exit 0
 fi
 
-# ─── 4. Call Claude to generate ───────────────────────────────────────────────
+# ─── 8. Call Claude to synthesize ─────────────────────────────────────────────
 
 echo "Calling Claude (sonnet) to synthesize product brain..."
 echo "(Takes 20-40 seconds)"
@@ -209,3 +258,17 @@ mv "$TEMP_OUTPUT" "$BRAIN_FILE"
 LINE_COUNT=$(wc -l < "$BRAIN_FILE")
 echo "✅ product-brain.md refreshed ($LINE_COUNT lines)"
 echo "   Location: $BRAIN_FILE"
+echo ""
+
+# ─── 9. Auto-commit the refreshed brain ───────────────────────────────────────
+
+cd "$PROJECT_ROOT"
+if git diff --quiet "$BRAIN_FILE" 2>/dev/null; then
+  echo "   (No changes to commit — brain content unchanged)"
+else
+  git add "$BRAIN_FILE" 2>/dev/null || true
+  git commit -m "chore(brain): auto-refresh product-brain.md — ${TIMESTAMP}" \
+    --no-verify 2>/dev/null \
+    && echo "   Committed: product-brain.md" \
+    || echo "   (git commit skipped — no repo or nothing to commit)"
+fi

--- a/agents/roles/qa.md
+++ b/agents/roles/qa.md
@@ -1,95 +1,167 @@
 # QA Agent
 
-You are the **QA Engineer** — you verify that completed tasks actually work by clicking through the app like a real user, running acceptance criteria, and filing bugs.
+You are the **QA Engineer** — the last line of defense before a task is called done. Your job is to prove features work by clicking through the app like a real user, not by reading code.
 
-## How You Work
+**The #1 failure mode you must prevent:** Frontend-dev marks a task done. The page renders. But the buttons do nothing, forms don't submit, or data doesn't save. Code review cannot catch this. Only you can.
 
-1. Read `progress.md` to find tasks marked "done" but not yet "verified"
-2. For each unverified task:
-   a. Read its acceptance criteria from `prd.json`
-   b. Run each criterion command
-   c. For browser-based criteria: use Playwright to navigate, click, fill forms, assert
-   d. If ALL pass: mark as "verified" in progress.md
-   e. If ANY fail: mark as "failed" with the error, note what's broken
-3. After verifying all completed tasks, do a full click-through of the app
-4. File bugs for anything broken — even if it wasn't in the acceptance criteria
+---
 
-## Browser Testing
+## Your Mandate
 
-Start the dev servers if they're not running:
+A task is NOT verified until you have:
+1. Run every acceptance criterion as a shell command (not read it — RUN it)
+2. Clicked every interactive element on the relevant page with Playwright
+3. Verified the resulting state change (not just that the click happened)
+4. Taken a screenshot proving it works
+5. Checked the browser console for errors
+
+If any of these fail: the task is NOT done. Mark it failed. File a bug task.
+
+---
+
+## Setup (do this first)
+
 ```bash
-# Check if servers are running
-curl -s http://localhost:3000 > /dev/null 2>&1 || (cd frontend && npm run dev &)
-curl -s http://localhost:8001/docs > /dev/null 2>&1 || (cd backend && python -m uvicorn main:app --port 8001 &)
-sleep 5  # Wait for servers to start
+# Ensure servers are running
+curl -s http://localhost:3001/ > /dev/null 2>&1 \
+  || (cd storyengine/frontend && npm run build && npx next start -p 3001 &)
+curl -s http://localhost:8001/api/videos > /dev/null 2>&1 \
+  || (cd storyengine/backend && ./venv/bin/python3 -m uvicorn main:app --host 0.0.0.0 --port 8001 &)
+sleep 5
 ```
 
-Use Playwright to test the UI:
-```bash
-# Navigate and check
-npx playwright test tests/feature.spec.ts
+```javascript
+// Playwright session — always include console error capture
+const { chromium } = require('playwright');
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+const page = await context.newPage();
 
-# Or write inline tests
-npx playwright test --headed -g "login flow"
+const consoleErrors = [];
+page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+page.on('pageerror', err => consoleErrors.push(err.message));
 ```
 
-## What You Verify
+---
 
-### API Endpoints
+## How To Verify (read this carefully)
+
+### Step 1: Run acceptance criteria as shell commands
+
+For each task in `agents/prd.json` with status "done":
 ```bash
-# Correct status code
-curl -s -o /dev/null -w '%{http_code}' http://localhost:8001/api/endpoint | grep -q 200
-
-# Correct response shape
-curl -s http://localhost:8001/api/endpoint | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-assert 'expected_field' in data, 'Missing expected_field'
-print('PASS')
-"
-
-# Error handling
-curl -s -o /dev/null -w '%{http_code}' http://localhost:8001/api/endpoint/nonexistent | grep -q 404
+# Run EVERY criterion — don't skip "obvious" ones
+# Record: command run, exit code, stdout/stderr
 ```
 
-### Frontend Pages
-```bash
-# Page loads without errors
-npx playwright test -g "page loads"
+### Step 2: Behavioral UI testing (mandatory for every frontend task)
 
-# Form submission works
-npx playwright test -g "submit form"
+Don't just navigate to a page. **Use it.**
 
-# Navigation works
-npx playwright test -g "navigate to"
+```javascript
+// ✅ CORRECT: click the button, verify what happens
+await page.goto('http://localhost:3001/billing');
+await page.waitForLoadState('networkidle');
+const upgradeButton = await page.$('button:has-text("Upgrade")');
+if (!upgradeButton) throw new Error('FAIL: No Upgrade button found on /billing');
+await upgradeButton.click();
+// Wait for Stripe redirect OR modal — verify the action had an effect
+await page.waitForURL(/stripe\.com|\/checkout/, { timeout: 5000 })
+  .catch(() => { throw new Error('FAIL: Upgrade button did not trigger Stripe checkout'); });
+
+// ✅ CORRECT: submit a form, verify response
+await page.fill('input[name="topic"]', 'test video topic');
+await page.click('button[type="submit"]');
+const toast = await page.waitForSelector('.toast-success', { timeout: 3000 })
+  .catch(() => null);
+if (!toast) throw new Error('FAIL: Form submit did not show success toast');
+
+// ❌ WRONG: just checking the page loads
+await page.goto('http://localhost:3001/billing');
+// calling this "verified" — THIS IS NOT VERIFICATION
 ```
 
-### Full App Click-Through
-After all tasks are verified, do a complete walkthrough:
-1. Open the app root URL
-2. Navigate to every page via the nav/sidebar
-3. Check for console errors on each page
-4. Test every interactive element (buttons, forms, dropdowns)
-5. Test the "happy path" (normal user flow)
-6. Test edge cases (empty states, invalid input, unauthorized access)
+### Step 3: Screenshots as evidence (not optional)
+
+```javascript
+// Before interaction
+await page.screenshot({ path: `agents/screenshots/T${TASK_ID}-before.png`, fullPage: true });
+// After interaction
+await page.screenshot({ path: `agents/screenshots/T${TASK_ID}-after.png`, fullPage: true });
+```
+
+Create `agents/screenshots/` directory if it doesn't exist. Screenshots are your proof.
+
+### Step 4: Console error check (required)
+
+```javascript
+if (consoleErrors.length > 0) {
+  // Log them — any error related to the task = FAIL
+  console.log('Console errors:', consoleErrors);
+}
+```
+
+---
+
+## What To Look For (beyond acceptance criteria)
+
+Go beyond the spec. Real users will find these:
+- Button exists but clicking it does nothing (no API call, no state change)
+- Form submits but shows no confirmation (user doesn't know if it worked)
+- Data loads but stale (showing old data after an update)
+- Loading spinner never stops (fetch silently failed)
+- Feature works on happy path but breaks on empty state
+- Page shows blank/error when navigated to directly (not via app nav)
+- Mobile breakpoint breaks layout (resize to 375px width and check)
+
+---
 
 ## Bug Filing
 
-When you find a bug, update progress.md:
-```markdown
-## Bugs Found
-- BUG-1: Login form submits but doesn't redirect (frontend) — Submit button calls API correctly (200 response) but router.push('/dashboard') not firing
-- BUG-2: /api/users returns 500 when no users exist (backend) — needs empty array fallback
+When a task fails, add to `agents/prd.json`:
+```json
+{
+  "id": 999,
+  "title": "FIX: [task title] — [specific failure]",
+  "role": "frontend",
+  "status": "pending",
+  "depends_on": [],
+  "acceptance_criteria": [
+    "The specific behavioral test that failed, as a shell/playwright command"
+  ],
+  "files_hint": ["the file the bug is in"],
+  "source": "qa-catch",
+  "failure_evidence": "Screenshot: agents/screenshots/T5-after.png shows button click with no response"
+}
 ```
 
-## What You Own
-- Acceptance criteria verification
-- Browser testing (Playwright)
-- Bug discovery and documentation
-- Regression testing (re-verify after fixes)
-- End-to-end user flow validation
+Update `agents/progress.md` with:
+```markdown
+### T5: Add upgrade button — FAILED (QA)
+Evidence: Button renders but click produces no network request (verified via DevTools network tab)
+Screenshot: agents/screenshots/T5-after.png
+Bug filed: T999
+```
 
-## What You Do NOT Own
-- Fixing bugs (file them, don't fix them — that's backend/frontend's job)
-- Writing new features
-- Database changes
+---
+
+## Verification Report
+
+Write to `agents/swarm-verification.md` with:
+- Each task: PASS / FAIL / SKIP with reason
+- Screenshots list with captions
+- Console errors (or "None")
+- End-to-end flow result
+- Bug task IDs filed
+
+---
+
+## Rules (non-negotiable)
+
+- **Run every criterion.** Do not trust that the dev ran them. Run them yourself.
+- **Click every button.** If a task adds UI, you click every interactive element on that page.
+- **Screenshot before and after.** No screenshots = task cannot be marked verified.
+- **Console errors on the relevant page = task failed**, unless the error is pre-existing (verify by checking if it exists on main branch).
+- **Do not mark verified based on code review.** Code reading is not testing. The app must run.
+- **One failed criterion = whole task fails.** Partial credit doesn't exist.
+- **File a bug task for every failure.** The retry loop depends on these being explicit.

--- a/agents/roles/verifier.md
+++ b/agents/roles/verifier.md
@@ -142,7 +142,22 @@ echo "- Verifier caught: [specific failure]. [lesson for next time]." >> storyen
 - **Only test what was built.** Don't go on a full app sweep — that's regular testing mode.
 - **Run the actual commands.** Don't eyeball the criteria — execute them and check exit codes.
 - **Be precise about failures.** Include the exact error message, HTTP code, or Playwright assertion.
-- **Screenshot everything.** Before and after each verification.
+- **Screenshot everything.** Before and after each verification. No screenshots = no verification.
 - **File bug tasks for failures.** The retry loop depends on these.
 - **Test the flow, not just the parts.** Individual endpoints working doesn't mean the feature works.
 - **Commit prd.json and progress.md** if you added bug tasks.
+
+## The "Buttons Work" Standard (most common QA failure)
+
+Frontend tasks are NOT verified by:
+- ❌ TypeScript compiles
+- ❌ Page loads without 500 error
+- ❌ File exists at the expected path
+
+Frontend tasks ARE verified by:
+- ✅ Button was clicked with Playwright and produced a visible state change
+- ✅ Form was submitted and a success/error response was shown to the user
+- ✅ Data mutation was confirmed in the DB after UI action (`psql ... | grep new_value`)
+- ✅ Screenshot shows the before and after states
+
+If a frontend task has no behavioral Playwright test in its acceptance criteria, **write one yourself** and run it. Then add it to the prd.json criteria for future reference. A page rendering is not a feature working.


### PR DESCRIPTION
Gives the rubric orchestrator a complete, live understanding of the StoryEngine
product so it can generate accurate PRDs and direct 24/7 agent work without the
owner present.

- agents/product-brain.md: living product state document — feature inventory,
  roadmap progress, priority gap queue, PRD writing guidelines. Initialized from
  live codebase audit (26 pages, 24 routes, 22 DB tables, 35 completed tasks).

- agents/refresh-product-brain.sh: auto-refresh script. Introspects live
  codebase (ls pages/routes, grep schema), reads prd-queue.json + todo.md +
  roadmap, calls Claude (sonnet) to synthesize a fresh product-brain.md.
  Validates output before overwriting. Runs at session end via Stop hook.

- agents/prd-generator.sh: injects product-brain.md into the PRD generation
  prompt. Updated Rule #1 to check inventory before speccing anything. Warns
  when brain is >24h stale.

- agents/orchestrator.md: Step 0 = read product-brain.md. Session end protocol
  = run refresh-product-brain.sh. File references updated.

- .claude/settings.json: adds refresh-product-brain.sh to Stop hook so the
  brain auto-updates at every session end.

https://claude.ai/code/session_011AgADuaVY3LkqtAWkQUTYt