### PR TITLE
feat(queue): migrate run_research to arq job queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ storyengine/                     # Production dashboard (Next.js 16 + FastAPI + 
 │   ├── pipeline_executor.py     # Background task orchestrator
 │   ├── job_queue.py             # arq enqueue abstraction (stage → Redis job)
 │   ├── task_store.py            # db_persist_task() — background_tasks DB writes
-│   └── worker.py                # arq WorkerSettings + 12 stage handlers
+│   └── worker.py                # arq WorkerSettings + stage handlers
 └── schema.sql                   # Canonical DB schema (9 tables, 51+ columns)
 tasks/                           # Task tracking, lessons learned
 ├── todo.md                      # Current tasks + handoffs

--- a/storyengine/backend/job_queue.py
+++ b/storyengine/backend/job_queue.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 # Stage -> arq function name map (must match worker.py handler names)
 _STAGE_HANDLERS: dict[str, str] = {
+    "research":         "arq_run_research",
     "script":           "arq_run_script",
     "voice":            "arq_run_voice",
     "image_prompts":    "arq_run_image_prompts",

--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -361,6 +361,7 @@ async def run_research(
             result = await executor.run_research(video_id)
             _set_task_status(video_id, result.get("status", "unknown"), result.get("error"), tenant_id=tenant_id)
         except Exception as e:
+            logger.exception("[research] fallback task failed video=%s: %s", video_id, e)
             _set_task_status(video_id, "failed", str(e), tenant_id=tenant_id)
         finally:
             await asyncio.sleep(30)

--- a/storyengine/backend/routes/pipeline.py
+++ b/storyengine/backend/routes/pipeline.py
@@ -334,14 +334,15 @@ async def create_idea(
 @router.post("/research/{video_id}", response_model=PipelineResponse)
 async def run_research(
     video_id: str,
+    request: Request,
     background_tasks: BackgroundTasks,
     tenant_id: str = Depends(get_tenant_id),
 ):
     """Run research agent on a video idea.
 
-    Runs in background. Poll /status/{video_id} or check activity feed.
+    Runs in background via arq queue (falls back to BackgroundTasks if Redis unavailable).
+    Poll /status/{video_id} or check activity feed.
     """
-    # Check video exists
     video = await fetch_one(
         "SELECT id, status FROM videos WHERE id = $1 AND tenant_id = $2",
         video_id, tenant_id,
@@ -349,7 +350,6 @@ async def run_research(
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
-    # Check not already running
     if _get_task_status(video_id, tenant_id):
         raise HTTPException(status_code=409, detail="Task already running for this video")
 
@@ -360,38 +360,18 @@ async def run_research(
             executor = PipelineExecutor(tenant_id)
             result = await executor.run_research(video_id)
             _set_task_status(video_id, result.get("status", "unknown"), result.get("error"), tenant_id=tenant_id)
-
-            # Auto-cascade: keep advancing through pipeline steps
-            if result.get("status") != "failed":
-                terminal = {"rendered", "uploaded", "uploaded_draft", "done", "published"}
-                for _ in range(20):  # Safety limit
-                    video = await fetch_one("SELECT status FROM videos WHERE id = $1", video_id)
-                    status = (video or {}).get("status", "")
-                    if status in terminal:
-                        break
-                    _set_task_status(video_id, "running", f"Running: {status}", tenant_id=tenant_id)
-                    step_result = await executor.run_next_step(video_id)
-                    step_status = step_result.get("status", "")
-                    if step_status == "failed":
-                        _set_task_status(video_id, "failed", step_result.get("error"), tenant_id=tenant_id)
-                        break
-                    if step_status in ("needs_approval", "idle"):
-                        _set_task_status(video_id, "completed", step_result.get("message", "Waiting for approval"), tenant_id=tenant_id)
-                        break
-                    _set_task_status(video_id, step_status, tenant_id=tenant_id)
         except Exception as e:
             _set_task_status(video_id, "failed", str(e), tenant_id=tenant_id)
         finally:
-            # Clear after a delay so frontend can poll final status
             await asyncio.sleep(30)
             _clear_task_status(video_id, tenant_id)
 
-    background_tasks.add_task(_run)
+    await _enqueue_or_fallback(request, background_tasks, "research", video_id, tenant_id, _run)
 
     return PipelineResponse(
         video_id=video_id,
         status="running",
-        message="Research started — pipeline will auto-advance through all steps",
+        message="Research started",
     )
 
 

--- a/storyengine/backend/worker.py
+++ b/storyengine/backend/worker.py
@@ -93,6 +93,10 @@ async def _run_stage(
 
 # -- individual stage handlers ------------------------------------------------
 
+async def arq_run_research(ctx: dict, video_id: str, tenant_id: str, attempt: int) -> dict:
+    return await _run_stage(ctx, "research", "run_research", video_id, tenant_id, attempt)
+
+
 async def arq_run_script(ctx: dict, video_id: str, tenant_id: str, attempt: int) -> dict:
     return await _run_stage(ctx, "script", "run_script", video_id, tenant_id, attempt)
 
@@ -155,6 +159,7 @@ class WorkerSettings:
     redis_settings = RedisSettings(host=_redis_host, port=_redis_port)
 
     functions = [
+        func(arq_run_research,         name="arq_run_research",         timeout=3600, max_tries=3),
         func(arq_run_script,           name="arq_run_script",           timeout=3600, max_tries=3),
         func(arq_run_voice,            name="arq_run_voice",            timeout=3600, max_tries=3),
         func(arq_run_image_prompts,    name="arq_run_image_prompts",    timeout=1800, max_tries=3),


### PR DESCRIPTION
## Summary

Migrates the `run_research` pipeline stage from in-process `BackgroundTasks` dispatch to the persistent Redis+arq job queue — making it consistent with all 12 other stage routes and adding crash/restart recovery.

## Changes

- **`storyengine/backend/job_queue.py`** (+1 line): Added `"research": "arq_run_research"` to `_STAGE_HANDLERS` dict
- **`storyengine/backend/worker.py`** (+5 lines): Added `arq_run_research` one-liner handler mirroring `arq_run_script` pattern; registered in `WorkerSettings.functions` with `timeout=3600, max_tries=3`
- **`storyengine/backend/routes/pipeline.py`** (+5/-25 lines):
  - Added `request: Request` parameter (required by `_enqueue_or_fallback`)
  - Replaced `background_tasks.add_task(_run)` with `await _enqueue_or_fallback(request, background_tasks, "research", ...)`
  - Removed legacy 20-iteration auto-cascade loop (`run_next_step()` × 20) — pre-queue architectural debt inconsistent with all other stage routes
  - Updated response message to "Research started" (no longer implies auto-advance)

## Why remove the cascade loop?

The `run_next_step()` × 20 loop was written before the queue existed as a "run everything" shortcut. Every other stage route runs only its own step. With queue architecture, each stage is a discrete job. The UI polls `videos.status` and triggers next stages. Removing the cascade makes research consistent with script, voice, images, etc.

## Validation Evidence

| Check | Result |
|-------|--------|
| Static imports (all 3 modules) | ✅ `all imports ok` |
| `arq_run_research` in `WorkerSettings.functions` | ✅ Confirmed |
| `"research"` in `_STAGE_HANDLERS` | ✅ `arq_run_research` |
| Tenant isolation tests (`test_sse_cross_tenant_lock.py`) | ✅ 4/4 passed |
| Full test suite | ✅ 232 passed, 18 pre-existing failures (unchanged vs main) |

## Recovery Path (After State)

```
POST /api/pipeline/research/{video_id}
       │
       ▼
_enqueue_or_fallback()
  ├─► arq_pool.enqueue_job("arq_run_research", ...)  [PREFERRED — survives restart]
  └─► background_tasks.add_task(_run)               [FALLBACK if Redis unavailable]
```

Worker restart mid-research → arq picks up from Redis → job reaches terminal state without intervention.

## Manual Recovery Test (Acceptance Gate)

Per issue requirements:
1. Trigger research job via API
2. Confirm `background_tasks` row: `pending` → `running`
3. `systemctl restart storyengine-worker` mid-run
4. Verify job resumes and `background_tasks` reaches `completed`
5. Verify `videos.status = 'ready_for_scripting'` and `bot_activity` shows `started` + `completed`

Fixes #395