### PR TITLE
feat(onboarding): Step 2 partial-save — Skip for now + dashboard Finish-setup banner

### DIFF
--- a/storyengine/frontend/src/app/dashboard/page.tsx
+++ b/storyengine/frontend/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
+import Link from "next/link";
 import {
   Film,
   Eye,
@@ -11,7 +12,14 @@ import {
   Plus,
   ChevronRight,
   CalendarDays,
+  Key,
+  ArrowRight,
 } from "lucide-react";
+
+// Mirrors the key set in `app/onboarding/page.tsx`. Dashboard reads this
+// flag to allow partial-onboarding users into the app (with a Finish
+// setup banner) instead of bouncing them back to /onboarding.
+const STEP2_SKIPPED_KEY = "onboarding_step2_skipped";
 import { GlassCard } from "@/components/ui/GlassCard";
 import { StatCard } from "@/components/ui/StatCard";
 import { StatusPill } from "@/components/ui/StatusPill";
@@ -151,12 +159,31 @@ export default function DashboardPage() {
     return items.slice(0, 6);
   }, [pendingReview]);
 
-  // Redirect to onboarding if not completed
+  // Redirect to onboarding if not completed — UNLESS the user explicitly
+  // clicked "Skip for now" on Step 2. In that case let them into the
+  // dashboard and render a persistent FinishSetupBanner up top so they
+  // can come back on their own time.
+  //
+  // Also clear the skip flag the moment onboarding completes, so the
+  // banner disappears for good.
   useEffect(() => {
-    if (!onboardingLoading && onboarding && !onboarding.completed) {
+    if (onboardingLoading || !onboarding) return;
+    if (onboarding.completed) {
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(STEP2_SKIPPED_KEY);
+      }
+      return;
+    }
+    const skipped =
+      typeof window !== "undefined" &&
+      window.localStorage.getItem(STEP2_SKIPPED_KEY) === "1";
+    if (!skipped) {
       router.replace("/onboarding");
     }
   }, [onboardingLoading, onboarding, router]);
+
+  const showFinishSetupBanner =
+    !!onboarding && !onboarding.completed && !onboardingLoading;
 
   if (summaryLoading || onboardingLoading) {
     return (
@@ -178,6 +205,53 @@ export default function DashboardPage() {
 
   return (
     <motion.div className="space-y-8" variants={container} initial="hidden" animate="show">
+      {showFinishSetupBanner && (
+        <motion.div variants={item}>
+          <Link
+            href="/onboarding"
+            data-testid="finish-setup-banner"
+            className="flex items-center justify-between gap-4 px-5 py-4 rounded-xl transition-all hover:brightness-110"
+            style={{
+              background:
+                "linear-gradient(90deg, rgba(255, 180, 0, 0.08), rgba(0, 212, 170, 0.06))",
+              border: "1px solid rgba(255, 180, 0, 0.35)",
+            }}
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div
+                className="w-9 h-9 rounded-full flex items-center justify-center shrink-0"
+                style={{
+                  background: "rgba(255, 180, 0, 0.12)",
+                  color: "var(--gold)",
+                }}
+              >
+                <Key size={16} />
+              </div>
+              <div className="min-w-0">
+                <p
+                  className="text-sm font-semibold font-body"
+                  style={{ color: "var(--text-primary)" }}
+                >
+                  Finish setting up your account
+                </p>
+                <p
+                  className="text-xs font-body"
+                  style={{ color: "var(--text-secondary)" }}
+                >
+                  Connect your tools so StoryEngine can generate your first video.
+                </p>
+              </div>
+            </div>
+            <div
+              className="flex items-center gap-1 text-xs font-semibold font-body shrink-0"
+              style={{ color: "var(--gold)" }}
+            >
+              Finish setup <ArrowRight size={14} />
+            </div>
+          </Link>
+        </motion.div>
+      )}
+
       {/* Header */}
       <motion.div variants={item} className="flex items-center justify-between">
         <h1 className="text-4xl font-display" style={{ color: "var(--text-primary)" }}>

--- a/storyengine/frontend/src/app/onboarding/page.tsx
+++ b/storyengine/frontend/src/app/onboarding/page.tsx
@@ -25,6 +25,11 @@ import { WelcomeStep } from "@/components/onboarding/WelcomeStep";
 import { Check, User, Palette, Key, Youtube, Film } from "lucide-react";
 
 const WELCOME_SEEN_KEY = "onboarding_welcome_seen";
+// Set when a user clicks "Skip for now" on Step 2. The dashboard reads
+// this to decide between "bounce back to /onboarding" (the strict default)
+// vs. "let them in + show a Finish setup banner" (the escape hatch).
+// Cleared automatically once `onboarding.completed` flips true.
+const STEP2_SKIPPED_KEY = "onboarding_step2_skipped";
 
 // Single unified step sequence — no branching
 const STEPS = [
@@ -308,6 +313,13 @@ function OnboardingContent() {
     setShowWelcome(false);
   }
 
+  function handleSkipOnboardingForNow() {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STEP2_SKIPPED_KEY, "1");
+    }
+    router.replace("/dashboard");
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -442,6 +454,7 @@ function OnboardingContent() {
               onSaveKey={handleSaveApiKey}
               onTestKey={handleTestApiKey}
               onNext={handleNext}
+              onSkipForNow={handleSkipOnboardingForNow}
             />
           )}
 

--- a/storyengine/frontend/src/components/onboarding/ApiKeysStep.tsx
+++ b/storyengine/frontend/src/components/onboarding/ApiKeysStep.tsx
@@ -36,6 +36,11 @@ interface ApiKeysStepProps {
   onSaveKey: (keyName: string, value: string) => Promise<boolean>;
   onTestKey: (keyName: string) => Promise<boolean>;
   onNext: () => void;
+  // Optional escape hatch — when present, a "Skip for now" link renders
+  // below the Continue button. Lets users who don't have all their API
+  // keys handy push into the dashboard and come back later. Parent is
+  // responsible for any flagging + navigation.
+  onSkipForNow?: () => void;
 }
 
 function KeyRow({
@@ -215,6 +220,7 @@ export function ApiKeysStep({
   onSaveKey,
   onTestKey,
   onNext,
+  onSkipForNow,
 }: ApiKeysStepProps) {
   const configuredCount = keys.filter((k) => k.configured).length;
   const total = keys.length;
@@ -285,7 +291,7 @@ export function ApiKeysStep({
           ))}
         </div>
 
-        <div className="flex flex-col items-center gap-3 pt-2">
+        <div className="flex flex-col items-center gap-2 pt-2">
           <ActionButton
             onClick={onNext}
             disabled={configuredCount < total}
@@ -294,6 +300,16 @@ export function ApiKeysStep({
               ? `Connect all ${total} tools to continue`
               : "Continue"}
           </ActionButton>
+          {onSkipForNow && configuredCount < total && (
+            <button
+              type="button"
+              onClick={onSkipForNow}
+              className="text-xs font-body underline-offset-4 hover:underline transition-colors"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              Skip for now — finish later in Settings
+            </button>
+          )}
         </div>
       </GlassCard>
     </motion.div>


### PR DESCRIPTION
## Summary

Step 2's hard-gate ("Connect all 4 tools to continue") is the single biggest drop-off cliff in the funnel. Users who don't have all four API keys ready were stuck. This PR adds an escape hatch without touching the backend.

## What the user sees

**On Step 2 (no keys connected):**
- Primary button: *"Connect all 4 tools to continue"* (still grayscale-disabled — Continue is still the encouraged path)
- New secondary link below: *"Skip for now — finish later in Settings"*

**On click:** localStorage flag → `/dashboard`.

**On the dashboard when onboarding isn't complete:**
- Gold-bordered banner at the top: 🔑 *"Finish setting up your account / Connect your tools so StoryEngine can generate your first video."*
- CTA links to `/onboarding` which auto-advances them right back to Step 2.

## How it works under the hood

- Frontend-only. No schema change, no new endpoint.
- `localStorage.onboarding_step2_skipped = "1"` is the signal. Dashboard's existing "redirect to /onboarding" guard now lets flagged users through.
- Flag auto-clears the first time the dashboard sees `onboarding.completed === true`, so the banner vanishes cleanly once the user actually finishes.
- Partial key data the user already saved on the server is preserved — this PR changes gating, not data.

## Files changed

- `components/onboarding/ApiKeysStep.tsx` — new optional `onSkipForNow` prop. Link renders only when provided AND key count is short of total (Continue still gates the happy path).
- `app/onboarding/page.tsx` — `STEP2_SKIPPED_KEY` constant + `handleSkipOnboardingForNow()` that writes the flag and routes to `/dashboard`. Passed through to `<ApiKeysStep />`.
- `app/dashboard/page.tsx` — redirect guard reads the flag; flag cleared on `completed === true`; new banner rendered as the first element in the main motion container.

## Verified live

Fresh cooking-niche account (channel configured, 0/4 keys, style empty):
- ✅ Skip link appears under the grayscale-disabled Continue button
- ✅ Click → flag written → lands on `/dashboard` without a bounce-back loop
- ✅ Banner renders at top with correct copy + CTA
- ✅ Banner links back into `/onboarding` which auto-advances to Step 2
- ✅ Dashboard content (stats, usage, pipeline distribution, recent videos) all accessible below the banner
- ✅ `npx tsc --noEmit` clean

Screenshots attached in the Telegram thread.

## Out of scope (tracked)

- Backend `onboarding_skipped_at` column for **durable cross-device** skip state. Current flag is per-browser, which is actually fine: partial onboarding is inherently a within-session state. Cross-device durability becomes interesting only if teams want to skip on mobile and finish on desktop, which is a different flow.

## Test plan

- [x] `npx tsc --noEmit`
- [x] Playwright MCP live: skip link → dashboard banner → back to /onboarding → auto-advance to Step 2
- [ ] Full backend-integrated Playwright spec for the partial-save path (future AC-S1/S2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)