### PR TITLE
fix(orchestrator): wire upload skill to executor.run_upload

### DIFF
--- a/storyengine/backend/claude_orchestrator.py
+++ b/storyengine/backend/claude_orchestrator.py
@@ -302,7 +302,7 @@ Respond with a JSON object:
             "video_motion": executor.run_video_scripts,
             "thumbnail": executor.run_thumbnail,
             "render": executor.run_render,
-            "upload": None,  # TODO: add upload method to executor
+            "upload": executor.run_upload,
         }
 
         method = skill_to_method.get(decision.skill_id)


### PR DESCRIPTION
## Summary
- Wires the \`upload\` skill in \`claude_orchestrator.py\` to \`executor.run_upload\` (previously \`None\` with a TODO).
- Closes the one remaining unmapped entry in \`skill_to_method\`.

## Why
The orchestrator dispatches pipeline skills to executor methods. \`run_upload()\` was implemented in \`pipeline_executor.py:2016\` but never hooked into the dispatch table. This surfaced as a silent failure when a pipeline reached the upload stage.

## Shipped via
First spike of the Archon outer harness (\`.archon/workflows/storyengine-fix-issue.yaml\`). Plan → implement → validate (syntax, wiring, functional tests) → human review → draft PR. No autonomous merge.

## Test plan
- [x] Python syntax valid (\`ast.parse\`)
- [x] Grep confirms \`"upload": executor.run_upload,\` is present
- [x] TODO comment removed
- [x] Functional tests pass (\`pytest tests/functional/\`)
- [ ] Manual smoke: trigger an upload skill through the orchestrator on a test video

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Archon