### PR TITLE
feat(onboarding): Step 2 polish + Step 5 niche-aware starter chips

### DIFF
--- a/storyengine/frontend/src/app/onboarding/page.tsx
+++ b/storyengine/frontend/src/app/onboarding/page.tsx
@@ -8,6 +8,7 @@ import {
   testApiKey,
   getOnboardingStatus,
   getReadinessStatus,
+  getChannelProfile,
   generateSystemPrompts,
   getYouTubeConnectUrl,
   getYouTubeStatus,
@@ -106,6 +107,24 @@ function OnboardingContent() {
           loadApiKeys();
         }
         if (landedStep > 0) setStep(landedStep);
+
+        // Hydrate local form state from the server when the user returns
+        // mid-flow (auto-advance landed them past Step 1). Without this,
+        // downstream surfaces that key off local state — niche-aware Step
+        // 5 starter chips, for example — have nothing to work with.
+        if (s.channel_configured) {
+          getChannelProfile()
+            .then((cp) => {
+              if (cp.channel_name) setChannelName((prev) => prev || cp.channel_name);
+              if (cp.niche) setNiche((prev) => prev || cp.niche);
+              if (cp.target_audience) {
+                setAudience((prev) => prev || cp.target_audience);
+              }
+            })
+            .catch(() => {
+              // Non-blocking — worst case the user sees generic starters.
+            });
+        }
 
         // Show the welcome screen only for a genuinely fresh-landing user:
         // they haven't started Step 1 yet, and haven't seen the welcome on
@@ -441,6 +460,7 @@ function OnboardingContent() {
 
           {currentStepKey === "video" && (
             <CreateVideoStep
+              niche={niche}
               onComplete={() => {
                 // Redirect handled inside CreateVideoStep
               }}

--- a/storyengine/frontend/src/components/onboarding/ApiKeysStep.tsx
+++ b/storyengine/frontend/src/components/onboarding/ApiKeysStep.tsx
@@ -1,12 +1,27 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Check, Circle, ExternalLink } from "lucide-react";
+import { Check, Circle, ExternalLink, Eye, EyeOff } from "lucide-react";
 import { useState } from "react";
 import { GlassCard } from "@/components/ui/GlassCard";
 import { ActionButton } from "@/components/ui/ActionButton";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
+
+// Format hints per provider — gives users a visual template so they can
+// eyeball a paste before submitting. Keys not in this map fall back to the
+// generic "Paste your API key..." placeholder.
+const KEY_FORMAT_HINTS: Record<string, string> = {
+  anthropic_api_key: "sk-ant-xxxxxxxxxxxxxxxx…",
+  elevenlabs_api_key: "sk_xxxxxxxxxxxxxxxx…",
+  elevenlabs_voice_id: "e.g. 21m00Tcm4TlvDq8ikWAM",
+  kie_ai_api_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  openai_api_key: "sk-proj-xxxxxxxxxxxxxxxx…",
+  gemini_api_key: "AIzaxxxxxxxxxxxxxxxxxxxx…",
+};
+
+// Keys that are public identifiers, not secrets — shouldn't be masked.
+const UNMASKED_KEYS = new Set<string>(["elevenlabs_voice_id"]);
 
 interface ApiKeyConfig {
   key: string;
@@ -37,6 +52,10 @@ function KeyRow({
   const [saving, setSaving] = useState(false);
   const [connected, setConnected] = useState(config.configured);
   const [error, setError] = useState<string | null>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  const isMasked = !UNMASKED_KEYS.has(config.key) && !revealed;
+  const placeholder = KEY_FORMAT_HINTS[config.key] ?? "Paste your API key…";
 
   async function handleSave() {
     if (!value.trim()) return;
@@ -132,19 +151,41 @@ function KeyRow({
           transition={{ duration: 0.2 }}
           className="flex items-center gap-2 pt-1"
         >
-          <input
-            type="password"
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            placeholder="Paste your API key..."
-            className={cn(
-              "flex-1 rounded-lg border bg-[var(--bg-void)] px-3 py-1.5 text-sm",
-              "placeholder:text-[var(--text-secondary)]/50",
-              "focus:border-[var(--accent)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)]",
-              "border-[var(--border)]"
+          <div className="relative flex-1">
+            <input
+              type={isMasked ? "password" : "text"}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={placeholder}
+              aria-label={`${config.label} value`}
+              className={cn(
+                "w-full rounded-lg border bg-[var(--bg-void)] px-3 py-1.5 text-sm",
+                "placeholder:text-[var(--text-secondary)]/50",
+                "focus:border-[var(--accent)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)]",
+                "border-[var(--border)]",
+                // Leave room on the right for the eye toggle when it renders.
+                !UNMASKED_KEYS.has(config.key) && "pr-9"
+              )}
+              disabled={saving}
+            />
+            {!UNMASKED_KEYS.has(config.key) && (
+              <button
+                type="button"
+                onClick={() => setRevealed((v) => !v)}
+                aria-label={revealed ? "Hide key" : "Show key"}
+                aria-pressed={revealed}
+                disabled={saving}
+                className={cn(
+                  "absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded",
+                  "text-[var(--text-secondary)] hover:text-[var(--text-primary)]",
+                  "focus:outline-none focus:ring-1 focus:ring-[var(--accent)]",
+                  "disabled:opacity-40 disabled:cursor-not-allowed"
+                )}
+              >
+                {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
             )}
-            disabled={saving}
-          />
+          </div>
           <ActionButton
             onClick={handleSave}
             disabled={!value.trim() || saving}
@@ -200,6 +241,13 @@ export function ApiKeysStep({
           >
             These API keys power your video pipeline. Each service handles a
             different part.
+          </p>
+          <p
+            className="text-xs font-body mt-2"
+            style={{ color: "var(--text-tertiary)" }}
+          >
+            BYOK — you pay providers directly. Weekly cadence runs ~$15–30/mo
+            across all four.
           </p>
         </div>
 

--- a/storyengine/frontend/src/components/onboarding/ChannelIdentityStep.tsx
+++ b/storyengine/frontend/src/components/onboarding/ChannelIdentityStep.tsx
@@ -74,13 +74,21 @@ export function ChannelIdentityStep({
           required
         />
 
-        <Select
-          label="What topics will you cover? (optional)"
-          options={nicheOptions}
-          value={niche}
-          onChange={(e) => onChange("niche", e.target.value)}
-          placeholder="Select a niche..."
-        />
+        <div className="flex flex-col gap-1">
+          <Select
+            label="What topics will you cover? (optional)"
+            options={nicheOptions}
+            value={niche}
+            onChange={(e) => onChange("niche", e.target.value)}
+            placeholder="Select a niche..."
+          />
+          <p
+            className="text-xs font-body"
+            style={{ color: "var(--text-tertiary)" }}
+          >
+            We&apos;ll tune your scripts and visuals to this.
+          </p>
+        </div>
 
         <Textarea
           label="Who are you making videos for? (optional)"

--- a/storyengine/frontend/src/components/onboarding/CreateVideoStep.tsx
+++ b/storyengine/frontend/src/components/onboarding/CreateVideoStep.tsx
@@ -14,14 +14,95 @@ import {
   type TitleSuggestion,
 } from "@/lib/api";
 
+// Starter topics per niche — the user just spent 4 steps setting up; asking
+// them to invent a topic cold on Step 5 is blank-page cruelty. When the
+// topic field is empty we surface 3 starters tuned to their declared niche
+// from Step 1. They're prompts, not final titles — one click fills the
+// textarea, they can edit, then Suggest Titles or Use as Title as usual.
+//
+// Keys match `ChannelIdentityStep.tsx::nicheOptions` values.
+const TOPIC_STARTERS_BY_NICHE: Record<string, string[]> = {
+  economy_finance: [
+    "How the Fed's latest move affects your wallet",
+    "3 recession signals hiding in plain sight",
+    "What rising treasury yields mean for everyday Americans",
+  ],
+  technology: [
+    "Why the latest AI announcement actually matters",
+    "The state of open-source agent frameworks in 2026",
+    "5 hidden features in a tool you already use",
+  ],
+  science: [
+    "How a phenomenon you see every day actually works",
+    "The truth about a science myth you've heard a hundred times",
+    "A recent discovery that could reshape its field",
+  ],
+  health_wellness: [
+    "5 mobility drills to do while you drink coffee",
+    "How to actually read a nutrition label",
+    "The truth about a supplement everyone's taking",
+  ],
+  history: [
+    "The real story behind an event textbooks skim",
+    "5 things pop culture got wrong about a famous era",
+    "A historical figure we forgot — and why we shouldn't have",
+  ],
+  politics: [
+    "What a new bill actually does (in plain English)",
+    "The history behind a modern political fight",
+    "How a federal institution really works — no spin",
+  ],
+  education: [
+    "How to learn a new skill in 30 days",
+    "3 myths about a subject you were taught wrong",
+    "5 free resources that beat most paid courses",
+  ],
+  entertainment: [
+    "Why a recent hit actually works",
+    "The best scenes in a genre you love",
+    "Hidden themes in a show everyone's watching",
+  ],
+  sports: [
+    "How to read advanced stats without the jargon",
+    "Why an underrated team is about to break out",
+    "The truth about a long-running sports myth",
+  ],
+  cooking: [
+    "5 quick weeknight dinners under $15",
+    "How to season a cast iron once and for all",
+    "Pantry staples every home cook needs",
+  ],
+  travel: [
+    "Hidden gems in a region everyone visits wrong",
+    "How to plan a week abroad on a budget",
+    "Mistakes first-time travelers make (and how to avoid them)",
+  ],
+  gaming: [
+    "Every new player in a popular game should know this",
+    "Why a core mechanic everyone argues about is broken",
+    "The best starter build nobody talks about",
+  ],
+};
+
+// Fallback for "other" / niche-skipped users. Deliberately generic but
+// still shaped like real video concepts so the chip isn't wasted space.
+const GENERIC_TOPIC_STARTERS = [
+  "The one thing everyone gets wrong about my topic",
+  "5 things you're probably doing wrong",
+  "How I accomplished something in 30 days",
+];
+
 interface CreateVideoStepProps {
   onComplete: (videoId: string) => void;
+  niche?: string;
 }
 
-export function CreateVideoStep({ onComplete }: CreateVideoStepProps) {
+export function CreateVideoStep({ onComplete, niche }: CreateVideoStepProps) {
   const router = useRouter();
   const [innerStep, setInnerStep] = useState(1);
   const [topic, setTopic] = useState("");
+  const starters =
+    (niche && TOPIC_STARTERS_BY_NICHE[niche]) || GENERIC_TOPIC_STARTERS;
   const [selectedTitle, setSelectedTitle] = useState("");
   const [suggestions, setSuggestions] = useState<TitleSuggestion[] | null>(null);
   const [suggestLoading, setSuggestLoading] = useState(false);
@@ -126,6 +207,43 @@ export function CreateVideoStep({ onComplete }: CreateVideoStepProps) {
                 onBlur={(e) => (e.target.style.borderColor = "var(--border)")}
                 autoFocus
               />
+
+              <AnimatePresence>
+                {!topic.trim() && starters.length > 0 && (
+                  <motion.div
+                    key="starters"
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.2 }}
+                    className="flex flex-col gap-2 overflow-hidden"
+                  >
+                    <p
+                      className="text-xs font-body"
+                      style={{ color: "var(--text-tertiary)" }}
+                    >
+                      Or start with one of these:
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {starters.map((starter, i) => (
+                        <button
+                          key={i}
+                          type="button"
+                          onClick={() => setTopic(starter)}
+                          className="text-left text-xs font-body px-3 py-1.5 rounded-full border transition-all hover:brightness-110"
+                          style={{
+                            background: "rgba(0, 212, 170, 0.06)",
+                            borderColor: "rgba(0, 212, 170, 0.25)",
+                            color: "var(--text-secondary)",
+                          }}
+                        >
+                          {starter}
+                        </button>
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
 
               <div className="flex gap-2">
                 <button


### PR DESCRIPTION
## Summary

Ships **Feel #2** (Step 2 drop-off cliff) and **Feel #3** (Step 5 blank-page-at-the-finish-line) from the onboarding UX walkthrough. Purely frontend, no backend changes, no shape changes to existing APIs.

## Step 2 — "Tools"

The drop-off cliff. Users land here after 5 min of setup and see 4 "Configure" buttons with no cost info, jargon labels, and a password field they can't visually verify. Four tweaks:

- **Cost line** under the heading: *"BYOK — you pay providers directly. Weekly cadence runs ~$15–30/mo across all four."* Answers the silent $$$ anxiety.
- **Per-provider placeholder hints** — `sk-ant-xxxxxxxxxxxxxxxx…`, `sk_xxxxxxxxxxxxxxxx…`, `e.g. 21m00Tcm4TlvDq8ikWAM`, etc. Users can eyeball a paste before hitting Save.
- **👁 Eye-icon visibility toggle** on every masked input. Click to reveal, click to hide. `aria-pressed` + `aria-label` for screen readers.
- **ElevenLabs Voice ID is no longer masked.** It's a public identifier, not a secret. Rendered as `type="text"` with a realistic example placeholder.

## Step 1 — "Channel"

- **Niche helper text** under the dropdown: *"We'll tune your scripts and visuals to this."* Answers "why am I being asked this?" without an info-popover.

## Step 5 — "First Video"

Was a blank textarea after 15 min of setup. Blank-page dread at the exact moment you want the user to feel excited. Now:

- **Niche-aware starter chips** render under the textarea when it's empty — 3 starters per niche (cooking, economy_finance, gaming, travel, history, etc.), plus a generic fallback for "other" / skipped-niche users.
- Clicking a chip populates the textarea, the chip row animates out, Suggest Titles + Use as Title light up.
- **Local-state hydration fix:** returning users who auto-advance past Step 1 now get their `niche` / `channelName` / `target_audience` pulled from `/api/channel-profile` on mount — so niche-tuned starters actually work for them too, not just fresh signups.

## What's in the code

- `components/onboarding/ApiKeysStep.tsx` — `KEY_FORMAT_HINTS` map, `UNMASKED_KEYS` set, eye-icon toggle button, cost line in the header copy.
- `components/onboarding/ChannelIdentityStep.tsx` — niche helper paragraph.
- `components/onboarding/CreateVideoStep.tsx` — `TOPIC_STARTERS_BY_NICHE` + `GENERIC_TOPIC_STARTERS` maps, `niche` prop, chip row with framer-motion reveal.
- `app/onboarding/page.tsx` — `getChannelProfile()` import + hydration in the onboarding status `useEffect`, `niche` prop passed through to `CreateVideoStep`.

## Verified live

Full-stack local. Walked as a fresh cooking-niche creator:
- Step 1: niche helper text reads *"We'll tune your scripts and visuals to this."* ✅
- Step 2: cost line, `sk-ant-…` placeholder, eye icon on Anthropic; Voice ID plain-text with a real example; Save & Test stays grayscale-disabled on empty ✅
- Step 5: cooking chips render (*"5 quick weeknight dinners under $15"*, etc.); click → textarea populated, chips animate out, Suggest/Use as Title buttons light up ✅
- Auto-advance hydration path tested by seeding the DB directly — niche carries through ✅

`npx tsc --noEmit` passes clean.

## Out of scope (tracked for next PRs)

- Partial-save "I'll finish in Settings later" escape hatch on Step 2 (needs backend — new task on the board)
- Collapse ElevenLabs API Key + Voice ID into one card (non-trivial refactor — new task on the board)
- Replace static chips with backend-generated suggestions once we have a topic-suggest endpoint

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Playwright MCP live: cost line, format hints, eye toggle, voice-id unmasked, chips-by-niche, click-to-populate, hydration on auto-advance
- [ ] `npx playwright test onboarding.spec.ts` — existing specs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)