### PR TITLE
feat(onboarding): welcome screen between signup and Step 1

### DIFF
--- a/storyengine/frontend/src/app/onboarding/page.tsx
+++ b/storyengine/frontend/src/app/onboarding/page.tsx
@@ -20,7 +20,10 @@ import { StyleSetupStep } from "@/components/onboarding/StyleSetupStep";
 import { ApiKeysStep } from "@/components/onboarding/ApiKeysStep";
 import { YouTubeConnectStep } from "@/components/onboarding/YouTubeConnectStep";
 import { CreateVideoStep } from "@/components/onboarding/CreateVideoStep";
+import { WelcomeStep } from "@/components/onboarding/WelcomeStep";
 import { Check, User, Palette, Key, Youtube, Film } from "lucide-react";
+
+const WELCOME_SEEN_KEY = "onboarding_welcome_seen";
 
 // Single unified step sequence — no branching
 const STEPS = [
@@ -45,6 +48,11 @@ function OnboardingContent() {
   const [loading, setLoading] = useState(true);
   const [step, setStep] = useState(0);
   const [displayName, setDisplayName] = useState("");
+
+  // Welcome-screen gate. Renders once per browser on the very first landing
+  // in step 0. Skipped automatically if onboarding auto-advanced (user already
+  // did Step 1 on a prior session) or if localStorage says they've seen it.
+  const [showWelcome, setShowWelcome] = useState(false);
 
   // Channel state
   const [channelName, setChannelName] = useState("");
@@ -88,13 +96,24 @@ function OnboardingContent() {
         // Auto-advance past completed steps (order: channel → keys → style → youtube → video)
         const s = status.steps;
         const keysComplete = s.api_keys.configured === s.api_keys.required;
+        let landedStep = 0;
         if (s.channel_configured && keysComplete && s.style_generated) {
-          setStep(3); // YouTube step
+          landedStep = 3; // YouTube step
         } else if (s.channel_configured && keysComplete) {
-          setStep(2); // Style step
+          landedStep = 2; // Style step
         } else if (s.channel_configured) {
-          setStep(1); // Keys step
+          landedStep = 1; // Keys step
           loadApiKeys();
+        }
+        if (landedStep > 0) setStep(landedStep);
+
+        // Show the welcome screen only for a genuinely fresh-landing user:
+        // they haven't started Step 1 yet, and haven't seen the welcome on
+        // this browser. Skip when auto-advance sent them past Step 1.
+        if (landedStep === 0 && typeof window !== "undefined") {
+          const alreadySeen =
+            window.localStorage.getItem(WELCOME_SEEN_KEY) === "1";
+          if (!alreadySeen) setShowWelcome(true);
         }
       })
       .catch(() => {
@@ -263,10 +282,30 @@ function OnboardingContent() {
     handleNext();
   }
 
+  function handleDismissWelcome() {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(WELCOME_SEEN_KEY, "1");
+    }
+    setShowWelcome(false);
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <Spinner />
+      </div>
+    );
+  }
+
+  // Welcome screen renders on its own, without the stepper — it's the hug
+  // right after signup, before the first form shows up.
+  if (showWelcome) {
+    return (
+      <div className="flex items-center justify-center min-h-screen px-4 py-12">
+        <WelcomeStep
+          displayName={displayName}
+          onContinue={handleDismissWelcome}
+        />
       </div>
     );
   }

--- a/storyengine/frontend/src/components/onboarding/WelcomeStep.tsx
+++ b/storyengine/frontend/src/components/onboarding/WelcomeStep.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Film, Key, Palette, User, Youtube } from "lucide-react";
+import { GlassCard } from "@/components/ui/GlassCard";
+import { ActionButton } from "@/components/ui/ActionButton";
+
+const PIPELINE_PREVIEW = [
+  { icon: User, label: "Channel" },
+  { icon: Key, label: "Tools" },
+  { icon: Palette, label: "Style" },
+  { icon: Youtube, label: "YouTube" },
+  { icon: Film, label: "First Video" },
+];
+
+interface WelcomeStepProps {
+  displayName: string;
+  onContinue: () => void;
+}
+
+function firstNameFromDisplay(name: string): string {
+  const first = name.trim().split(/\s+/)[0] || "";
+  return first || "there";
+}
+
+export function WelcomeStep({ displayName, onContinue }: WelcomeStepProps) {
+  const firstName = firstNameFromDisplay(displayName);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+      className="w-full max-w-lg mx-auto"
+    >
+      <GlassCard className="flex flex-col gap-8 py-10 px-6 sm:px-10 text-center">
+        <div className="flex flex-col gap-3">
+          <motion.h1
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, delay: 0.05 }}
+            className="text-2xl sm:text-3xl font-semibold font-body"
+            style={{ color: "var(--text-primary)" }}
+          >
+            Hey {firstName} <span aria-hidden>👋</span>
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, delay: 0.15 }}
+            className="text-sm sm:text-base font-body"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            5 quick steps and you&apos;ll have your first AI-produced video. Here&apos;s the path:
+          </motion.p>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.25 }}
+          className="flex items-center justify-between gap-1 sm:gap-2"
+          aria-label="Onboarding steps"
+        >
+          {PIPELINE_PREVIEW.map((s) => {
+            const Icon = s.icon;
+            return (
+              <div
+                key={s.label}
+                className="flex flex-col items-center gap-1.5 min-w-0 flex-1"
+              >
+                <div
+                  className="w-9 h-9 sm:w-10 sm:h-10 rounded-full flex items-center justify-center"
+                  style={{
+                    background: "rgba(0, 212, 170, 0.08)",
+                    border: "1px solid rgba(0, 212, 170, 0.25)",
+                    color: "var(--turquoise)",
+                  }}
+                >
+                  <Icon size={16} />
+                </div>
+                <span
+                  className="text-[9px] sm:text-[10px] font-mono uppercase tracking-wider truncate w-full text-center"
+                  style={{ color: "var(--text-tertiary)" }}
+                >
+                  {s.label}
+                </span>
+              </div>
+            );
+          })}
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.45, delay: 0.35 }}
+          className="flex flex-col items-center gap-2"
+        >
+          <ActionButton onClick={onContinue}>
+            Let&apos;s go →
+          </ActionButton>
+          <p
+            className="text-xs font-body"
+            style={{ color: "var(--text-tertiary)" }}
+          >
+            Takes about 15 minutes. You can pause and come back anytime.
+          </p>
+        </motion.div>
+      </GlassCard>
+    </motion.div>
+  );
+}

--- a/storyengine/frontend/tests/onboarding.spec.ts
+++ b/storyengine/frontend/tests/onboarding.spec.ts
@@ -133,4 +133,46 @@ test.describe("Onboarding UX — PRD acceptance criteria", () => {
     expect(resp.status(), `icon fetch status=${resp.status()}`).toBeGreaterThanOrEqual(200);
     expect(resp.status()).toBeLessThan(300);
   });
+
+  test("AC-W1: fresh user (no welcome-seen flag) sees the welcome screen with display name", async ({ page }) => {
+    await stubBackend(page);
+    // No localStorage seed — page starts with a clean slate.
+    await page.goto("/onboarding");
+
+    await expect(page.getByRole("heading", { name: /Hey\s+Test/ })).toBeVisible();
+    await expect(page.getByText(/5 quick steps/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Let.?s go/i })).toBeVisible();
+    await expect(page.getByText(/takes about 15 minutes/i)).toBeVisible();
+  });
+
+  test("AC-W2: clicking Let's go dismisses welcome, lands on Step 1, and persists the flag", async ({ page }) => {
+    await stubBackend(page);
+    await page.goto("/onboarding");
+
+    await page.getByRole("button", { name: /Let.?s go/i }).click();
+
+    await expect(page.getByRole("heading", { name: "Your Channel" })).toBeVisible();
+
+    const flag = await page.evaluate(() =>
+      window.localStorage.getItem("onboarding_welcome_seen"),
+    );
+    expect(flag).toBe("1");
+  });
+
+  test("AC-W3: returning user with welcome-seen flag skips welcome and lands on Step 1 directly", async ({ page }) => {
+    await stubBackend(page);
+
+    // Seed localStorage before the app mounts. We need a context reload after
+    // seeding because localStorage is per-origin and set via addInitScript
+    // applies to subsequent navigations.
+    await page.addInitScript(() => {
+      window.localStorage.setItem("onboarding_welcome_seen", "1");
+    });
+
+    await page.goto("/onboarding");
+
+    await expect(page.getByRole("heading", { name: "Your Channel" })).toBeVisible();
+    // Welcome heading must not render.
+    await expect(page.getByRole("heading", { name: /Hey\s+/ })).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary

Addresses the #1 finding from the onboarding user-feel walkthrough: the silent transition from *Create Account* → Step 1 misses the warmest, highest-attention moment we'll ever have with a new user. They just handed us their email and password — and we meet them with another form.

This PR adds a brief welcome screen between signup and Step 1.

## What the user sees

> **Hey Ryan 👋**
> 5 quick steps and you'll have your first AI-produced video. Here's the path:
>
> [Channel]  [Tools]  [Style]  [YouTube]  [First Video]
>
> [Let's go →]
>
> *Takes about 15 minutes. You can pause and come back anytime.*

Shown once per browser on the very first `/onboarding` landing. Skipped automatically if auto-advance sent them past Step 1 (they already started onboarding on a prior session), or if they've already dismissed it.

## Why it works

- **Personal greeting.** First-name greeting immediately after signup answers *"does this thing know who I am?"*
- **5-step preview.** Same icons as the in-flow stepper, so when Step 1 renders the visual language is already familiar.
- **Time expectation.** "Takes about 15 minutes" answers the unspoken *"how long is this going to be"* anxiety before it can stall the user.
- **"You can pause and come back anytime."** Removes the *"am I committed now?"* feeling before it appears.

## What's in the PR

- `components/onboarding/WelcomeStep.tsx` — new component. framer-motion staggered reveal, 5-icon preview matching the in-flow stepper, reuses the existing `ActionButton` + `GlassCard` primitives.
- `app/onboarding/page.tsx` — new `showWelcome` gate, `handleDismissWelcome()` writes `onboarding_welcome_seen` to localStorage. Auto-advance logic refactored to compute `landedStep` first so the gate can cleanly check *"did auto-advance send us past Step 1?"* and skip the welcome when so.
- `tests/onboarding.spec.ts` — three new acceptance criteria (AC-W1 fresh-user greeting, AC-W2 dismiss lands Step 1 + persists, AC-W3 returning user skips).

## Verified live

Full-stack local (frontend :3001, backend :8001 via SSH tunnel to Supabase). Signed up as `ryan.ayler+welcome@gmail.com` and walked the transition:
- Welcome renders after account creation (screenshots in `.playwright-mcp/`)
- "Let's go →" dismisses and Step 1 "Your Channel" renders in its place
- Reload after dismissal skips welcome and lands directly on Step 1
- `localStorage.onboarding_welcome_seen === "1"` persists correctly

`npx tsc --noEmit` passes clean.

## Out of scope (tracked in Command Center)

- Onboarding FEEL #2: Step 2 cost expectations + partial-save + format hints
- Onboarding FEEL #3: niche-aware topic suggestions on Step 5
- Google OAuth on signup
- `/signup` route vs. `/login` URL split

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Playwright MCP live: welcome renders, dismisses, persists
- [x] Auto-advance path: returning partial-onboarding user skips welcome
- [ ] `npx playwright test onboarding.spec.ts` run against this branch (spec is in, but I didn't install browsers + run the full suite from CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)