### PR TITLE
feat(slack): degrade SlackClient to silent no-op when no token

### DIFF
--- a/skills/video-pipeline/shared/clients/slack_client.py
+++ b/skills/video-pipeline/shared/clients/slack_client.py
@@ -23,11 +23,12 @@ class SlackClient:
         channel_id: Optional[str] = None,
     ):
         self.bot_token = bot_token or os.getenv("SLACK_BOT_TOKEN")
-        if not self.bot_token:
-            raise ValueError("SLACK_BOT_TOKEN not found in environment")
+        # Neutered mode: with no token, this client is a silent no-op instead of
+        # raising. Required for customer-facing / non-Slack channels.
+        self.enabled = bool(self.bot_token)
 
         self.channel_id = channel_id or os.getenv("SLACK_CHANNEL_ID", self.DEFAULT_CHANNEL_ID)
-        self.client = WebClient(token=self.bot_token)
+        self.client = WebClient(token=self.bot_token) if self.enabled else None
 
     def send_message(self, text: str, channel_id: Optional[str] = None) -> dict:
         """Send a message to a Slack channel with retry on transient errors.
@@ -42,6 +43,8 @@ class SlackClient:
         Raises:
             SlackApiError: On permanent API errors (invalid token, channel not found, etc.)
         """
+        if not self.enabled:
+            return None
         target_channel = channel_id or self.channel_id
 
         last_error = None
@@ -82,6 +85,8 @@ class SlackClient:
         Raises:
             SlackApiError: On API errors
         """
+        if not self.enabled:
+            return None
         target_channel = channel_id or self.channel_id
 
         response = self.client.reactions_add(
@@ -101,6 +106,8 @@ class SlackClient:
         Returns:
             Message dict if found, None otherwise
         """
+        if not self.enabled:
+            return None
         target_channel = channel_id or self.channel_id
 
         try:
@@ -138,6 +145,8 @@ class SlackClient:
         Returns:
             Slack API response dict with ok, ts, channel.
         """
+        if not self.enabled:
+            return None
         target_channel = channel_id or self.channel_id
 
         last_error = None

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -327,3 +327,8 @@ _After each session, add a one-line summary of what was done and any new lessons
 - Missed imports: title_idea/{idea_bot,cli,trending_idea_bot}.py + research/agent.py used `from curiosity_gap.gap_title_engine import ...` (canonical: `title_idea.curiosity_gap.gap_title_engine`); script/run.py used `from brief_translator import ...` (canonical: `script.brief_translator`).
 - Pattern: after a "remove shims + rewrite imports" sweep, grep the WHOLE tree for the old top-level names (`^\s*(from|import)\s+<oldname>`) before trusting it — the leftover empty dirs (only __pycache__/tests) hide that the package is gone. Vestigial dirs without __init__.py are a tell.
 - NOTE: `python -m orchestrator.pipeline` with NO args is NOT a safe smoke test — it instantiates clients and hangs/works; use `python -c "import orchestrator.pipeline"` instead.
+
+### SlackClient now no-ops without a token (neuter for customer-facing) (2026-06-08)
+- SlackClient.__init__ used to `raise ValueError` if SLACK_BOT_TOKEN was missing, and the pipeline instantiates it unconditionally (VideoPipeline.__init__) — so simply blanking the token in .env would CRASH every run.
+- Fix: __init__ sets `self.enabled = bool(token)` and `self.client = None` when absent (no raise); the 4 API methods (send_message/send_blocks/add_reaction/get_message) early-return None when not enabled. notify/notify_blocks + all notify_* delegate to those, so the whole client goes silent.
+- To actually silence Slack: this code change + blank SLACK_BOT_TOKEN/SLACK_APP_TOKEN in .env. Pattern: an optional integration should degrade to a no-op, not raise, when its credential is absent.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -271,3 +271,8 @@ PRD2 Pipeline UX: 12/14 done+verified. T12 (full regression) blocked on T3/T4/T7
 - **Not done / next:** smoke test was import-only (no paid run). Before relying on production: run a single-video dry pass, and reinstall the setup_cron.sh production jobs (queue/discover/autopilot) — they are NOT in the live crontab (only storyengine/agents swarm + bot_healthcheck).
 - **Separate effort:** standing up a new Hermes agent profile `Youtuber` (~/.hermes/profiles/youtuber) as the YouTube production brain that drives this pipeline; multi-channel generalization planned (ChannelConfig). See ~/Desktop/Power_Doctrine Pipeline-main-integration/HERMES_REBUILD_PLAN.md.
 - **Caution:** `/home/clawd/pipeline-bot/venv` (referenced by infra detect_python) does not exist; live fallback is repo-root `economy-fastforward/venv`.
+
+## Handoff (2026-06-08 — neuter Slack for customer-facing bot)
+- SlackClient no longer raises without a token; degrades to a silent no-op (enabled flag + guarded API methods). Verified: no-token instantiation + all notify_* return None, no exceptions.
+- Paired with blanking SLACK_BOT_TOKEN/SLACK_APP_TOKEN in the VPS .env (gitignored) so the pipeline posts nothing to Slack. The legacy Slack listener (pipeline_control.py) is already stopped + its healthcheck cron disabled.
+- Context: pipeline is being driven by the new Telegram bot @YoutubeAGI_bot (Hermes profile 'youtuber'); Slack is being retired.


### PR DESCRIPTION
Pipeline is going customer-facing via Telegram (@YoutubeAGI_bot); Slack is being retired. SlackClient no longer raises on missing SLACK_BOT_TOKEN — it no-ops (enabled flag + guarded API methods), so we can blank SLACK_* in .env without crashing the pipeline. Verified: no-token instantiation + all notify_* return None, no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)