### PR TITLE
yt-dlp: zero-config cookies path (follow-up to #455)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,9 +81,11 @@ GEMINI_API_KEY=xxxxx
 
 # yt-dlp anti-bot escape hatches (StoryEngine backend — routes/niche.py).
 # YouTube flags the VPS datacenter IP ("Sign in to confirm you're not a bot"),
-# which kills per-video metadata + transcripts. Set ONE of:
-# YTDLP_COOKIES_FILE=/home/clawd/.config/storyengine/youtube_cookies.txt  # Netscape cookies.txt exported from a logged-in browser
-# YTDLP_PROXY=socks5://user:pass@host:port                                # proxy with an unflagged egress IP
+# which kills per-video metadata + transcripts. Zero-config fix: drop an
+# exported Netscape cookies.txt at ~/.config/storyengine/youtube_cookies.txt
+# (picked up automatically, no restart). Or set ONE of:
+# YTDLP_COOKIES_FILE=/path/to/cookies.txt          # explicit cookies path (overrides the default)
+# YTDLP_PROXY=socks5://user:pass@host:port          # proxy with an unflagged egress IP
 
 # OAuth2 credentials for upload + analytics (stored as JSON files):
 #   .youtube-credentials.json — OAuth client (from Google Cloud Console)

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -17,7 +17,7 @@ See `.env.example` for all required variables. Critical ones:
 | `SLACK_CHANNEL_ID` | Slack | `C0A9U1X8NSW` |
 | `REDIS_URL` | Redis / arq queue | `redis://localhost:6379` (default). Used by StoryEngine backend and arq worker. If Redis is unreachable, pipeline stages fall back to in-process BackgroundTasks (no error — check logs for "Redis/arq pool not available" warning). |
 | `PER_USER_KEYS_ENABLED` | StoryEngine vault | Feature flag. Default `false`. When `true`, `vault.get_secret()` resolves user-scoped key first (`tenant:user:name`), then falls back to tenant-shared key (`tenant:name`). Raises `KeyError` if neither exists. Enable for PRD slice 4+ (per-user API key UI). |
-| `YTDLP_COOKIES_FILE` | yt-dlp (StoryEngine backend) | Path to Netscape-format `cookies.txt` exported from a browser logged into YouTube. Fixes the "Sign in to confirm you're not a bot" block on the VPS IP that kills transcripts/metadata in `routes/niche.py` (Model A Video, competitor scraping, voice-learn). Optional — unset means yt-dlp runs unauthenticated. |
+| `YTDLP_COOKIES_FILE` | yt-dlp (StoryEngine backend) | Path to Netscape-format `cookies.txt` exported from a browser logged into YouTube. Fixes the "Sign in to confirm you're not a bot" block on the VPS IP that kills transcripts/metadata in `routes/niche.py` (Model A Video, competitor scraping, voice-learn). Optional — when unset, `~/.config/storyengine/youtube_cookies.txt` is used automatically if it exists (zero-config: drop the file, no restart needed). |
 | `YTDLP_PROXY` | yt-dlp (StoryEngine backend) | Proxy URL (`http://` or `socks5://`) with an unflagged egress IP. Alternative to `YTDLP_COOKIES_FILE` for the same bot-check block. |
 
 ## Rules

--- a/storyengine/backend/routes/niche.py
+++ b/storyengine/backend/routes/niche.py
@@ -339,6 +339,14 @@ def _ytdlp_antibot_opts() -> dict:
             opts["cookiefile"] = cookies
         else:
             print(f"[yt-dlp] YTDLP_COOKIES_FILE set but not found: {cookies}")
+    else:
+        # Zero-config default: drop an exported cookies.txt here and it's
+        # picked up on the next request — no .env edit or restart needed.
+        default_cookies = os.path.expanduser(
+            "~/.config/storyengine/youtube_cookies.txt"
+        )
+        if os.path.isfile(default_cookies):
+            opts["cookiefile"] = default_cookies
     proxy = os.environ.get("YTDLP_PROXY", "").strip()
     if proxy:
         opts["proxy"] = proxy


### PR DESCRIPTION
When YTDLP_COOKIES_FILE is unset, auto-use ~/.config/storyengine/youtube_cookies.txt if it exists. Drop the exported cookies file there → fixed, no .env edit, no restart. Verified the fallback detection live on the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)