### PR TITLE
Product-brain refresh + VPS stale-copy cleanup session

### DIFF
--- a/agents/product-brain.md
+++ b/agents/product-brain.md
@@ -1,225 +1,204 @@
 # StoryEngine Product Brain
 
-_Last refreshed: 2026-04-09 (handcrafted from live codebase audit)_
-_Next refresh: run `./agents/refresh-product-brain.sh` after any session_
+_Last refreshed: 2026-07-21 12:05 (auto-generated)_
 
 ---
 
-## Product Identity
+## Section 1: Product Identity
 
-**What it is:** StoryEngine — "topic in, video out." Multi-tenant SaaS where creators type a topic and the AI pipeline handles everything: research → script → voice → custom images → video clips → thumbnail → render → YouTube upload.
+StoryEngine is a multi-tenant AI video SaaS: a creator types a topic (or points at a reference video), and the pipeline runs research → script → voice → cast/environment design → storyboards → coverage images → sound → clips → thumbnail → render → YouTube upload end to end. The moat is the learning loop — per-channel patterns (CTR, title structure, thumbnail style) feed autopilot so quality compounds instead of resetting every video, and an MCP server exposes the same production surface to Claude so a creator (or their agent) can direct a channel conversationally.
 
-**The moat:** The learning loop. After 10 videos, the AI knows the user's audience. CTR improves automatically. No competitor has this.
+**Pricing (ratified 2026-07-20, `tasks/decisions.md`):**
+| Tier | Price | Videos/mo | Key differentiator |
+|------|-------|-----------|---------------------|
+| Starter | $29/mo | 12, capped at 10 min length | 1 channel workspace, core pipeline |
+| Pro | $79/mo | Unlimited (fair-use) | Channel DNA, MCP access, autopilot dial, unlimited uploads |
+| Agency | $199/mo | Unlimited (fair-use) | Full-auto autopilot, multi-channel ($49/mo/extra workspace — no Stripe object yet), MCP access |
 
-**Pricing tiers:**
-| Tier | Price | Videos/mo | Key features |
-|------|-------|-----------|--------------|
-| Starter | $25/mo | 4 | 1 visual style, standard render |
-| Creator | $40/mo | 15 | 3 styles, autopilot, full learning loop |
-| Studio | $75/mo | 50 | All styles, API access, voice clone, 3 seats |
+Annual (~20% off: $24/$64/$159) is display-only on `/pricing` — no annual Stripe price object exists yet, checkout is monthly-only.
 
-**UX principles:** Action-first dashboard, 3-click video creation, visible pipeline progress, AI insights surface, empty states sell, errors are helpful, mobile-aware.
+**7 UX principles:** action-first (every screen answers "what's next"), 3-click video creation, visible pipeline progress (SSE, not polling-and-hope), AI insights surface (learnings/patterns shown, not buried), empty states sell (never a blank page), errors are helpful (named cause + next step, never a raw 500), mobile-aware layouts.
 
-**Stack:** Next.js 16 + React 19 + TypeScript + TailwindCSS 4 + Framer Motion | FastAPI + asyncpg + Supabase PostgreSQL
-**Design tokens:** `--turquoise` (#00D4AA), `--gold`, `--orange`, `--bg-void` (#0A0A0B), `GlassCard`, `ActionButton`, `StatusPill`, `Spinner`, `Modal`
+**Stack:** Next.js 16 + React 19 + TypeScript + TailwindCSS 4 + Framer Motion (frontend) · FastAPI + asyncpg + Supabase PostgreSQL + arq/Redis queue (backend). Design tokens: `--turquoise` (#00D4AA), `--gold`, `--bg-void` (#0A0A0B); components `GlassCard`, `ActionButton`, `StatusPill`.
 
 ---
 
-## Implementation Inventory
+## Section 2: Implementation Inventory
+
+**Status legend:** ✅ verified (task marked `verified`, or belongs to a `complete` PRD) · ✅ unverified (built via non-PRD engineering loop — no PRD record) · 🔵 ACTIVE (in current PRD4, done or pending, not yet verified) · ❌ MISSING (roadmap item, no PRD, no code) · 📋 PLANNED
 
 ### Auth & Access
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Email/password auth (PBKDF2-SHA256) | ✅ Done | `routes/settings.py`, `routes/google_auth.py` |
-| Google OAuth | ✅ Done | `routes/google_auth.py`, `/login` page |
-| JWT 30-day sessions | ✅ Done | auth middleware in `main.py` |
-| AuthenticatedShell route protection | ✅ Done | `frontend/src/components/` |
-| dev-token bypass (disabled in prod) | ✅ Done | env-gated |
-| Onboarding wizard (3-step: channel → keys → done) | ✅ Done | `frontend/src/app/onboarding/` |
-| Password reset flow (token → email → page) | ✅ Done | `password_reset_tokens` table, `/forgot-password`, `/reset-password` |
-| Multi-tenant isolation (tenant_id scoping) | ✅ Done | `tenants` + `memberships` tables, RLS |
+| Email/password + Google OAuth + password reset, JWT sessions | ✅ DONE (verified) | PRD1, `routes/google_auth.py`, `routes/settings.py` |
+| Onboarding wizard | ✅ DONE (verified) | PRD1, `frontend/src/app/onboarding/` |
+| Multi-tenant isolation (tenant_id + RLS) | ✅ DONE (verified) | PRD3, `tenants`/`memberships` tables |
+| MCP agent tokens (tenant-scoped, plan-gated) | ✅ DONE (unverified) | C57/C62, `agent_tokens` table, `routes/agent_access.py` |
+| Workspace-as-channel model (1 workspace = 1 channel) | ✅ DONE (unverified) | C61b, `get_workspace_info` MCP tool |
 
 ### Billing & Plans
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Stripe checkout + webhooks + portal | ✅ Done | `routes/billing.py` |
-| `/billing` page (plan display, usage bars, upgrade CTA) | ✅ Done | `frontend/src/app/billing/` |
-| `/pricing` public page (3 tiers, feature grid, CTA) | ✅ Done | `frontend/src/app/pricing/` |
-| Plan enforcement middleware (`check_plan_limits`) | ✅ Done | `tenant_usage` table, usage hooks |
-| Free trial logic (14-day Creator trial on signup) | ✅ Done | `accounts` table, trial countdown |
-| Trial countdown badge + banner | ✅ Done | frontend components |
-| Transactional email (welcome, reset, trial warning) | ✅ Done | `email_service.py`, `email_tasks.py` |
-| Billing receipt email on checkout | ✅ Done | wired in `routes/billing.py` |
+| Stripe checkout + webhooks + portal | ✅ DONE (verified) | PRD1, `routes/billing.py` |
+| `/billing` + `/pricing` pages, ratified ladder copy | ✅ DONE (unverified) | C63, `frontend/src/app/pricing/` |
+| Plan enforcement (video count + length cap) | ✅ DONE (verified) | PRD1/C62, `routes/billing.py::enforce_video_length_cap` |
+| MCP tier gate + good-standing gate (lapsed Stripe kills token same-day) | ✅ DONE (unverified) | C57, `agent_tokens.authenticate_with_standing` |
+| Feature board (suggest/vote/status ladder) | ✅ DONE (unverified) | C65, `routes/feature_board.py`, `/ideas` |
+| Extra-channel seat Stripe price object | ❌ MISSING | no Stripe object yet (decisions.md 2026-07-20) |
 
 ### Core Pipeline & UI
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Full video pipeline (research→render→upload) | ✅ Done | 13 stages, all with `run.py` entry points |
-| Pipeline dashboard (all stages, status tabs) | ✅ Done | `frontend/src/app/pipeline/` |
-| Video detail page (all production tabs) | ✅ Done | `frontend/src/components/production/` |
-| Pipeline progress UX (SSE real-time stage tracking) | ✅ Done | `/api/activity/stream` SSE, `stage_transitions` table |
-| Script review + approval | ✅ Done | `routes/review.py`, `/review` page |
-| Render tab + `RenderTab.tsx` | ✅ Done | component exists |
-| System prompt editors (per pipeline stage) | ✅ Done | `routes/system_prompts.py`, `/system-prompts` |
-| Storyboard viewer | ✅ Done | `frontend/src/app/storyboard/` |
-| Visuals page | ✅ Done | `frontend/src/app/visuals/` |
+| Full pipeline (research→render→upload), arq queue | ✅ DONE (verified) | PRD3, `backend/pipeline_executor.py`, `backend/worker.py` |
+| Chat-primary create surface (converged, 1 INSERT path) | ✅ DONE (unverified) | C38, `routes/videos.py::create_video` |
+| Per-stage resumability (skip-if-done: voice/sound/clips/images/thumbnail/upload) | ✅ DONE (unverified) | C16b/C16d/C16e, `docs/failure-modes.md` |
+| Generation claims (no double-dispatch races) | ✅ DONE (unverified) | C16a, `generation_claims` table |
+| Model routing (per-scene, channel-style-aware) | ✅ DONE (unverified) | C13/C13b/C14, `shared/model_router.py` |
+| Draft-pass / finalize trust ladder | ✅ DONE (unverified) | C17/C18, `generation_passes` table |
+| Style presets (5 image-engine profiles) + gallery + chat door | ✅ DONE (unverified) | C20/C21a/C21b, `style_presets` table |
+| Camera-preset chips (12 curated moves) | ✅ DONE (unverified) | C23, `routes/camera_presets.py` |
+| MCP process brain (canonical stage order + gap detection) + media tools | ✅ DONE (unverified) | C66/C48, `production_guide.py`, `routes/mcp.py` |
+| Video preview player (RenderTab) | 🔵 ACTIVE (PRD4-T8) | `frontend/src/components/production/RenderTab.tsx` |
 
 ### Discovery & Competitors
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Competitors page (pagination, filters, scrape progress) | ✅ Done | `frontend/src/app/competitors/`, `routes/` |
-| Discovery page | ✅ Done | `frontend/src/app/discovery/`, `routes/discovery.py` |
-| Autopilot page + controls | ✅ Done | `frontend/src/app/autopilot/`, `routes/autopilot.py` |
-| Calendar page | ✅ Done | `frontend/src/app/calendar/` |
+| Discovery + autopilot + calendar pages | ✅ DONE (verified) | PRD2, `frontend/src/app/discovery/`, `/autopilot`, `/calendar` |
+| Competitor scraper + channel patterns | ✅ DONE (unverified) | `routes/channel_patterns.py`, `competitor_videos` table |
+| Early-warning launch classifier (per-channel CTR outlier) | ✅ DONE (unverified) | C58, `early_warning.py` |
+| Reference-video modeling (Model A Video, title gap engine) | ✅ DONE (unverified) | C38/C59, `title_idea/curiosity_gap/` |
 
 ### Analytics & Learning
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Analytics page (overview, CTR timeline, framework perf) | ✅ Done | `frontend/src/app/analytics/`, `routes/analytics.py` |
-| Learnings page (pattern cards, extract/analyze actions) | ✅ Done | `frontend/src/app/learnings/`, `routes/learning_extraction.py` |
-| Learnings insights redesign (hero stats, recommendations, topic perf) | 🔵 PRD 4 T1 | `frontend/src/app/learnings/page.tsx` |
-| Analytics 2.0 (topic heatmap, competitor benchmark) | 🔵 PRD 4 T2 | `routes/analytics.py` + analytics page |
-| Video preview player (in-app, RenderTab) | 🔵 PRD 4 T3 | `components/production/RenderTab.tsx` |
+| Analytics backend (topic-perf + competitor-benchmark endpoints) | 🔵 ACTIVE (PRD4-T1) | `routes/analytics.py` |
+| Learning Insights dashboard redesign | 🔵 ACTIVE (PRD4-T6) | `frontend/src/app/learnings/page.tsx` |
+| Analytics 2.0 frontend (topic chart + competitor card) | 🔵 ACTIVE (PRD4-T7) | `frontend/src/app/analytics/` |
+| Channel DNA + patterns | ✅ DONE (unverified) | `routes/channel_dna.py`, `channel_patterns` table |
 
 ### Marketing & Legal
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Landing page (hero, features, pricing, CTA) | ✅ Done | `frontend/src/app/page.tsx` |
-| `/terms` and `/privacy` legal pages | ✅ Done | `frontend/src/app/terms/`, `privacy/` |
-| `/demo` page | ✅ Done | `frontend/src/app/demo/` |
-| `/docs` page | ✅ Done | `frontend/src/app/docs/` |
+| Landing page | ✅ DONE (verified) | PRD2, `frontend/src/app/page.tsx` |
+| Transactional email (Resend: welcome/reset/trial/receipts) | ✅ DONE (verified) | PRD2 |
+| Legal pages (Terms + Privacy) | 🔵 ACTIVE (PRD4-T10) | `frontend/src/app/terms/`, `/privacy` |
+| Getting Started / help docs | 🔵 ACTIVE (PRD4-T9) | `frontend/src/app/docs/` |
+| Demo mode (backend done, frontend pending) | 🔵 ACTIVE (PRD4-T4 done / T11 pending) | `routes/demo.py`, `frontend/src/app/demo/` |
 
-### Infrastructure (Gaps — Week 3 of roadmap)
+### Infrastructure
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Job Queue (Redis + arq/dramatiq, persistent pipeline jobs) | ❌ Missing | No Redis setup. Pipeline uses in-process asyncio. Server restart = lost jobs. |
-| Per-tenant storage (Supabase Storage, signed URLs) | ❌ Missing | Assets use Kie.ai URLs (expire) and Google Drive (not isolated). |
-| Error monitoring (Sentry, backend + frontend) | ❌ Missing | Console only. No structured error tracking. |
-| Security hardening (CORS lockdown, SQL audit, CSRF) | ❌ Missing | SEC-1 through SEC-6 open in todo.md |
-| Rate limiting per plan (concurrent job limits) | ❌ Missing | No per-tenant API rate limits |
-| Storyboard extraction V2 (Supabase rewrite) | ❌ Blocked | T27-003: `extraction.py` not wired into pipeline for Supabase videos |
-| Permanent asset storage (all image gen steps) | ❌ Missing | T27-008: Kie.ai URLs expire |
+| arq/Redis job queue (persistent stages, retry) | ✅ DONE (verified) | PRD3, `backend/worker.py`, `infra/setup_worker.sh` |
+| Rate limiting + security hardening (CORS, CSRF, auth limits) | ✅ DONE (verified) | PRD3, `rate_limit.py` |
+| Ledger uniqueness backstop (no duplicate spend) | ✅ DONE (unverified) | C16c, `generation_ledger_dedup_idx` |
+| Export manifest backend | 🔵 ACTIVE (PRD4-T5) | `GET /api/videos/{id}/export-manifest` |
+| Brand Kit + notification preferences backend | 🔵 ACTIVE (PRD4-T2, T3) | `routes/channel_profile.py`, `routes/preferences.py` |
+| Per-tenant object storage (Supabase Storage, signed URLs) | ❌ MISSING | assets still resolved via Kie/Drive + signed proxy (C25a), not migrated |
+| Error monitoring (Sentry) | ❌ MISSING | console/log only |
 
-### Polish & Launch (Week 4 of roadmap)
+### Polish & Launch
 | Feature | Status | Evidence |
 |---------|--------|----------|
-| Getting started guide (help docs, FAQ) | 🔵 PRD 4 (T9 pending) | `/docs` page exists but needs content |
-| Brand kit (logo, accent color, intro/outro per channel) | 📋 Planned | Week 4 Day 10 |
-| Load testing (k6), backup strategy | 📋 Planned | Week 4 Day 18 |
-| Webhook API (Zapier, Make.com) | 📋 Planned | Tier 4 |
-| GDPR / data export | 📋 Planned | Tier 4 |
+| Export button + Brand Kit UI + notification toggles | 🔵 ACTIVE (PRD4-T12, pending) | not yet in `frontend/src/app/settings/` |
+| Beta launch regression sweep | 🔵 ACTIVE (PRD4-T13, pending) | not started |
+| Security audit (auth, tenant isolation, secrets) | 🔵 ACTIVE (PRD4-T14, pending) | not started |
+| Performance & load readiness check | 🔵 ACTIVE (PRD4-T15, pending) | not started |
+| Dashboard redesign (action-first cards) | ❌ MISSING | roadmap Day 10, not in any PRD |
+| Invite-a-manager flow | ❌ MISSING | traced C61b, not built — seeded on feature board |
 
 ---
 
-## Roadmap Progress (18-Day Plan)
+## Section 3: Roadmap Progress
 
-| Day | Date | Focus | Status |
-|-----|------|-------|--------|
-| 1 | Apr 7 | Public pricing + plan enforcement | ✅ Done |
-| 2 | Apr 8 | Trial + password reset + email + dev-token | ✅ Done |
-| 3 | Apr 9 | Create video simplification | 🔵 In progress (PRD 4 T4-T7) |
-| 4 | Apr 10 | Empty states + error handling | ✅ Done (PRD 1) |
-| 5 | Apr 11 | Pipeline progress UX | ✅ Done (PRD 2) |
-| 6 | Apr 14 | Landing page | ✅ Done |
-| 7 | Apr 15 | Dashboard redesign | 📋 Pending |
-| 8 | Apr 16 | Learning insights dashboard | 🔵 In progress (PRD 4 T1) |
-| 9 | Apr 17 | Analytics 2.0 | 🔵 In progress (PRD 4 T2) |
-| 10 | Apr 18 | Settings completion + brand kit | 📋 Pending |
-| 11 | Apr 21 | Job queue (Part 1) | ❌ Not started |
-| 12 | Apr 22 | Job queue (Part 2) + rate limiting | ❌ Not started |
-| 13 | Apr 23 | Per-tenant storage | ❌ Not started |
-| 14 | Apr 24 | Error monitoring + logging | ❌ Not started |
-| 15 | Apr 25 | Security hardening | ❌ Not started |
-| 16 | Apr 28 | Video preview + UI polish | 🔵 In progress (PRD 4 T3) |
-| 17 | Apr 29 | Documentation + demo | 🔵 In progress (PRD 4 T9) |
-| 18 | Apr 30 | Beta launch prep | 📋 Pending |
+| Day | Date | Focus | Status | PRD Reference |
+|-----|------|-------|--------|----------------|
+| 1 | 2026-04-08 | Billing UI | ✅ Done | PRD1 |
+| 2 | 2026-04-08 | Plan enforcement | ✅ Done | PRD1, C62 |
+| 3 | 2026-04-08 | Trial + password reset | ✅ Done | PRD1 |
+| 4 | 2026-04-08 | Fix broken endpoints + empty states | ✅ Done | PRD1 |
+| 5 | 2026-04-08 | Create video simplification | ✅ Done | PRD1, C38 |
+| 6 | 2026-04-08 | Pipeline progress UX (SSE) | ✅ Done | PRD2 |
+| 7 | 2026-04-08 | Error handling + toasts | ✅ Done | PRD2 |
+| 8 | 2026-04-08 | Landing page | ✅ Done | PRD2 |
+| 9 | 2026-04-08 | Transactional email | ✅ Done | PRD2 |
+| 10 | — | Dashboard redesign | ❌ Not started | none |
+| 11 | 2026-04-08 | Job queue | ✅ Done | PRD3 |
+| 12 | 2026-04-08 | Job queue cont. + rate limiting | ✅ Done | PRD3 |
+| 13 | — | Per-tenant storage | ❌ Not started | none (PRD3's "Storage" scope was task persistence, not object storage) |
+| 14 | — | Error monitoring (Sentry) | ❌ Not started | none |
+| 15 | 2026-04-08 | Security hardening | ✅ Done | PRD3 |
+| 16 | 2026-04-08→ | Learning Insights dashboard | 🔵 Built, unverified | PRD4-T1, T6 |
+| 17 | 2026-04-08→ | Analytics 2.0 | 🔵 Built, unverified | PRD4-T7 |
+| 18 | 2026-04-08→ | Video preview + Brand Kit | 🔵 In progress | PRD4-T2, T8, T12 |
 
----
-
-## Current Priority Gap Queue
-
-### Tier 1 — Active (PRD 4 remaining tasks T11-T15)
-PRD 4 is the active PRD. Complete these before generating PRD 5.
-
-### Tier 2 — Next PRD (Week 3: Infrastructure)
-1. **Job Queue** — Redis + arq. Pipeline stages as persistent jobs. Retry, dead letter. Server restart kills jobs today.
-2. **Per-tenant Storage** — Supabase Storage for SaaS. Kie.ai URLs expire and aren't tenant-isolated.
-3. **Error Monitoring** — Sentry (backend + frontend). No visibility into production errors.
-4. **Security Hardening** — SEC-1 (dev-token in dev), SEC-4 (hardcoded CORS IP), SEC-5 (f-string SQL), rate limiting on auth.
-
-### Tier 3 — Week 4: Polish & Launch
-5. **Dashboard redesign** — Action-first: active video cards, pending approvals, quick-start CTA, usage meter.
-6. **Brand kit** — Logo, accent color, intro/outro, watermark per channel. Persist to render.
-7. **Settings completion** — API key validation feedback, integration status indicators.
-8. **Beta launch prep** — Load test (k6), ToS/Privacy complete, invite 10 beta creators.
-
-### Tier 4 — Post-Beta
-9. Webhook API (Zapier, Make.com)
-10. GDPR / data export
-11. Team collaboration (invite flow, role enforcement — schema supports it)
-12. Voice clone per channel
+_Note: since PRD4 opened (2026-04-08), most engineering effort has run through a parallel, non-PRD-tracked worker loop (the "C-numbered" chunks in `tasks/todo.md`) — MCP surface, model routing, trust ladder, style/camera presets, feature board — rather than advancing PRD4's remaining 5 tasks. That's why PRD4 is still 10/15 done as of 2026-07-21._
 
 ---
 
-## Live Codebase Snapshot
+## Section 4: Current Priority Gap Queue
 
-**Frontend pages (26):** activity, analytics, autopilot, billing, calendar, competitors, dashboard, demo, discovery, docs, forgot-password, learnings, login, onboarding, pipeline, pricing, privacy, profile, render, reset-password, review, settings, storyboard, system-prompts, terms, visuals + landing (page.tsx)
+### Tier 1 — ACTIVE (PRD4, 5 tasks remaining; T1-T10 built, not yet verified)
+- T11: Demo mode frontend — landing + 3 sub-pages
+- T12: Export button + Brand Kit UI + notification toggles
+- T13: Beta launch regression sweep (full page + API)
+- T14: Security audit (auth, tenant isolation, secrets)
+- T15: Performance & load readiness check
 
-**Backend route files (24):** activity, analytics, assets, autopilot, billing, channel_profile, dashboard, demo, discovery, google_auth, learning_extraction, niche, pipeline, preferences, profile, projects, review, settings, skills, system_prompts, videos, visual_styles, youtube_sync, agents
+### Tier 2 — NEXT PRD (Week 3/4 gaps not yet in a PRD)
+1. **Dashboard redesign** (Day 10) — action-first cards: active videos, pending approvals, quick-start CTA, usage meter.
+2. **Per-tenant object storage** (Day 13) — migrate asset URLs off Kie.ai/Drive onto Supabase Storage with signed URLs; today's signed-proxy fix (C25a/C48) covers auth, not storage location.
+3. **Error monitoring** (Day 14) — Sentry backend + frontend, tenant_id in every structured log line.
+4. **Sheet auto-split on content-filter rejection** — root cause diagnosed 2026-07-20 (OpenAI density scoring on caption-dense sheets); Ryan ruled no nano-fallback, fix the structure instead.
+5. **Extra-channel seat Stripe price** — $49/mo object referenced in ratified pricing copy but not created in Stripe yet.
 
-**DB tables (22):** tenants, users, memberships, videos, scripts, assets, competitor_channels, competitor_videos, learnings, title_insights, title_tests, autopilot_config, discovery_ideas, channel_profiles, accounts, projects, user_preferences, tenant_prompt_defaults, stage_transitions, bot_activity, tenant_usage, password_reset_tokens
+### Tier 3 — Week 4 Polish
+- Settings completion (API key validation feedback, integration status indicators)
+- `rate_limit.py`'s `_get_tenant_plan` legacy-tenant fallback dedupe (C60 STOP item — needs a live DB check first)
+- MCP OAuth wrapper for claude.ai Desktop/phone connectors (bearer-token only today)
+
+### Tier 4 — POST-BETA
+- Webhook API (Zapier, Make.com)
+- GDPR / data export
+- Invite-a-manager flow (traced C61b, not built — also seeded on the feature board)
+- Voice clone per channel
+- Annual billing (Stripe price objects + toggle — currently display-only)
 
 ---
 
-## PRD Writing Guidelines for This Product
+## Section 5: PRD Writing Guidelines
 
-### Task Structure
-Each task: single role (backend-dev | frontend-dev | qa-engineer | security-auditor), 15-45 min effort, ONE concern. 8-15 tasks per PRD.
+### Task structure
+Each task: single role (backend | frontend | qa | security), 15-45 min effort, ONE concern. 8-15 tasks per PRD, dependencies declared explicitly (`depends_on`).
 
-### File Conventions
-- Backend: `storyengine/backend/routes/<name>.py` — register in `storyengine/backend/main.py`
+### File conventions
+- Backend routes: `storyengine/backend/routes/<name>.py` — must register in `storyengine/backend/main.py`
+- Pydantic models: `storyengine/backend/models.py` (source of truth for API shape)
+- Migrations: `storyengine/backend/migrations/<NNN>_<name>.sql` + update `storyengine/schema.sql` (latest: `113_storyboard_errors.sql`)
 - Frontend pages: `storyengine/frontend/src/app/<page>/page.tsx`
 - Frontend components: `storyengine/frontend/src/components/<category>/<Name>.tsx`
-- API layer: `storyengine/frontend/src/lib/api.ts`
-- Types: `storyengine/frontend/src/lib/types.ts`
-- DB migrations: `storyengine/backend/migrations/<NNN>_<name>.sql` + update `storyengine/schema.sql`
-- Pydantic models: `storyengine/backend/models.py`
+- API layer: `storyengine/frontend/src/lib/api.ts`; types: `storyengine/frontend/src/lib/types.ts`
 
-### Acceptance Criteria Patterns
+### Acceptance criteria patterns
 ```bash
-# API endpoint exists
 curl -s -o /dev/null -w '%{http_code}' http://localhost:8001/api/endpoint | grep -q 200
-
-# DB column exists
 psql "$DATABASE_URL" -c "SELECT column_name FROM information_schema.columns WHERE table_name='videos'" | grep -q new_column
-
-# TypeScript compiles
 cd storyengine/frontend && npx tsc --noEmit
-
-# File exists
 test -f storyengine/backend/routes/new_route.py
-
-# Router registered in main.py
 grep -q "new_route" storyengine/backend/main.py
 ```
 
-### Wiring Checklist (every feature must pass)
-- DB column exists (migrated, not just in schema.sql)
-- Route registered in `main.py`
-- Pydantic model matches route response
-- Frontend fetchApi calls correct endpoint path
-- TypeScript types match backend response fields
-- Component wired to real API data (not mock)
-- Loading + error + empty states handled
-- `npx tsc --noEmit` passes
+### Wiring checklist (every feature must pass)
+1. DB column exists (migrated, not just in schema.sql)
+2. Route registered in `main.py`
+3. Pydantic model matches route response exactly
+4. Frontend `fetchApi` calls the correct endpoint path
+5. TypeScript types match backend response field names
+6. Component wired to real API data, not mock/hardcoded
+7. Loading + error + empty states all handled
+8. `npx tsc --noEmit` passes clean
 
-### Design System (mandatory for all UI tasks)
-- Dark background: `var(--bg-void)` (#0A0A0B), cards: `glass-card` class
-- Accents: `var(--turquoise)` (#00D4AA), `var(--gold)`, `var(--orange)`, `var(--red)` for errors
-- Text: `var(--text-primary)`, `var(--text-secondary)`, `var(--text-tertiary)`
-- Font: `font-display` for headings
-- Components: `GlassCard`, `ActionButton`, `StatusPill`, `Spinner`, `Modal`, `FilterSelect`, `VerdictBadge`
-- Motion: Framer Motion with container/item stagger pattern
+### Design system (mandatory for UI tasks)
+Invoke `web-design-system` skill first. Dark background `var(--bg-void)`, `glass-card` class for panels, accents `var(--turquoise)`/`var(--gold)`/`var(--orange)`/`var(--red)`. Components: `GlassCard`, `ActionButton`, `StatusPill`, `Spinner`, `Modal`. Motion: Framer Motion container/item stagger.
 
-### What NOT to Spec (already built — do not duplicate)
-Auth, billing UI, Stripe, plan enforcement, trial logic, password reset, email service, landing page, pricing page, legal pages, pipeline core, SSE progress tracking, toast system, error boundaries, empty states, onboarding wizard, competitors page, discovery, analytics baseline, learnings baseline.
+### What NOT to spec (already built — guard rail)
+Auth (email/password, Google OAuth, password reset, onboarding, MCP agent tokens, workspace-as-channel), billing (Stripe checkout/webhooks/portal, `/billing`+`/pricing` pages, plan enforcement, MCP tier gate, good-standing gate, feature board), full pipeline + arq queue + chat-primary create + per-stage resumability + generation claims + model routing + draft-pass/finalize + style presets + camera-preset chips + director memory + inline chat storyboards/per-scene approve, MCP process brain + media tools + environments tool family, discovery/autopilot/calendar pages, competitor scraper + channel patterns, early-warning classifier, reference-video modeling (Model A Video, title gap engine), Channel DNA, landing page, transactional email, ledger dedup backstop, rate limiting + security hardening.


### PR DESCRIPTION
## What changed

This PR carries the one commit not already on main from this session: an auto-generated refresh of `agents/product-brain.md` (2026-07-21) — updates the ratified pricing tiers (Starter $29 / Pro $79 / Agency $199, per tasks/decisions.md 2026-07-20), the implementation inventory, and PRD-writing guardrails to match the current codebase.

## Context — the session's main work is already on main and deployed

The rest of this session landed on main directly (fast-forward) and was deployed to the VPS as `b615beda → 130a0901`:

- `72e32914` — port-scoped the uvicorn kill in `skills/video-pipeline/infra/storyengine_deploy.sh` to `uvicorn main:app.*8001` so it can never match a sibling `main:app` service (Hailey, future apps). `run-agent.sh` was already scoped.
- `1ffe2761` / `4b062cfe` — todo notes tracking the VPS stale-copy cleanup: audited that nothing (crontab, systemd system+user units, home-dir scripts, processes) referenced the two orphaned checkouts carrying the old bare `pkill -f "next-server"`, neutralized them, then deleted both (`/home/clawd/agent-workspace`, `/home/clawd/economy-fastforward`) with Ryan's approval.

## Reviewer notes

- The product-brain refresh is auto-generated (found modified in the worktree, reviewed for sanity — pricing and inventory match current decisions/code).
- Deploy verified: backend healthy on 8001, scoped kill present in the live tree at line 136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)