### PR TITLE
feat(onboarding): make Whisper optional (captions are nice-to-have)

### DIFF
--- a/storyengine/backend/routes/dashboard.py
+++ b/storyengine/backend/routes/dashboard.py
@@ -189,13 +189,16 @@ async def get_onboarding_status(tenant_id: str = Depends(get_tenant_id)):
         )
     channel_configured = bool(cp and cp.get("channel_name"))
 
-    # Step 2: count configured API keys (5 required)
+    # Step 2: count configured API keys. Keep this list in sync with
+    # `PIPELINE_REQUIRED_KEYS` in routes/pipeline.py — removing a key here
+    # without removing it there (or vice versa) will drift the onboarding
+    # gate from the readiness gate. `openai_api_key` is intentionally NOT
+    # here: Whisper powers captions, which are opt-in rather than core.
     required_keys = [
         "anthropic_api_key",
         "elevenlabs_api_key",
         "elevenlabs_voice_id",
         "kie_ai_api_key",
-        "openai_api_key",
     ]
     configured_count = 0
     for key_name in required_keys:
@@ -231,14 +234,18 @@ async def get_onboarding_status(tenant_id: str = Depends(get_tenant_id)):
     )
     display_name = (account_row.get("display_name") or "") if account_row else ""
 
-    # Completion: channel + all 5 keys + first video (style + YouTube are optional)
-    completed = channel_configured and configured_count == 5 and first_video_created
+    # Completion: channel + all required keys + first video (style + YouTube are optional)
+    completed = (
+        channel_configured
+        and configured_count == len(required_keys)
+        and first_video_created
+    )
 
     # Progress out of 5 required + optional steps
     done = 1  # account_created always true
     if channel_configured:
         done += 1
-    if configured_count == 5:
+    if configured_count == len(required_keys):
         done += 1
     if style_generated:
         done += 1
@@ -251,7 +258,7 @@ async def get_onboarding_status(tenant_id: str = Depends(get_tenant_id)):
         "steps": {
             "account_created": True,
             "channel_configured": channel_configured,
-            "api_keys": {"configured": configured_count, "required": 5},
+            "api_keys": {"configured": configured_count, "required": len(required_keys)},
             "style_generated": style_generated,
             "youtube_connected": youtube_connected,
             "first_video_created": first_video_created,

--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -55,11 +55,11 @@ PIPELINE_REQUIRED_KEYS = [
     {"key": "elevenlabs_api_key", "label": "ElevenLabs API Key", "reason": "Voice narration synthesis", "url": "https://elevenlabs.io"},
     {"key": "elevenlabs_voice_id", "label": "ElevenLabs Voice ID", "reason": "Voice selection for narration", "url": "https://elevenlabs.io"},
     {"key": "kie_ai_api_key", "label": "Kie.ai", "reason": "Image and video generation", "url": "https://kie.ai"},
-    {"key": "openai_api_key", "label": "OpenAI (Whisper)", "reason": "Audio transcription for captions", "url": "https://platform.openai.com"},
 ]
 
 PIPELINE_OPTIONAL_KEYS = [
-    {"key": "gemini_api_key", "label": "Gemini (optional)", "reason": "Thumbnail analysis — skipped without this", "url": "https://aistudio.google.com"},
+    {"key": "openai_api_key", "label": "OpenAI (Whisper)", "reason": "Audio transcription for captions — pipeline still runs without it", "url": "https://platform.openai.com"},
+    {"key": "gemini_api_key", "label": "Gemini", "reason": "Thumbnail analysis — skipped without this", "url": "https://aistudio.google.com"},
 ]
 
 


### PR DESCRIPTION
## Summary

Confirmed live against the real account in the full-stack local walkthrough: Step 2 "Tools" blocked advance because OpenAI (Whisper) was in the required set even when Anthropic + ElevenLabs + Kie.ai were all connected. Per product call from Ryan — captions via Whisper are opt-in, not core — the pipeline produces videos without them.

## What changed

- `backend/routes/pipeline.py` — moved `openai_api_key` from `PIPELINE_REQUIRED_KEYS` → `PIPELINE_OPTIONAL_KEYS`. `/api/pipeline/readiness` now returns 4 required (Anthropic, ElevenLabs key + voice id, Kie.ai); Whisper shows up in `warnings` alongside Gemini.
- `backend/routes/dashboard.py` — removed `openai_api_key` from the `required_keys` list used by `/api/dashboard/onboarding/status`. Replaced all three hard-coded `5` checks with `len(required_keys)` so future drift is impossible. Added a comment pinning the list in sync with `pipeline.py`.

## Why no frontend changes

`ApiKeysStep` reads `keys` from the readiness response directly — Whisper simply disappears from the Step 2 gate. `configuredCount === total` unlocks "Continue" at 4/4 without any UI logic change.

Users who want captions later can add an OpenAI key in `Settings → Keys`; the pipeline skips the caption stage gracefully when the key is absent.

## Verified live

```
GET /api/dashboard/onboarding/status
  → api_keys: {configured: 4, required: 4}

GET /api/pipeline/readiness
  → ready=true, missing=0, configured=4, warnings=2 (Whisper + Gemini)
```

Ryan's real account was previously stuck at Step 2 (4/5 connected) — with this change it reports `completed=true` and `/onboarding` correctly redirects to `/dashboard`.

## Closes

- fix-roadmap 2.1 (partial — gate softened; full partial-save/come-back-later flow still queued)
- Command Center: "SE fix-roadmap 2.1 — Soften Whisper hard-gate (CONFIRMED LIVE)"

## Test plan

- [x] Backend endpoints verified with curl (responses above)
- [x] Redirect-to-dashboard verified in Playwright against the authed dev tenant
- [ ] Full end-to-end onboarding walk as a fresh test user (separate follow-up — requires account reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)