### PR TITLE
feat(onboarding): PRD audit + P0 UX fixes

### DIFF
--- a/storyengine/frontend/public/manifest.json
+++ b/storyengine/frontend/public/manifest.json
@@ -6,7 +6,6 @@
   "background_color": "#121212",
   "theme_color": "#00D4AA",
   "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/icon-192.svg", "sizes": "any", "type": "image/svg+xml" }
   ]
 }

--- a/storyengine/frontend/src/app/layout.tsx
+++ b/storyengine/frontend/src/app/layout.tsx
@@ -27,7 +27,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head>
-        <link rel="apple-touch-icon" href="/icon-192.png" />
+        <link rel="icon" href="/icon-192.svg" type="image/svg+xml" />
+        <link rel="apple-touch-icon" href="/icon-192.svg" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link

--- a/storyengine/frontend/src/app/onboarding/page.tsx
+++ b/storyengine/frontend/src/app/onboarding/page.tsx
@@ -13,6 +13,7 @@ import {
   getYouTubeStatus,
   syncYouTubeMetrics,
 } from "@/lib/api";
+import { humanizeError } from "@/lib/errors";
 import { Spinner } from "@/components/ui/spinner";
 import { ChannelIdentityStep } from "@/components/onboarding/ChannelIdentityStep";
 import { StyleSetupStep } from "@/components/onboarding/StyleSetupStep";
@@ -70,6 +71,10 @@ function OnboardingContent() {
     { key: string; label: string; reason: string; url: string; configured: boolean }[]
   >([]);
 
+  // Network-health banner: set when the initial status load fails, so the
+  // user sees "we couldn't load your progress" rather than an empty Step 1.
+  const [statusLoadFailed, setStatusLoadFailed] = useState(false);
+
   // Check if onboarding is already complete, and auto-advance past completed steps
   useEffect(() => {
     getOnboardingStatus()
@@ -92,7 +97,9 @@ function OnboardingContent() {
           loadApiKeys();
         }
       })
-      .catch(() => {})
+      .catch(() => {
+        setStatusLoadFailed(true);
+      })
       .finally(() => setLoading(false));
   }, [router]);
 
@@ -166,7 +173,7 @@ function OnboardingContent() {
       loadApiKeys();
       setStep(1); // Keys step
     } catch (err) {
-      setChannelError(err instanceof Error ? err.message : "Failed to save");
+      setChannelError(humanizeError(err, "We couldn't save your channel. Please try again."));
     } finally {
       setChannelSaving(false);
     }
@@ -207,7 +214,7 @@ function OnboardingContent() {
       setStyleGenerated(true);
       setStyleSummary(result.summary || "Your custom style has been generated.");
     } catch (err) {
-      setStyleError(err instanceof Error ? err.message : "Failed to generate style");
+      setStyleError(humanizeError(err, "We couldn't generate your style. Please try again."));
     } finally {
       setStyleGenerating(false);
     }
@@ -269,6 +276,21 @@ function OnboardingContent() {
   return (
     <div className="flex items-center justify-center min-h-screen px-4 py-12">
       <div className="w-full max-w-xl">
+        {statusLoadFailed && (
+          <div
+            role="status"
+            data-testid="onboarding-network-banner"
+            className="mb-6 px-4 py-3 rounded-lg text-sm text-center"
+            style={{
+              background: "rgba(255, 180, 0, 0.08)",
+              border: "1px solid rgba(255, 180, 0, 0.35)",
+              color: "var(--gold)",
+            }}
+          >
+            We couldn&apos;t load your progress. Check your connection and refresh — any data you enter below may not save until we reconnect.
+          </div>
+        )}
+
         {/* Progress Bar */}
         <div className="flex items-center justify-center gap-0 mb-10">
           {STEPS.map((s, i) => {

--- a/storyengine/frontend/src/components/onboarding/ChannelIdentityStep.tsx
+++ b/storyengine/frontend/src/components/onboarding/ChannelIdentityStep.tsx
@@ -68,14 +68,14 @@ export function ChannelIdentityStep({
 
         <TextInput
           label="Channel Name"
-          placeholder="e.g., Economy FastForward"
+          placeholder="Your channel name"
           value={channelName}
           onChange={(e) => onChange("channelName", e.target.value)}
           required
         />
 
         <Select
-          label="What topics will you cover?"
+          label="What topics will you cover? (optional)"
           options={nicheOptions}
           value={niche}
           onChange={(e) => onChange("niche", e.target.value)}
@@ -83,8 +83,8 @@ export function ChannelIdentityStep({
         />
 
         <Textarea
-          label="Who are you making videos for?"
-          placeholder="e.g., Busy professionals who want to understand global economics without reading 50 articles."
+          label="Who are you making videos for? (optional)"
+          placeholder="Describe your ideal viewer — what they care about, what they want to learn."
           value={audience}
           onChange={(e) => onChange("audience", e.target.value)}
           rows={3}

--- a/storyengine/frontend/src/components/onboarding/CreateVideoStep.tsx
+++ b/storyengine/frontend/src/components/onboarding/CreateVideoStep.tsx
@@ -114,7 +114,7 @@ export function CreateVideoStep({ onComplete }: CreateVideoStepProps) {
               <textarea
                 value={topic}
                 onChange={(e) => setTopic(e.target.value)}
-                placeholder="e.g., Why the US dollar might lose its reserve currency status"
+                placeholder="A topic you want a video about — a question, a how-to, a hot take…"
                 rows={3}
                 className="w-full px-4 py-3 rounded-lg text-sm font-body outline-none resize-none transition-all"
                 style={{
@@ -315,7 +315,7 @@ export function CreateVideoStep({ onComplete }: CreateVideoStepProps) {
                 <textarea
                   value={angle}
                   onChange={(e) => setAngle(e.target.value)}
-                  placeholder="e.g., Focus on the geopolitical implications rather than economics"
+                  placeholder="Any specific angle, POV, or detail you want the video to take on?"
                   rows={2}
                   className="w-full px-4 py-3 rounded-lg text-sm font-body outline-none resize-none transition-all"
                   style={{

--- a/storyengine/frontend/src/components/ui/ActionButton.tsx
+++ b/storyengine/frontend/src/components/ui/ActionButton.tsx
@@ -42,8 +42,11 @@ export function ActionButton({
     <button
       onClick={onClick}
       disabled={disabled}
+      aria-disabled={disabled || undefined}
       className={cn(
-        "inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold font-body transition-all hover:brightness-110 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed",
+        "inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold font-body transition-all active:scale-[0.98]",
+        "enabled:hover:brightness-110",
+        "disabled:opacity-40 disabled:grayscale disabled:cursor-not-allowed disabled:pointer-events-none",
         className
       )}
       style={styles[variant]}

--- a/storyengine/frontend/src/lib/errors.ts
+++ b/storyengine/frontend/src/lib/errors.ts
@@ -1,0 +1,65 @@
+/**
+ * humanizeError — convert raw fetch/API errors into copy a user can actually read.
+ *
+ * Raw errors users should NEVER see: "Failed to fetch", "NetworkError when
+ * attempting to fetch resource", "API error 500: <body>", stack traces, etc.
+ *
+ * Strategy: inspect the error shape, return friendly copy. If we hit an
+ * unrecognized shape, fall back to a neutral message + log the raw error
+ * to the console so devs can still diagnose.
+ */
+export function humanizeError(
+  err: unknown,
+  fallback = "Something went wrong. Please try again."
+): string {
+  const raw =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : "";
+
+  // Network / offline / CORS blocked
+  if (
+    raw === "Failed to fetch" ||
+    raw.startsWith("NetworkError") ||
+    raw.startsWith("TypeError: Failed to fetch") ||
+    raw.includes("ERR_CONNECTION_REFUSED") ||
+    raw.includes("NetworkError when")
+  ) {
+    return "We couldn't reach our servers. Check your connection and try again.";
+  }
+
+  // Backend 5xx
+  if (/^API error 5\d\d/.test(raw)) {
+    return "Our servers hit a snag. Give it a moment and try again.";
+  }
+
+  // Backend 4xx auth
+  if (/^API error 401/.test(raw) || raw === "Session expired — redirecting to login") {
+    return "Your session expired. Please sign in again.";
+  }
+
+  // Backend 4xx plan / billing
+  if (/^API error 402/.test(raw) || raw === "Plan limit reached") {
+    return "You've hit a limit on your current plan.";
+  }
+
+  // Backend 4xx rate limit
+  if (/^API error 429/.test(raw)) {
+    return "You're doing that a lot. Give it a few seconds and try again.";
+  }
+
+  // Backend validation: if the API wrapper extracted a "detail" string from
+  // the JSON body, it won't start with "API error"; it'll be human-ish
+  // already (e.g. "Channel name too long"). Pass through when it looks safe.
+  if (raw && !raw.startsWith("API error ") && raw.length < 160) {
+    return raw;
+  }
+
+  // Last-resort fallback — log the raw error so devs can still find it
+  if (typeof console !== "undefined" && raw) {
+    console.warn("[humanizeError] unmapped:", raw);
+  }
+  return fallback;
+}

--- a/storyengine/frontend/tests/onboarding.spec.ts
+++ b/storyengine/frontend/tests/onboarding.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Acceptance spec for PRD `storyengine/prds/onboarding-ux-audit-2026-04-17.md`.
+// Each test maps to a numbered acceptance criterion in the "Acceptance Criteria
+// (Test Plan)" section of that PRD.
+//
+// All backend routes are intercepted here so these tests run without a live
+// backend (and deterministically regardless of backend state).
+
+async function stubBackend(page: Page, opts: { onboardingStatus?: "ok" | "fail"; saveChannel?: "ok" | "fail" } = {}) {
+  const { onboardingStatus = "ok", saveChannel = "ok" } = opts;
+
+  await page.route("**/api/dashboard/onboarding/status", async (route) => {
+    if (onboardingStatus === "fail") {
+      await route.fulfill({ status: 500, body: "boom" });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        completed: false,
+        display_name: "Test User",
+        steps: {
+          channel_configured: false,
+          api_keys: { configured: 0, required: 3 },
+          style_generated: false,
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/auth/youtube/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ connected: false, channel_name: null }),
+    });
+  });
+
+  await page.route("**/api/channel-profile", async (route) => {
+    if (saveChannel === "fail") {
+      // Simulate an unreachable backend — the same shape fetchApi produces
+      // when the origin is down.
+      await route.abort("failed");
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+}
+
+test.describe("Onboarding UX — PRD acceptance criteria", () => {
+  test("AC-1: shows network-health banner when onboarding-status load fails", async ({ page }) => {
+    await stubBackend(page, { onboardingStatus: "fail" });
+    await page.goto("/onboarding");
+
+    // Wait for the initial load to complete — the banner renders once the catch block fires.
+    const banner = page.getByTestId("onboarding-network-banner");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(/couldn.?t load your progress/i);
+
+    // Step 1 should still render below the banner so the user can continue
+    // typing (data just won't persist until reconnect).
+    await expect(page.getByRole("heading", { name: "Your Channel" })).toBeVisible();
+  });
+
+  test("AC-2: Step 1 Channel Name placeholder is NOT 'Economy FastForward'", async ({ page }) => {
+    await stubBackend(page);
+    await page.goto("/onboarding");
+
+    const channelInput = page.getByRole("textbox", { name: /channel name/i });
+    const placeholder = await channelInput.getAttribute("placeholder");
+
+    expect(placeholder, "placeholder leaks Ryan's channel name").not.toMatch(/economy\s*fast\s*forward/i);
+  });
+
+  test("AC-3: Niche and Audience labels carry '(optional)' affordance", async ({ page }) => {
+    await stubBackend(page);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText(/what topics will you cover\?.*optional/i)).toBeVisible();
+    await expect(page.getByText(/who are you making videos for\?.*optional/i)).toBeVisible();
+  });
+
+  test("AC-4: Continue button looks and behaves disabled when Channel Name is empty", async ({ page }) => {
+    await stubBackend(page);
+    await page.goto("/onboarding");
+
+    const continueBtn = page.getByRole("button", { name: "Continue" });
+    await expect(continueBtn).toBeDisabled();
+    await expect(continueBtn).toHaveAttribute("aria-disabled", "true");
+
+    // Computed opacity should be <= 0.4 (the PRD target) — opacity-40 class wins
+    // over filled-variant inline background.
+    const opacity = await continueBtn.evaluate((el) =>
+      parseFloat(getComputedStyle(el).opacity),
+    );
+    expect(opacity).toBeLessThanOrEqual(0.4 + 0.01);
+
+    // Cursor should visibly communicate not-allowed.
+    const cursor = await continueBtn.evaluate(
+      (el) => getComputedStyle(el).cursor,
+    );
+    expect(cursor).toBe("not-allowed");
+  });
+
+  test("AC-5: Step 1 submit-failure error is human-readable, not raw fetch text", async ({ page }) => {
+    await stubBackend(page, { saveChannel: "fail" });
+    await page.goto("/onboarding");
+
+    // Fill the minimum required field so Continue is enabled.
+    await page.getByRole("textbox", { name: /channel name/i }).fill("Test Channel");
+
+    // Click Continue — the stub will cause updateChannelProfile to throw.
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // An error appears in the form.
+    const errorText = await page
+      .locator("p")
+      .filter({ hasText: /couldn.?t|connection|please try again|session|limit|snag|doing that a lot/i })
+      .first()
+      .textContent();
+    expect(errorText, "friendly error copy should render").toBeTruthy();
+
+    // Raw dev strings must NOT leak to the user.
+    await expect(page.getByText("Failed to fetch")).toHaveCount(0);
+    await expect(page.getByText(/^API error \d/)).toHaveCount(0);
+    await expect(page.getByText(/NetworkError/)).toHaveCount(0);
+  });
+
+  test("AC-6: /icon-192.svg is served with a 2xx status", async ({ page }) => {
+    const resp = await page.request.get("/icon-192.svg");
+    expect(resp.status(), `icon fetch status=${resp.status()}`).toBeGreaterThanOrEqual(200);
+    expect(resp.status()).toBeLessThan(300);
+  });
+});

--- a/storyengine/prds/onboarding-ux-audit-2026-04-17.md
+++ b/storyengine/prds/onboarding-ux-audit-2026-04-17.md
@@ -1,0 +1,137 @@
+# PRD — Onboarding UX Audit & Fix Plan
+
+**Owner:** Ryan (via Osiris)
+**Created:** 2026-04-17
+**Status:** Audit complete → P0 fixes in this PR, P1+ tracked in Command Center
+
+## Problem
+
+New users drop into StoryEngine and feel they've been thrown into chaos. The 5-step `/onboarding` wizard was shipped (commit `44063a19`) to fix this, but a hands-on audit with Playwright + component review surfaced concrete UX bugs that still make the first minute confusing.
+
+This PRD is the audit report + the ranked fix plan + an executable acceptance-criteria test (Playwright spec) that we iterate against.
+
+## Audit Method
+
+- **Live walk-through** via Playwright MCP with frontend running at `localhost:3001`, backend mocked/unreachable.
+- **Component code review** of all 5 step components: `ChannelIdentityStep`, `ApiKeysStep`, `StyleSetupStep`, `YouTubeConnectStep`, `CreateVideoStep`.
+- Screenshot evidence saved at `.playwright-mcp/onboarding-step-1-*.png`.
+
+## Step-by-Step Findings
+
+### Step 1 — "Your Channel" (ChannelIdentityStep.tsx)
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| 1.1 | **P0** | Backend fetch errors leak raw string `"Failed to fetch"` into the user-visible error line. Observed live. | `app/onboarding/page.tsx:169, 210` — `err.message` rendered directly |
+| 1.2 | **P0** | Placeholder copy uses Ryan's own channel (`"e.g., Economy FastForward"`), audience example is one specific niche, and angle example is domain-specific. Non-economy users feel the product isn't for them. | `ChannelIdentityStep.tsx:71, 87` |
+| 1.3 | **P1** | Niche and audience are both optional per the code (`disabled={!channelName.trim()}`) but the UI has no "(optional)" affordance. Users think they must fill all three. | `ChannelIdentityStep.tsx:69–91` |
+| 1.4 | **P1** | Disabled `Continue` button only dims via `opacity-50` layered on a saturated turquoise background — at 50% opacity on a near-black bg it still looks clickable. | `ActionButton.tsx:44–49` |
+| 1.5 | **P2** | No client-side validation; clicking Continue with the button disabled gives no hint why. | `ChannelIdentityStep.tsx:100–111` |
+| 1.6 | **P2** | No `/favicon.ico` or `/icon-192.png`; every page shows 404s in console. | `app/layout.tsx` manifest |
+
+### Step 2 — "Tools" / API Keys (ApiKeysStep.tsx)
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| 2.1 | **P0** | All 3 keys hard-required with no save-and-come-back. If a user doesn't have (e.g.) a Kie.ai key yet, they're blocked from the rest of onboarding. | `ApiKeysStep.tsx` Continue gate |
+| 2.2 | **P1** | Input placeholder `"Paste your API key…"` on a password-masked field — user can't see what they pasted. If they paste a malformed key, they learn only when Save & Test fails. Either switch to text input with visual toggle, or show format hint (`sk-ant-…`) as a masked prefix preview. | `ApiKeysStep.tsx:135–139` |
+| 2.3 | **P1** | No explicit success confirmation when a key validates — only a state change. Silent success. | `ApiKeysStep.tsx:53–55` |
+| 2.4 | **P1** | Parent handler `handleTestApiKey` silently swallows errors (returns `false`) — test failures render as "didn't work" with no reason. | `app/onboarding/page.tsx:225–237` |
+| 2.5 | **P2** | `reason` field for each key is a one-liner; no "why this API matters for your videos" framing beyond that. | `ApiKeysStep.tsx` row rendering |
+| 2.6 | **P2** | Password input lacks `aria-label`; screen reader users get no context. | `ApiKeysStep.tsx:135` |
+
+### Step 3 — "Style" (StyleSetupStep.tsx)
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| 3.1 | **P1** | Copy says "Describe how you want your videos to sound and feel" — ambiguous (narrator tone? script content? editing style?). Users don't know what to write. | `StyleSetupStep.tsx` heading |
+| 3.2 | **P1** | No ETA / progress indicator while `generateSystemPrompts` runs (can take 10–30s). Only a `<Spinner />`; users may think it hung. | `StyleSetupStep.tsx:~100` |
+| 3.3 | **P2** | After success, the summary card appears with no "Continue" affordance explanation — some users skip accidentally. | `StyleSetupStep.tsx:83` |
+| 3.4 | **P2** | Skip button goes straight to next step without confirming "you can always come back in Settings". | `StyleSetupStep.tsx:114–119` |
+
+### Step 4 — "YouTube" (YouTubeConnectStep.tsx)
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| 4.1 | **P0** | **OAuth cancellation is silently swallowed.** If user clicks Connect → authorizes nothing / denies / closes the popup, `catch` block does not set error state. They return to the onboarding page with no feedback and no retry prompt. | `app/onboarding/page.tsx:175–184` (handler) + `YouTubeConnectStep.tsx` |
+| 4.2 | **P1** | Scope-explanation copy is absent. Users consent to OAuth with no idea what StoryEngine will access. | `YouTubeConnectStep.tsx` |
+| 4.3 | **P1** | Sync errors are caught and swallowed. If sync fails in background after Connect, user sees no indicator and may think data is still loading. | `app/onboarding/page.tsx:186–194` |
+| 4.4 | **P2** | Skip button text `"Skip — you can connect later in Settings"` is good. Keep. But no analog on Styles step. | `YouTubeConnectStep.tsx:~117` |
+
+### Step 5 — "First Video" (CreateVideoStep.tsx)
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| 5.1 | **P0** | Topic placeholder `"Why the US dollar might lose reserve currency status"` is Ryan's actual domain. Cooking/fitness/travel creators feel the product isn't for them. Same issue repeated in angle placeholder. | `CreateVideoStep.tsx:~110, ~306` |
+| 5.2 | **P1** | After clicking "Create Video & Start Pipeline", page navigates to `/pipeline/{videoId}` with no intermediate "Your video is being created…" confirmation. Users may think the flow is broken. | `CreateVideoStep.tsx:~64–71` |
+| 5.3 | **P1** | Suggestion cards display cryptic "Thumbnail: {thumbnail_text}" — users don't expect a title-suggestion to carry thumbnail copy. Relabel as "Suggested thumbnail text". | `CreateVideoStep.tsx:230` |
+| 5.4 | **P2** | Suggestion `score` badge shown only when `score > 0` — inconsistent, no explanation of what 0–10 means. | `CreateVideoStep.tsx:210` |
+| 5.5 | **P2** | No "credits this will cost" warning before clicking Suggest Titles (API-costing action). | `CreateVideoStep.tsx:~190` |
+
+### Cross-Cutting
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| X.1 | **P0** | If `getOnboardingStatus()` fails on mount, user lands on Step 0 with no network-health banner. | `app/onboarding/page.tsx:74–97` |
+| X.2 | **P1** | URL `?step=<key>` is not read; only `?yt_connected=true` is. Users can't bookmark a step, and testing individual steps requires backend mocks. | `app/onboarding/page.tsx:43, 115–122` |
+| X.3 | **P1** | Error messages across the flow use `err.message` directly. Need a `sanitizeError()` util that maps common fetch/network errors to user-friendly copy. | cross-cutting |
+
+## P0 Fixes (This PR)
+
+Ships in commit(s) on branch `claude/onboarding-ux-audit`:
+
+1. **Sanitize error messages.** New util `frontend/src/lib/errors.ts::humanizeError(err)` that maps common network/fetch failures to user-friendly copy. Apply in `handleSaveChannel`, `handleGenerateStyle`. (Addresses 1.1, X.3.)
+2. **Generic placeholders** in Steps 1 and 5. Replace Ryan-specific examples with neutral ones. (Addresses 1.2, 5.1.)
+3. **"(optional)" labels** on Niche + Audience in Step 1. (Addresses 1.3.)
+4. **Stronger disabled button state** — `ActionButton` gets `disabled:opacity-40` (not 50) + `disabled:grayscale` + cursor override to make disabled state unmistakable. (Addresses 1.4.)
+5. **Network-health banner** — if `getOnboardingStatus()` fails on mount, show a yellow banner at top of page: "We couldn't load your progress. Check your connection and refresh." (Addresses X.1.)
+6. **Favicon + icon-192** — add placeholder PNGs so console stops 404ing. (Addresses 1.6.)
+
+## P1 Fixes (Next PR)
+
+Tracked in Command Center — plan for follow-up:
+
+- Partial-save / come-back on Step 2 (remove hard-gate).
+- Password field visual toggle (eye icon) on Step 2.
+- Explicit success/failure copy on key test.
+- YouTube OAuth cancellation error handler.
+- Scope explanation before YouTube connect.
+- Step 3 clarifying copy + ETA.
+- Step 5 intermediate "creating your video…" confirmation.
+- Cross-cutting: URL `?step=` deep-linking.
+
+## P2 Fixes (Backlog)
+
+- Accessibility sweep across all steps (aria-live, aria-describedby, labels).
+- First-run checklist on dashboard post-onboarding (fix-roadmap 6.2 already captured).
+- Retry affordances on failed steps.
+
+## Acceptance Criteria (Test Plan)
+
+These are the statements the new Playwright spec (`frontend/tests/onboarding.spec.ts`) asserts. Each maps to one or more fixes above.
+
+1. On fresh `/onboarding` load with a failing backend, the page renders Step 1 content AND a "couldn't load your progress" banner. (P0 #5)
+2. Step 1 placeholder for Channel Name does NOT contain the string "Economy FastForward". (P0 #2)
+3. Step 1 labels for Niche and Audience contain the substring "(optional)". (P0 #3)
+4. Step 1 Continue button has `aria-disabled="true"` (or the disabled attribute) when Channel Name is empty, and its computed style opacity ≤ 0.4. (P0 #4)
+5. Step 1 submit failure (mocked backend 500) shows a human-readable error, NOT the raw string "Failed to fetch" or any ERROR_CODE-like string. (P0 #1)
+6. `<link rel="icon">` resolves 200 (not 404). (P0 #6)
+
+Test file stubs the backend via `page.route()` so it runs offline.
+
+## Out of Scope (for This PR)
+
+- Backend changes. (All fixes are frontend-only.)
+- Onboarding component restructure (component split, step branching).
+- Re-architecting `?step=` URL support (tracked as P1).
+
+## Files Changed in P0 Commit
+
+- `storyengine/frontend/src/lib/errors.ts` *(new)*
+- `storyengine/frontend/src/app/onboarding/page.tsx` *(error sanitization + network-health banner)*
+- `storyengine/frontend/src/components/onboarding/ChannelIdentityStep.tsx` *(placeholders + optional labels)*
+- `storyengine/frontend/src/components/onboarding/CreateVideoStep.tsx` *(placeholders)*
+- `storyengine/frontend/src/components/ui/ActionButton.tsx` *(stronger disabled state)*
+- `storyengine/frontend/public/favicon.ico` *(new)* + `icon-192.png` *(new)*
+- `storyengine/frontend/tests/onboarding.spec.ts` *(new — 6 acceptance tests)*
+- `storyengine/prds/onboarding-ux-audit-2026-04-17.md` *(this doc)*


### PR DESCRIPTION
## Summary

- Audited `/onboarding` live via Playwright MCP + full component code review. New users were dropping into real UX friction even after the unified 5-step wizard (44063a19) shipped. Full findings + ranked fix plan live in [`storyengine/prds/onboarding-ux-audit-2026-04-17.md`](./storyengine/prds/onboarding-ux-audit-2026-04-17.md).
- This PR ships the **P0 fixes** — frontend-only, no backend changes, no breaking API contracts.
- P1 + P2 items tracked in the PRD + Command Center for follow-up PRs.

## What's in here

**PRD** — full audit report with per-step issue inventory, severity-ranked fixes, and acceptance-criteria test plan.

**P0 fixes:**

1. **Error sanitization.** New `src/lib/errors.ts::humanizeError()` maps raw fetch failures like `"Failed to fetch"` and `"API error 500: <body>"` to friendly copy. Wired into `handleSaveChannel` + `handleGenerateStyle`. Raw errors still hit `console.warn` for dev diagnosis.
2. **Network-health banner.** If `getOnboardingStatus()` fails on mount, render a gold banner at the top of Step 1 ("We couldn't load your progress…") instead of silently landing the user on an empty form.
3. **De-brand Step 1 + Step 5 placeholders.** Replaced `"e.g., Economy FastForward"`, the busy-professional audience example, and the US-dollar / geopolitical-implications topic examples with neutral copy so non-economy creators don't feel the product isn't for them.
4. **"(optional)" affordances.** Niche + Audience were already optional per the button gate but UI didn't say so. Added to labels.
5. **Stronger `ActionButton` disabled state.** Was `opacity-50` over saturated turquoise on dark bg → still looked clickable. Now `opacity-40 + grayscale + cursor-not-allowed + pointer-events-none`, plus `enabled:hover:brightness-110` so hover doesn't override disabled. Also added `aria-disabled`.
6. **Icon 404 cleanup.** `public/manifest.json` + `app/layout.tsx` referenced `icon-192.png` / `icon-512.png` that don't exist in `public/` (only `icon-192.svg` does). Repointed to the SVG and added explicit `<link rel="icon">` so browsers stop 404ing `/favicon.ico` on every page.

**Test spec** — new `tests/onboarding.spec.ts` covers all 6 acceptance criteria from the PRD. Stubs backend via `page.route()` so it runs offline and deterministically.

## Out of scope (tracked in PRD)

- **Step 2:** Partial-save, password visual toggle, explicit key-test success/failure copy
- **Step 3:** Clarifying "what does 'style' mean" copy + generation ETA
- **Step 4:** YouTube OAuth cancellation error handler, scope explainer
- **Step 5:** "Creating your video…" intermediate state before pipeline redirect
- Cross-cutting: URL `?step=` deep-linking, accessibility sweep

## Test plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] Playwright MCP live: banner, placeholders, "(optional)" labels, grayscale disabled button all render (before/after screenshots in `.playwright-mcp/`)
- [ ] `npx playwright test onboarding.spec.ts` against this branch (see new AC-1…AC-6)
- [ ] Manual smoke: walk steps with real backend + valid credentials
- [ ] Manual smoke: walk steps with backend down — confirm banner renders + errors are human-readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)