### PR TITLE
fix(pipeline): repoint 5 stale shim-name imports (pipeline couldn't import)

### DIFF
--- a/skills/video-pipeline/research/agent.py
+++ b/skills/video-pipeline/research/agent.py
@@ -30,7 +30,7 @@ from shared.json_utils import parse_json_response
 
 # Curiosity gap imports (lazy loaded to avoid circular deps at module level)
 if CURIOSITY_GAP_ENABLED:
-    from curiosity_gap.gap_title_engine import GapTitleEngine
+    from title_idea.curiosity_gap.gap_title_engine import GapTitleEngine
     from autopilot.learning.pattern_library import PatternLibrary
 
 logger = logging.getLogger(__name__)

--- a/skills/video-pipeline/script/run.py
+++ b/skills/video-pipeline/script/run.py
@@ -14,7 +14,7 @@ from orchestrator.pipeline_constants import IdeaFields, Statuses
 
 async def run(pipeline, brief: dict = None) -> dict:
     """Generate a script from a research brief."""
-    from brief_translator import translate_brief
+    from script.brief_translator import translate_brief
 
     if not pipeline.current_idea:
         idea = pipeline.get_idea_by_status(Statuses.READY_SCRIPTING)

--- a/skills/video-pipeline/title_idea/cli.py
+++ b/skills/video-pipeline/title_idea/cli.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from dotenv import load_dotenv
 load_dotenv(os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
 
-from curiosity_gap.gap_title_engine import GapTitleEngine
+from title_idea.curiosity_gap.gap_title_engine import GapTitleEngine
 from autopilot.learning.pattern_library import PatternLibrary
 from shared.clients.anthropic_client import AnthropicClient
 from shared.clients.airtable_client import AirtableClient

--- a/skills/video-pipeline/title_idea/idea_bot.py
+++ b/skills/video-pipeline/title_idea/idea_bot.py
@@ -16,7 +16,7 @@ Outputs 3 distinct video concepts with:
 import re
 from typing import Optional
 
-from curiosity_gap.gap_title_engine import GapTitleEngine
+from title_idea.curiosity_gap.gap_title_engine import GapTitleEngine
 from autopilot.learning.pattern_library import PatternLibrary
 from orchestrator.pipeline_constants import CURIOSITY_GAP_ENABLED
 

--- a/skills/video-pipeline/title_idea/trending_idea_bot.py
+++ b/skills/video-pipeline/title_idea/trending_idea_bot.py
@@ -19,7 +19,7 @@ from orchestrator.pipeline_constants import Models, CURIOSITY_GAP_ENABLED
 
 # Curiosity gap imports (lazy loaded to avoid circular deps)
 if CURIOSITY_GAP_ENABLED:
-    from curiosity_gap.gap_title_engine import GapTitleEngine
+    from title_idea.curiosity_gap.gap_title_engine import GapTitleEngine
     from autopilot.learning.pattern_library import PatternLibrary
 
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -321,3 +321,9 @@ _After each session, add a one-line summary of what was done and any new lessons
 - progress.md from PRD 4 had [x] marks for tasks 1-15. When PRD 2 deployed with tasks 1-13, mission-status saw all as done
 - Fix: verify progress.md title matches current PRD before trusting any [x] marks
 - Pattern: Any file that persists across PRD deployments MUST be validated against the current PRD
+
+### Shim-removal refactor left 5 stale imports (pipeline couldn't import) (2026-06-08)
+- Commit 17b03be0 "Remove all shims, update all imports, squeaky clean" deleted the back-compat shim packages (curiosity_gap/, brief_translator/, audio_sync/, etc.) but missed updating 5 imports, leaving `ModuleNotFoundError: No module named 'curiosity_gap.gap_title_engine'` — `orchestrator.pipeline` (and --run-queue/--discover) could not import at all.
+- Missed imports: title_idea/{idea_bot,cli,trending_idea_bot}.py + research/agent.py used `from curiosity_gap.gap_title_engine import ...` (canonical: `title_idea.curiosity_gap.gap_title_engine`); script/run.py used `from brief_translator import ...` (canonical: `script.brief_translator`).
+- Pattern: after a "remove shims + rewrite imports" sweep, grep the WHOLE tree for the old top-level names (`^\s*(from|import)\s+<oldname>`) before trusting it — the leftover empty dirs (only __pycache__/tests) hide that the package is gone. Vestigial dirs without __init__.py are a tell.
+- NOTE: `python -m orchestrator.pipeline` with NO args is NOT a safe smoke test — it instantiates clients and hangs/works; use `python -c "import orchestrator.pipeline"` instead.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -265,3 +265,9 @@ PRD2 Pipeline UX: 12/14 done+verified. T12 (full regression) blocked on T3/T4/T7
 - RUBRIC layout: two-column (queue + activity feed), tasks labeled by PRD
 - Agents use OAuth now (no API key charges)
 - Monitor: check cost page Apr 11 to confirm $0 API charges
+
+## Handoff (2026-06-08 — pipeline import repair + Youtuber agent)
+- **Fixed:** 5 stale shim-name imports left by 17b03be0 — pipeline now imports cleanly again (orchestrator.pipeline + all 5 touched entrypoints verified). Branch `claude/repair-pipeline-imports`. Done in an isolated git worktree (~/yt-repair) to avoid the storyengine dev-swarm's git stash/checkout/reset on the shared tree.
+- **Not done / next:** smoke test was import-only (no paid run). Before relying on production: run a single-video dry pass, and reinstall the setup_cron.sh production jobs (queue/discover/autopilot) — they are NOT in the live crontab (only storyengine/agents swarm + bot_healthcheck).
+- **Separate effort:** standing up a new Hermes agent profile `Youtuber` (~/.hermes/profiles/youtuber) as the YouTube production brain that drives this pipeline; multi-channel generalization planned (ChannelConfig). See ~/Desktop/Power_Doctrine Pipeline-main-integration/HERMES_REBUILD_PLAN.md.
+- **Caution:** `/home/clawd/pipeline-bot/venv` (referenced by infra detect_python) does not exist; live fallback is repo-root `economy-fastforward/venv`.


### PR DESCRIPTION
Commit 17b03be0 removed the back-compat shim packages but missed updating 5 imports, leaving `ModuleNotFoundError: curiosity_gap` so orchestrator.pipeline (--run-queue/--discover) could not import at all.

Fixes:
- title_idea/{idea_bot,cli,trending_idea_bot}.py + research/agent.py: `curiosity_gap.gap_title_engine` -> `title_idea.curiosity_gap.gap_title_engine`
- script/run.py: `brief_translator` -> `script.brief_translator`

Verified: orchestrator.pipeline + all 5 touched entrypoints import cleanly. No conflicts with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)